### PR TITLE
chore: remove package manager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "monkey-rust",
   "version": "0.12.1",
-  "packageManager": "pnpm@11.5.1",
   "description": "![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Summary
- remove the root `package.json` `packageManager` field

## Validation
- `rg -n '"packageManager"' package.json packages -g 'package.json'` returns no matches
