### PR TITLE
docs: fix Rust CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@gengjiawen/monkey-wasm)](https://www.npmjs.com/package/@gengjiawen/monkey-wasm)
 [![npm version](https://img.shields.io/npm/v/prettier-plugin-monkey?label=prettier-plugin-monkey)](https://www.npmjs.com/package/prettier-plugin-monkey)
 
-An interpreter for the Monkey programming language written in Rust
+An interpreter and compiler for the Monkey programming language written in Rust
 
 ![The Monkey Programming Language](https://cloud.githubusercontent.com/assets/1013641/22617482/9c60c27c-eb09-11e6-9dfa-b04c7fe498ea.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # monkey-rust
 
-![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)
+![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)
 [![monkey-interpreter](https://img.shields.io/crates/v/monkey-interpreter)](https://crates.io/crates/monkey-interpreter)
 [![npm version](https://img.shields.io/npm/v/@gengjiawen/monkey-wasm)](https://www.npmjs.com/package/@gengjiawen/monkey-wasm)
 [![npm version](https://img.shields.io/npm/v/prettier-plugin-monkey?label=prettier-plugin-monkey)](https://www.npmjs.com/package/prettier-plugin-monkey)

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,5 +1,5 @@
 # monkey-rust
-![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)
+![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)
 
 This is a compiler for the Monkey programming language written in Rust
 

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -1,5 +1,5 @@
 # monkey-rust
-![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)
+![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)
 
 This is a interpreter for the Monkey programming language written in Rust
 

--- a/lexer/README.md
+++ b/lexer/README.md
@@ -1,5 +1,5 @@
 # monkey-rust
-![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)
+![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)
 
 This is lexer for the Monkey programming language written in Rust
 

--- a/object/README.md
+++ b/object/README.md
@@ -1,5 +1,5 @@
 # monkey-rust
-![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)
+![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)
 
 This is a object for the Monkey programming language written in Rust
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monkey-rust",
   "version": "0.14.0",
-  "description": "An interpreter for the Monkey programming language written in Rust",
+  "description": "An interpreter and compiler for the Monkey programming language written in Rust",
   "main": "index.js",
   "directories": {
     "example": "examples"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monkey-rust",
   "version": "0.14.0",
-  "description": "![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)",
+  "description": "![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)",
   "main": "index.js",
   "directories": {
     "example": "examples"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monkey-rust",
   "version": "0.14.0",
-  "description": "![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)",
+  "description": "An interpreter for the Monkey programming language written in Rust",
   "main": "index.js",
   "directories": {
     "example": "examples"

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,5 +1,5 @@
 # monkey-rust
-![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)
+![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)
 
 This is a parser for the Monkey programming language written in Rust
 

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,4 +1,4 @@
-![Rust](https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg)
+![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)
 
 This lib designed for compiling monkey-parser into WebAssembly and
 publishing the resulting package to NPM.


### PR DESCRIPTION
## Summary

Fix the Rust CI badge in README showing as failing even though `main` builds successfully.

## Root cause

The README used the legacy workflow badge URL:

```
https://github.com/gengjiawen/monkey-rust/workflows/Rust/badge.svg
```

That badge reflects the most recent workflow run across all branches/events. Recent `release-please` PR runs complete with `action_required` (no jobs executed), which the badge treats as failing.

`main` branch push runs are all passing.

## Fix

Use the current badge URL scoped to `main` push events:

```
https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push
```