### PR TITLE
chore(ci): upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -13,7 +13,7 @@ jobs:
     # container: gengjiawen/node-build:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install and Build
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: docker run -v $PWD:/pwd -w /pwd gengjiawen/node-build bash -c "yarn && pnpx ts-node scripts/bump_cargo_packages.ts"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,7 +69,7 @@ jobs:
               ref: releasePr.head.ref,
             })
             core.info(`Triggered prepare-release.yml on ${releasePr.head.ref}`)
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: npx envinfo
       - run: cargo workspaces publish --from-git --token $CARGO_TOKEN
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - run: npx envinfo
       - name: Build
         run: cargo build


### PR DESCRIPTION
Update all workflow files from outdated v2/v3/v4 to actions/checkout@v6.

Assisted-by: Cursor (Cloud Agent)