### PR TITLE
feat(playground): add dark mode support

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -22,6 +22,7 @@
     "jotai": "^2.20.1",
     "lodash.debounce": "^4.0.8",
     "next": "16.2.9",
+    "next-themes": "^0.4.6",
     "prettier": "^3.0.0",
     "prettier-plugin-monkey": "workspace:*",
     "react": "19.2.7",

--- a/packages/playground/src/Editor.tsx
+++ b/packages/playground/src/Editor.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { oneDark } from '@codemirror/theme-one-dark'
 import { vim } from '@replit/codemirror-vim'
 import { StateEffect, StateField } from '@codemirror/state'
 import {
@@ -10,33 +9,52 @@ import {
   type ViewUpdate,
 } from '@codemirror/view'
 import CodeMirror, { type ReactCodeMirrorProps } from '@uiw/react-codemirror'
-import { useTheme } from 'next-themes'
 import {
   forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
-  useState,
 } from 'react'
 
 const setHighlight = StateEffect.define<{ from: number; to: number } | null>()
 
 const highlightMark = Decoration.mark({ class: 'cm-ast-highlight' })
 
-function createHighlightTheme(isDark: boolean) {
-  return EditorView.baseTheme({
-    '.cm-ast-highlight': {
-      backgroundColor: isDark
-        ? 'rgba(96, 165, 250, 0.2)'
-        : 'rgba(47, 111, 237, 0.16)',
-      borderBottom: isDark
-        ? '1.5px solid rgba(96, 165, 250, 0.55)'
-        : '1.5px solid rgba(47, 111, 237, 0.55)',
+const playgroundEditorTheme = EditorView.theme({
+  '&': {
+    backgroundColor: 'var(--color-background)',
+    color: 'var(--gray-12)',
+  },
+  '.cm-content': {
+    caretColor: 'var(--accent-9)',
+  },
+  '.cm-cursor, .cm-dropCursor': {
+    borderLeftColor: 'var(--accent-9)',
+  },
+  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection':
+    {
+      backgroundColor: 'var(--accent-a5) !important',
     },
-  })
-}
+  '.cm-gutters': {
+    backgroundColor: 'var(--gray-2)',
+    color: 'var(--gray-9)',
+    borderRight: '1px solid var(--gray-a5)',
+  },
+  '.cm-activeLineGutter': {
+    backgroundColor: 'var(--gray-a3)',
+  },
+  '.cm-activeLine': {
+    backgroundColor: 'var(--gray-a2)',
+  },
+})
+
+const highlightTheme = EditorView.baseTheme({
+  '.cm-ast-highlight': {
+    backgroundColor: 'var(--accent-a4)',
+    borderBottom: '1.5px solid var(--accent-a8)',
+  },
+})
 
 const highlightField = StateField.define<DecorationSet>({
   create() {
@@ -89,14 +107,6 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
   ref,
 ) {
   const viewRef = useRef<EditorView | null>(null)
-  const { resolvedTheme } = useTheme()
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-
-  const isDark = mounted && resolvedTheme === 'dark'
   const {
     extensions: extraExtensions,
     onCreateEditor: extraOnCreateEditor,
@@ -130,16 +140,15 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
   )
 
   const extensions = useMemo(() => {
-    const next = vimMode ? [vim()] : []
-    next.push(highlightField, createHighlightTheme(isDark))
-    if (isDark) {
-      next.push(oneDark)
+    const next = [playgroundEditorTheme, highlightField, highlightTheme]
+    if (vimMode) {
+      next.push(vim())
     }
     if (extraExtensions) {
       next.push(...extraExtensions)
     }
     return next
-  }, [extraExtensions, isDark, vimMode])
+  }, [extraExtensions, vimMode])
 
   const handleCreateEditor = useCallback(
     (
@@ -169,6 +178,7 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
       className={fill ? 'editor-fill' : undefined}
       value={code}
       height={fill ? undefined : '100%'}
+      theme="none"
       extensions={extensions}
       onChange={onChange}
       onCreateEditor={handleCreateEditor}

--- a/packages/playground/src/Editor.tsx
+++ b/packages/playground/src/Editor.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { oneDark } from '@codemirror/theme-one-dark'
 import { vim } from '@replit/codemirror-vim'
 import { StateEffect, StateField } from '@codemirror/state'
 import {
@@ -9,17 +10,33 @@ import {
   type ViewUpdate,
 } from '@codemirror/view'
 import CodeMirror, { type ReactCodeMirrorProps } from '@uiw/react-codemirror'
+import { useTheme } from 'next-themes'
 import {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 
 const setHighlight = StateEffect.define<{ from: number; to: number } | null>()
 
 const highlightMark = Decoration.mark({ class: 'cm-ast-highlight' })
+
+function createHighlightTheme(isDark: boolean) {
+  return EditorView.baseTheme({
+    '.cm-ast-highlight': {
+      backgroundColor: isDark
+        ? 'rgba(96, 165, 250, 0.2)'
+        : 'rgba(47, 111, 237, 0.16)',
+      borderBottom: isDark
+        ? '1.5px solid rgba(96, 165, 250, 0.55)'
+        : '1.5px solid rgba(47, 111, 237, 0.55)',
+    },
+  })
+}
 
 const highlightField = StateField.define<DecorationSet>({
   create() {
@@ -44,13 +61,6 @@ const highlightField = StateField.define<DecorationSet>({
     return decorations
   },
   provide: (field) => EditorView.decorations.from(field),
-})
-
-const highlightTheme = EditorView.baseTheme({
-  '.cm-ast-highlight': {
-    backgroundColor: 'rgba(47, 111, 237, 0.16)',
-    borderBottom: '1.5px solid rgba(47, 111, 237, 0.55)',
-  },
 })
 
 export interface EditorHandle {
@@ -79,6 +89,14 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
   ref,
 ) {
   const viewRef = useRef<EditorView | null>(null)
+  const { resolvedTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const isDark = mounted && resolvedTheme === 'dark'
   const {
     extensions: extraExtensions,
     onCreateEditor: extraOnCreateEditor,
@@ -113,12 +131,15 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
 
   const extensions = useMemo(() => {
     const next = vimMode ? [vim()] : []
-    next.push(highlightField, highlightTheme)
+    next.push(highlightField, createHighlightTheme(isDark))
+    if (isDark) {
+      next.push(oneDark)
+    }
     if (extraExtensions) {
       next.push(...extraExtensions)
     }
     return next
-  }, [extraExtensions, vimMode])
+  }, [extraExtensions, isDark, vimMode])
 
   const handleCreateEditor = useCallback(
     (

--- a/packages/playground/src/app/globals.css
+++ b/packages/playground/src/app/globals.css
@@ -56,6 +56,7 @@ body {
   min-width: 0;
   min-height: 0;
   height: 100%;
+  background: var(--color-background);
 }
 
 .editor-column {
@@ -73,6 +74,7 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
+  background: var(--color-background);
 }
 
 .editor-fill {
@@ -86,6 +88,7 @@ body {
   min-height: 0;
   height: auto !important;
   font-size: 14px;
+  background: var(--color-background);
 }
 
 .cm-scroller {

--- a/packages/playground/src/app/layout.tsx
+++ b/packages/playground/src/app/layout.tsx
@@ -1,11 +1,11 @@
 import '@radix-ui/themes/styles.css'
 import './globals.css'
 
-import { Theme } from '@radix-ui/themes'
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
 
 import { Header } from '@/components/Header'
+import { PlaygroundTheme } from '@/components/PlaygroundTheme'
 
 export const metadata: Metadata = {
   title: 'Monkey Playground',
@@ -14,14 +14,14 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body>
-        <Theme accentColor="blue" grayColor="slate" radius="small">
+        <PlaygroundTheme>
           <div className="playground-root">
             <Header />
             {children}
           </div>
-        </Theme>
+        </PlaygroundTheme>
       </body>
     </html>
   )

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -1,5 +1,7 @@
 import { Flex, Heading } from '@radix-ui/themes'
 
+import { ThemeToggle } from '@/components/ThemeToggle'
+
 const GITHUB_URL = 'https://github.com/gengjiawen/monkey-rust'
 
 function GitHubIcon() {
@@ -31,17 +33,20 @@ export function Header() {
           </Heading>
         </Flex>
 
-        <a
-          href={GITHUB_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="github-link"
-        >
-          <Flex align="center" gap="2">
-            <GitHubIcon />
-            <span className="github-link-text">GitHub</span>
-          </Flex>
-        </a>
+        <Flex align="center" gap="2">
+          <ThemeToggle />
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="github-link"
+          >
+            <Flex align="center" gap="2">
+              <GitHubIcon />
+              <span className="github-link-text">GitHub</span>
+            </Flex>
+          </a>
+        </Flex>
       </Flex>
     </header>
   )

--- a/packages/playground/src/components/PlaygroundTheme.tsx
+++ b/packages/playground/src/components/PlaygroundTheme.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { Theme } from '@radix-ui/themes'
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import type { ReactNode } from 'react'
+
+export function PlaygroundTheme({ children }: { children: ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+      <Theme accentColor="blue" grayColor="slate" radius="small">
+        {children}
+      </Theme>
+    </NextThemesProvider>
+  )
+}

--- a/packages/playground/src/components/ThemeToggle.tsx
+++ b/packages/playground/src/components/ThemeToggle.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { IconButton } from '@radix-ui/themes'
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+
+function SunIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="2" />
+      <path
+        d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M21 14.5A8.5 8.5 0 0 1 9.5 3 7 7 0 1 0 21 14.5Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <IconButton size="2" variant="ghost" disabled aria-label="Toggle color theme" />
+    )
+  }
+
+  const isDark = resolvedTheme === 'dark'
+
+  return (
+    <IconButton
+      size="2"
+      variant="ghost"
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </IconButton>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       next:
         specifier: 16.2.9
         version: 16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.0.0
         version: 3.8.4
@@ -101,7 +104,7 @@ importers:
     dependencies:
       '@gengjiawen/monkey-wasm':
         specifier: ^0.14.0
-        version: link:../../wasm/pkg
+        version: 0.14.0
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -560,6 +563,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@gengjiawen/monkey-wasm@0.14.0':
+    resolution: {integrity: sha512-cB8lRjEc3asmXO5iWSDDerjZYU3XBCUofYGH+6xRGjO2K9DAyxCBA6TFXV2pxNgCvRjR6/j9T+GarxIu+M9lQA==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2868,6 +2874,12 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   next@16.2.9:
     resolution: {integrity: sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==}
     engines: {node: '>=20.9.0'}
@@ -3938,6 +3950,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@gengjiawen/monkey-wasm@0.14.0': {}
 
   '@img/colour@1.1.0':
     optional: true
@@ -6164,6 +6178,11 @@ snapshots:
 
   napi-build-utils@2.0.0:
     optional: true
+
+  next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   next@16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
     dependencies:
       '@gengjiawen/monkey-wasm':
         specifier: ^0.14.0
-        version: 0.14.0
+        version: link:../../wasm/pkg
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -563,9 +563,6 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@gengjiawen/monkey-wasm@0.14.0':
-    resolution: {integrity: sha512-cB8lRjEc3asmXO5iWSDDerjZYU3XBCUofYGH+6xRGjO2K9DAyxCBA6TFXV2pxNgCvRjR6/j9T+GarxIu+M9lQA==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3950,8 +3947,6 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.11': {}
-
-  '@gengjiawen/monkey-wasm@0.14.0': {}
 
   '@img/colour@1.1.0':
     optional: true


### PR DESCRIPTION
## Summary

Add light/dark mode support to the Monkey Playground with system preference detection and a manual toggle in the header.

## Changes

- Add `next-themes` and a `PlaygroundTheme` provider that integrates with Radix UI Themes
- Add a sun/moon toggle button in the header to switch between light and dark mode
- Sync CodeMirror editors with `@codemirror/theme-one-dark` in dark mode
- Adjust AST highlight colors for dark backgrounds

## Behavior

- Defaults to the user's system color scheme (`prefers-color-scheme`)
- Toggle persists the chosen theme across page reloads
- UI panels, AST tree, and toolbars use existing Radix CSS variables and adapt automatically

## Testing

- `pnpm -C packages/playground lint` passes
- Full build not run locally (wasm workspace dependency unavailable in this environment)