### PR TITLE
fix(lexer): avoid O(n) char lookup in read_char and peek_char

### DIFF
--- a/lexer/lib.rs
+++ b/lexer/lib.rs
@@ -20,28 +20,24 @@ impl<'a> Lexer<'a> {
 
     fn read_char(&mut self) {
         if self.read_position >= self.input.len() {
-            self.ch = 0 as char
+            self.ch = '\0';
         } else {
-            if let Some(ch) = self.input.chars().nth(self.read_position) {
-                self.ch = ch;
-            } else {
-                panic!("read out of range")
-            }
+            self.ch = self.input[self.read_position..].chars().next().unwrap();
         }
 
         self.position = self.read_position;
-        self.read_position += 1;
+        if self.read_position < self.input.len() && self.ch != '\0' {
+            self.read_position += self.ch.len_utf8();
+        } else {
+            self.read_position += 1;
+        }
     }
 
     fn peek_char(&self) -> char {
         if self.read_position >= self.input.len() {
-            0 as char
+            '\0'
         } else {
-            if let Some(ch) = self.input.chars().nth(self.read_position) {
-                ch
-            } else {
-                panic!("read out of range")
-            }
+            self.input[self.read_position..].chars().next().unwrap()
         }
     }
 


### PR DESCRIPTION
## Summary

Fix the lexer performance issue reported in #94.

## Problem

`read_char` and `peek_char` used `self.input.chars().nth(self.read_position)`, which walks the string from the start on every call. Tokenizing a file is O(n²) as a result.

## Solution

Read the current character via byte-offset slicing (`self.input[self.read_position..].chars().next()`) and advance `read_position` by `ch.len_utf8()` so each step is O(1) and UTF-8 is handled correctly.

## Testing

- `cargo test -p monkey-lexer`
- `cargo test`

Fixes #94