### PR TITLE
fix(playground): prevent code panel growth on mobile bytecode switch

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -229,22 +229,23 @@ function App() {
           </SegmentedControl.Root>
         </Flex>
         <Box className="editor-frame">
-          {outputView === 'ast' && astData !== null ? (
-            <Box className="ast-frame">
+          {astData !== null ? (
+            <Box className="ast-frame" hidden={outputView !== 'ast'}>
               <AstTreeView
                 data={astData}
                 selection={selection}
                 onNodeSelect={handleNodeSelect}
               />
             </Box>
-          ) : (
+          ) : null}
+          <Box hidden={outputView === 'ast' && astData !== null} className="output-editor">
             <Editor
               code={outputView === 'ast' ? astOutput : compilerOutput}
               extra={{ readOnly: true, editable: false }}
               vimMode={false}
               fill
             />
-          )}
+          </Box>
         </Box>
       </Flex>
     </Flex>

--- a/packages/playground/src/Editor.tsx
+++ b/packages/playground/src/Editor.tsx
@@ -177,7 +177,7 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
       {...extraProps}
       className={fill ? 'editor-fill' : undefined}
       value={code}
-      height={fill ? undefined : '100%'}
+      height="100%"
       theme="none"
       extensions={extensions}
       onChange={onChange}

--- a/packages/playground/src/app/globals.css
+++ b/packages/playground/src/app/globals.css
@@ -14,8 +14,8 @@ body {
 .playground-root {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  min-height: 100dvh;
+  height: 100dvh;
+  overflow: hidden;
 }
 
 .playground-shell {
@@ -23,6 +23,7 @@ body {
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   flex: 1 1 0%;
   min-height: 0;
+  overflow: hidden;
 }
 
 .playground-header {
@@ -56,6 +57,7 @@ body {
   min-width: 0;
   min-height: 0;
   height: 100%;
+  overflow: hidden;
   background: var(--color-background);
 }
 
@@ -74,6 +76,7 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   background: var(--color-background);
 }
 
@@ -81,14 +84,21 @@ body {
   display: flex;
   flex: 1;
   min-height: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 .editor-fill .cm-editor {
   flex: 1;
   min-height: 0;
-  height: auto !important;
+  height: 100% !important;
+  max-height: 100%;
   font-size: 14px;
   background: var(--color-background);
+}
+
+.editor-fill .cm-scroller {
+  overflow: auto;
 }
 
 .cm-scroller {
@@ -103,6 +113,22 @@ body {
   overflow: auto;
   padding: 8px 10px 16px;
   background: var(--color-background);
+}
+
+.ast-frame[hidden] {
+  display: none;
+}
+
+.output-editor {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.output-editor[hidden] {
+  display: none;
 }
 
 .ast-tree {


### PR DESCRIPTION
## Summary

Fix a mobile layout bug where switching the output panel from AST to Bytecode caused the top code editor to suddenly grow taller.

## Root cause

Bytecode output uses CodeMirror, which was allowed to expand with its content (`height: auto`). On mobile's stacked grid layout, the bottom panel pushed the overall shell beyond the viewport, and both equal-height rows grew together.

AST view avoided this because the tree scrolls inside a constrained `overflow: auto` container.

## Changes

- Lock the playground shell to the viewport (`height: 100dvh`, `overflow: hidden`)
- Make CodeMirror fill its parent at `height: 100%` instead of growing with content
- Keep the output editor mounted but hidden while AST is shown, avoiding layout jumps on toggle

## Testing

- `pnpm -C packages/playground lint` passes
- Verify on a viewport <= 780px: switching AST ↔ Bytecode keeps the top editor at half height