### PR TITLE
Fix error message of the eval_boolean_infix 

### DIFF
--- a/interpreter/lib.rs
+++ b/interpreter/lib.rs
@@ -222,7 +222,7 @@ fn eval_boolean_infix(op: &Token, left: bool, right: bool) -> Result<Rc<Object>,
     let result = match &op.kind {
         TokenKind::EQ => Object::Boolean(left == right),
         TokenKind::NotEq => Object::Boolean(left != right),
-        op => return Err(format!("Invalid infix operator for int: {}", op)),
+        op => return Err(format!("Invalid infix operator for boolean: {}", op)),
     };
 
     Ok(Rc::from(result))


### PR DESCRIPTION
# Description 
The error message of the eval_boolean_infix was written incorrectly `Invalid infix operator for integer`, and i changed it to `Invalid infix operator for boolean`.