### PR TITLE
fix(lexer): make character reads linear

### DIFF
--- a/lexer/lexer_test.rs
+++ b/lexer/lexer_test.rs
@@ -51,6 +51,16 @@ mod tests {
     }
 
     #[test]
+    fn test_lexer_unicode_string() {
+        let mut l = Lexer::new(r#""你好""#);
+        let token = l.next_token();
+
+        assert_eq!(token.kind, TokenKind::STRING("你好".to_string()));
+        assert_eq!(token.span.start, 0);
+        assert_eq!(token.span.end, r#""你好""#.len());
+    }
+
+    #[test]
     fn test_lexer_array() {
         test_lexer_common("array", "[3]");
     }
@@ -64,15 +74,23 @@ mod tests {
     fn test_lexer_bool() {
         test_lexer_common("bool", "let y=true");
     }
-    
+
+    #[test]
+    fn test_lexer_large_input() {
+        let input = "let x = 1;".repeat(10_000);
+        let mut l = Lexer::new(&input);
+        let tokens = test_token_set(&mut l);
+
+        assert_eq!(tokens.len(), 50_001);
+        assert_eq!(tokens.last().unwrap().kind, TokenKind::EOF);
+    }
+
     #[test]
     fn test_comments_then_blank_line() {
         // Ensure comments followed by a blank line are skipped correctly
         // and do not yield ILLEGAL tokens.
         test_lexer_common("comments_then_blank_line", "// comment\n\nlet x = 5");
     }
-
-
 
     #[test]
     fn test_lexer_complex() {

--- a/lexer/lib.rs
+++ b/lexer/lib.rs
@@ -12,36 +12,28 @@ pub struct Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     pub fn new(input: &'a str) -> Self {
-        let mut l = Lexer { input, position: 0, read_position: 0, ch: 0 as char };
+        let mut l = Lexer { input, position: 0, read_position: 0, ch: '\0' };
 
         l.read_char();
         return l;
     }
 
     fn read_char(&mut self) {
-        if self.read_position >= self.input.len() {
-            self.ch = 0 as char
-        } else {
-            if let Some(ch) = self.input.chars().nth(self.read_position) {
-                self.ch = ch;
-            } else {
-                panic!("read out of range")
-            }
-        }
-
         self.position = self.read_position;
-        self.read_position += 1;
+
+        if self.position >= self.input.len() {
+            self.ch = '\0'
+        } else {
+            self.ch = self.input[self.position..].chars().next().unwrap();
+            self.read_position = self.position + self.ch.len_utf8();
+        }
     }
 
     fn peek_char(&self) -> char {
         if self.read_position >= self.input.len() {
-            0 as char
+            '\0'
         } else {
-            if let Some(ch) = self.input.chars().nth(self.read_position) {
-                ch
-            } else {
-                panic!("read out of range")
-            }
+            self.input[self.read_position..].chars().next().unwrap()
         }
     }
 
@@ -49,6 +41,12 @@ impl<'a> Lexer<'a> {
         // println!("self ch {}, position {} read_position {}", self.ch, self.position, self.read_position);
         // Skip any whitespace and successive line comments before producing a token.
         self.skip_ignorable();
+        let start = self.position;
+        if self.ch == '\0' {
+            self.read_char();
+            return Token { span: Span { start, end: start + 1 }, kind: TokenKind::EOF };
+        }
+
         let t = match self.ch {
             '=' => {
                 if self.peek_char() == '=' {
@@ -81,7 +79,6 @@ impl<'a> Lexer<'a> {
             '[' => TokenKind::LBRACKET,
             ':' => TokenKind::COLON,
             ']' => TokenKind::RBRACKET,
-            '\u{0}' => TokenKind::EOF,
             '"' => {
                 let (start, end, string) = self.read_string();
                 return Token { span: Span { start, end }, kind: TokenKind::STRING(string) };
@@ -103,10 +100,7 @@ impl<'a> Lexer<'a> {
         };
 
         self.read_char();
-        return Token {
-            span: Span { start: self.position - 1, end: self.read_position - 1 },
-            kind: t,
-        };
+        return Token { span: Span { start, end: self.position }, kind: t };
     }
 
     fn skip_whitespace(&mut self) {

--- a/lexer/snapshots/lexer__lexer_test__tests__complex.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__complex.snap
@@ -644,7 +644,7 @@ expression: "\n// welcome to monkeylang\nlet five = 5;\nlet ten = 10;\n\nlet add
       "type": "EQ"
     },
     "span": {
-      "start": 197,
+      "start": 196,
       "end": 198
     }
   },
@@ -682,7 +682,7 @@ expression: "\n// welcome to monkeylang\nlet five = 5;\nlet ten = 10;\n\nlet add
       "type": "NotEq"
     },
     "span": {
-      "start": 207,
+      "start": 206,
       "end": 208
     }
   },


### PR DESCRIPTION
## Summary
- replace repeated `chars().nth()` lookups with byte-offset based character reads
- keep token spans based on byte offsets and fix two-character operator start spans
- add regression coverage for large lexer input and UTF-8 string contents

Closes #94

## Tests
- `cargo test`