### PR TITLE
feat(compiler): add debug info and playground bytecode-to-source linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "lazy_static",
  "monkey-object",
  "monkey-parser",
+ "serde",
  "strum",
  "strum_macros 0.26.2",
 ]
@@ -214,6 +215,7 @@ dependencies = [
  "console_error_panic_hook",
  "monkey-compiler",
  "monkey-parser",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "wee_alloc",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -23,3 +23,4 @@ strum = { version = "0.25.0", features = ["derive"]}
 strum_macros = "0.26"
 monkey-parser = { path = "../parser", version = "0.14.0" }
 monkey-object = { path = "../object", version = "0.14.0" }
+serde = { version = "1.0.219", features = ["derive"] }

--- a/compiler/compiler.rs
+++ b/compiler/compiler.rs
@@ -1,8 +1,11 @@
 use object::builtins::BuiltIns;
+use serde::Serialize;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use object::Object;
 use parser::ast::{BlockStatement, Expression, Literal, Node, Statement};
+use parser::lexer::token::Span;
 use parser::lexer::token::TokenKind;
 
 use crate::op_code::Opcode::*;
@@ -13,11 +16,13 @@ struct CompilationScope {
     instructions: Instructions,
     last_instruction: EmittedInstruction,
     previous_instruction: EmittedInstruction,
+    debug_info: DebugInfo,
 }
 
 pub struct Compiler {
     pub constants: Vec<Rc<Object>>,
     pub symbol_table: SymbolTable,
+    function_debug_info: HashMap<usize, DebugInfo>,
     scopes: Vec<CompilationScope>,
     scope_index: usize,
 }
@@ -25,40 +30,180 @@ pub struct Compiler {
 pub struct Bytecode {
     pub instructions: Instructions,
     pub constants: Vec<Rc<Object>>,
+    pub debug_info: DebugInfo,
+    pub function_debug_info: HashMap<usize, DebugInfo>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PcSpan {
+    pub pc: usize,
+    pub span: Span,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugInfo {
+    pub pc_spans: Vec<PcSpan>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum InstructionScope {
+    Main,
+    Function { constant_index: usize },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstructionLineMapping {
+    pub line: usize,
+    pub pc: usize,
+    pub scope: InstructionScope,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BytecodeDebugView {
+    pub detail: String,
+    pub main_debug_info: DebugInfo,
+    pub function_debug_info: HashMap<usize, DebugInfo>,
+    pub instruction_lines: Vec<InstructionLineMapping>,
+}
+
+struct ScopedInstructions {
+    instructions: Instructions,
+    debug_info: DebugInfo,
 }
 
 impl Bytecode {
     pub fn string(&self) -> String {
-        let mut output = String::new();
+        self.debug_view().detail
+    }
 
-        output.push_str("Instructions:\n");
-        output.push_str(&self.instructions.string());
-        output.push_str("\nConstants:\n");
+    pub fn debug_view(&self) -> BytecodeDebugView {
+        let mut builder = BytecodeDisplayBuilder::new();
 
-        if self.constants.is_empty() {
-            output.push_str("(none)\n");
-            return output;
+        builder.write_line("Instructions:");
+        for line in self.instructions.string().lines() {
+            builder.write_instruction_line(line, InstructionScope::Main, |line| {
+                format!("{line}\n")
+            });
         }
 
-        for (index, constant) in self.constants.iter().enumerate() {
-            match constant.as_ref() {
-                Object::CompiledFunction(function) => {
-                    output.push_str(&format!(
-                        "{:04} CompiledFunction(num_locals={}, num_parameters={})\n",
-                        index, function.num_locals, function.num_parameters
-                    ));
-                    output.push_str("     Instructions:\n");
+        builder.write_line("");
+        builder.write_line("Constants:");
 
-                    let instructions = Instructions { data: function.instructions.clone() };
-                    for line in instructions.string().lines() {
-                        output.push_str(&format!("       {}\n", line));
+        if self.constants.is_empty() {
+            builder.write_line("(none)");
+        } else {
+            for (index, constant) in self.constants.iter().enumerate() {
+                match constant.as_ref() {
+                    Object::CompiledFunction(function) => {
+                        builder.write_line(&format!(
+                            "{index:04} CompiledFunction(num_locals={}, num_parameters={})",
+                            function.num_locals, function.num_parameters
+                        ));
+                        builder.write_line("     Instructions:");
+
+                        let instructions =
+                            Instructions { data: function.instructions.clone() };
+                        let scope =
+                            InstructionScope::Function { constant_index: index };
+                        for line in instructions.string().lines() {
+                            builder.write_instruction_line(line, scope.clone(), |line| {
+                                format!("       {line}\n")
+                            });
+                        }
                     }
+                    value => builder.write_line(&format!("{index:04} {value}")),
                 }
-                value => output.push_str(&format!("{:04} {}\n", index, value)),
             }
         }
 
-        output
+        BytecodeDebugView {
+            detail: builder.output,
+            main_debug_info: self.debug_info.clone(),
+            function_debug_info: self.function_debug_info.clone(),
+            instruction_lines: builder.instruction_lines,
+        }
+    }
+}
+
+struct BytecodeDisplayBuilder {
+    output: String,
+    line: usize,
+    instruction_lines: Vec<InstructionLineMapping>,
+}
+
+impl BytecodeDisplayBuilder {
+    fn new() -> Self {
+        Self { output: String::new(), line: 0, instruction_lines: vec![] }
+    }
+
+    fn write_line(&mut self, line: &str) {
+        self.output.push_str(line);
+        self.output.push('\n');
+        self.line += 1;
+    }
+
+    fn write_instruction_line(
+        &mut self,
+        raw_line: &str,
+        scope: InstructionScope,
+        format_line: impl FnOnce(&str) -> String,
+    ) {
+        if let Some(pc) = parse_instruction_pc(raw_line) {
+            self.instruction_lines.push(InstructionLineMapping {
+                line: self.line,
+                pc,
+                scope,
+            });
+        }
+
+        self.output.push_str(&format_line(raw_line));
+        self.line += 1;
+    }
+}
+
+fn parse_instruction_pc(line: &str) -> Option<usize> {
+    let trimmed = line.trim_start();
+    if trimmed.len() < 4 {
+        return None;
+    }
+
+    let pc_part = &trimmed[..4];
+    if !pc_part.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    pc_part.parse().ok()
+}
+
+impl DebugInfo {
+    pub fn add_pc_span(&mut self, pc: usize, span: &Span) {
+        if self
+            .pc_spans
+            .last()
+            .map(|last| last.span == *span)
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        self.pc_spans.push(PcSpan { pc, span: span.clone() });
+    }
+
+    pub fn span_for_pc(&self, pc: usize) -> Option<&Span> {
+        self.pc_spans
+            .iter()
+            .rev()
+            .find(|pc_span| pc_span.pc <= pc)
+            .map(|pc_span| &pc_span.span)
+    }
+
+    fn truncate_from_pc(&mut self, pc: usize) {
+        self.pc_spans.retain(|pc_span| pc_span.pc < pc);
     }
 }
 
@@ -76,6 +221,7 @@ impl Compiler {
             instructions: Instructions { data: vec![] },
             last_instruction: EmittedInstruction { opcode: OpNull, position: 0 },
             previous_instruction: EmittedInstruction { opcode: OpNull, position: 0 },
+            debug_info: DebugInfo::default(),
         };
 
         let mut symbol_table = SymbolTable::new();
@@ -86,6 +232,7 @@ impl Compiler {
         return Compiler {
             constants: vec![],
             symbol_table,
+            function_debug_info: HashMap::new(),
             scopes: vec![main_scope],
             scope_index: 0,
         };
@@ -124,20 +271,28 @@ impl Compiler {
                     .define(let_statement.identifier.kind.to_string());
                 self.compile_expr(&let_statement.expr)?;
                 if symbol.scope == SymbolScope::Global {
-                    self.emit(Opcode::OpSetGlobal, &vec![symbol.index]);
+                    self.emit_with_span(
+                        Opcode::OpSetGlobal,
+                        &vec![symbol.index],
+                        &let_statement.span,
+                    );
                 } else {
-                    self.emit(Opcode::OpSetLocal, &vec![symbol.index]);
+                    self.emit_with_span(
+                        Opcode::OpSetLocal,
+                        &vec![symbol.index],
+                        &let_statement.span,
+                    );
                 }
                 return Ok(());
             }
             Statement::Return(r) => {
                 self.compile_expr(&r.argument)?;
-                self.emit(Opcode::OpReturnValue, &vec![]);
+                self.emit_with_span(Opcode::OpReturnValue, &vec![], &r.span);
                 return Ok(());
             }
             Statement::Expr(e) => {
                 self.compile_expr(e)?;
-                self.emit(OpPop, &vec![]);
+                self.emit_with_span(OpPop, &vec![], expression_span(e));
                 return Ok(());
             }
         }
@@ -149,7 +304,7 @@ impl Compiler {
                 let symbol = self.symbol_table.resolve(identifier.name.clone());
                 match symbol {
                     Some(symbol) => {
-                        self.load_symbol(&symbol);
+                        self.load_symbol(&symbol, &identifier.span);
                     }
                     None => {
                         return Err(format!("Undefined variable '{}'", identifier.name));
@@ -160,42 +315,42 @@ impl Compiler {
                 Literal::Integer(i) => {
                     let int = Object::Integer(i.raw);
                     let operands = vec![self.add_constant(int)];
-                    self.emit(OpConst, &operands);
+                    self.emit_with_span(OpConst, &operands, &i.span);
                 }
                 Literal::Boolean(i) => {
                     if i.raw {
-                        self.emit(OpTrue, &vec![]);
+                        self.emit_with_span(OpTrue, &vec![], &i.span);
                     } else {
-                        self.emit(OpFalse, &vec![]);
+                        self.emit_with_span(OpFalse, &vec![], &i.span);
                     }
                 }
                 Literal::String(s) => {
                     let string_object = Object::String(s.raw.clone());
                     let operands = vec![self.add_constant(string_object)];
-                    self.emit(OpConst, &operands);
+                    self.emit_with_span(OpConst, &operands, &s.span);
                 }
                 Literal::Array(array) => {
                     for element in array.elements.iter() {
                         self.compile_expr(element)?;
                     }
-                    self.emit(OpArray, &vec![array.elements.len()]);
+                    self.emit_with_span(OpArray, &vec![array.elements.len()], &array.span);
                 }
                 Literal::Hash(hash) => {
                     for (key, value) in hash.elements.iter() {
                         self.compile_expr(&key)?;
                         self.compile_expr(&value)?;
                     }
-                    self.emit(OpHash, &vec![hash.elements.len() * 2]);
+                    self.emit_with_span(OpHash, &vec![hash.elements.len() * 2], &hash.span);
                 }
             },
             Expression::PREFIX(prefix) => {
                 self.compile_expr(&prefix.operand).unwrap();
                 match prefix.op.kind {
                     TokenKind::MINUS => {
-                        self.emit(OpMinus, &vec![]);
+                        self.emit_with_span(OpMinus, &vec![], &prefix.span);
                     }
                     TokenKind::BANG => {
-                        self.emit(OpBang, &vec![]);
+                        self.emit_with_span(OpBang, &vec![], &prefix.span);
                     }
                     _ => {
                         return Err(format!("unexpected prefix op: {}", prefix.op));
@@ -206,32 +361,32 @@ impl Compiler {
                 if infix.op.kind == TokenKind::LT {
                     self.compile_expr(&infix.right).unwrap();
                     self.compile_expr(&infix.left).unwrap();
-                    self.emit(Opcode::OpGreaterThan, &vec![]);
+                    self.emit_with_span(Opcode::OpGreaterThan, &vec![], &infix.span);
                     return Ok(());
                 }
                 self.compile_expr(&infix.left).unwrap();
                 self.compile_expr(&infix.right).unwrap();
                 match infix.op.kind {
                     TokenKind::PLUS => {
-                        self.emit(OpAdd, &vec![]);
+                        self.emit_with_span(OpAdd, &vec![], &infix.span);
                     }
                     TokenKind::MINUS => {
-                        self.emit(OpSub, &vec![]);
+                        self.emit_with_span(OpSub, &vec![], &infix.span);
                     }
                     TokenKind::ASTERISK => {
-                        self.emit(OpMul, &vec![]);
+                        self.emit_with_span(OpMul, &vec![], &infix.span);
                     }
                     TokenKind::SLASH => {
-                        self.emit(OpDiv, &vec![]);
+                        self.emit_with_span(OpDiv, &vec![], &infix.span);
                     }
                     TokenKind::GT => {
-                        self.emit(Opcode::OpGreaterThan, &vec![]);
+                        self.emit_with_span(Opcode::OpGreaterThan, &vec![], &infix.span);
                     }
                     TokenKind::EQ => {
-                        self.emit(Opcode::OpEqual, &vec![]);
+                        self.emit_with_span(Opcode::OpEqual, &vec![], &infix.span);
                     }
                     TokenKind::NotEq => {
-                        self.emit(Opcode::OpNotEqual, &vec![]);
+                        self.emit_with_span(Opcode::OpNotEqual, &vec![], &infix.span);
                     }
                     _ => {
                         return Err(format!("unexpected infix op: {}", infix.op));
@@ -240,19 +395,20 @@ impl Compiler {
             }
             Expression::IF(if_node) => {
                 self.compile_expr(&if_node.condition)?;
-                let jump_not_truthy = self.emit(OpJumpNotTruthy, &vec![9527]);
+                let jump_not_truthy =
+                    self.emit_with_span(OpJumpNotTruthy, &vec![9527], &if_node.span);
                 self.compile_block_statement(&if_node.consequent)?;
                 if self.last_instruction_is(OpPop) {
                     self.remove_last_pop();
                 }
 
-                let jump_pos = self.emit(OpJump, &vec![9527]);
+                let jump_pos = self.emit_with_span(OpJump, &vec![9527], &if_node.span);
 
                 let after_consequence_location = self.current_instruction().data.len();
                 self.change_operand(jump_not_truthy, after_consequence_location);
 
                 if if_node.alternate.is_none() {
-                    self.emit(OpNull, &vec![]);
+                    self.emit_with_span(OpNull, &vec![], &if_node.span);
                 } else {
                     self.compile_block_statement(&if_node.clone().alternate.unwrap())?;
                     if self.last_instruction_is(OpPop) {
@@ -265,9 +421,10 @@ impl Compiler {
             Expression::Index(index) => {
                 self.compile_expr(&index.object)?;
                 self.compile_expr(&index.index)?;
-                self.emit(OpIndex, &vec![]);
+                self.emit_with_span(OpIndex, &vec![], &index.span);
             }
             Expression::FUNCTION(f) => {
+                let function_span = f.span.clone();
                 self.enter_scope();
                 // f.name
                 for param in f.params.iter() {
@@ -278,55 +435,55 @@ impl Compiler {
                     self.replace_last_pop_with_return();
                 }
                 if !(self.last_instruction_is(OpReturnValue)) {
-                    self.emit(OpReturn, &vec![]);
+                    self.emit_with_span(OpReturn, &vec![], &function_span);
                 }
                 let num_locals = self.symbol_table.num_definitions;
                 let free_symbols = self.symbol_table.free_symbols.clone();
-                let instructions = self.leave_scope();
+                let scoped_instructions = self.leave_scope();
                 for x in free_symbols.clone() {
-                    self.load_symbol(&x);
+                    self.load_symbol(&x, &function_span);
                 }
 
                 let compiled_function = Rc::from(object::CompiledFunction {
-                    instructions: instructions.data,
+                    instructions: scoped_instructions.instructions.data,
                     num_locals,
                     num_parameters: f.params.len(),
                 });
 
-                let operands = vec![
-                    self.add_constant(Object::CompiledFunction(compiled_function)),
-                    free_symbols.len(),
-                ];
-                self.emit(OpClosure, &operands);
+                let constant_index = self.add_constant(Object::CompiledFunction(compiled_function));
+                self.function_debug_info_mut()
+                    .insert(constant_index, scoped_instructions.debug_info);
+                let operands = vec![constant_index, free_symbols.len()];
+                self.emit_with_span(OpClosure, &operands, &function_span);
             }
             Expression::FunctionCall(fc) => {
                 self.compile_expr(&fc.callee)?;
                 for arg in fc.arguments.iter() {
                     self.compile_expr(arg)?;
                 }
-                self.emit(OpCall, &vec![fc.arguments.len()]);
+                self.emit_with_span(OpCall, &vec![fc.arguments.len()], &fc.span);
             }
         }
 
         return Ok(());
     }
 
-    fn load_symbol(&mut self, symbol: &Rc<Symbol>) {
+    fn load_symbol(&mut self, symbol: &Rc<Symbol>, span: &Span) {
         match symbol.scope {
             SymbolScope::Global => {
-                self.emit(OpGetGlobal, &vec![symbol.index]);
+                self.emit_with_span(OpGetGlobal, &vec![symbol.index], span);
             }
             SymbolScope::LOCAL => {
-                self.emit(OpGetLocal, &vec![symbol.index]);
+                self.emit_with_span(OpGetLocal, &vec![symbol.index], span);
             }
             SymbolScope::Builtin => {
-                self.emit(OpGetBuiltin, &vec![symbol.index]);
+                self.emit_with_span(OpGetBuiltin, &vec![symbol.index], span);
             }
             SymbolScope::Free => {
-                self.emit(OpGetFree, &vec![symbol.index]);
+                self.emit_with_span(OpGetFree, &vec![symbol.index], span);
             }
             SymbolScope::Function => {
-                self.emit(OpCurrentClosure, &vec![]);
+                self.emit_with_span(OpCurrentClosure, &vec![], span);
             }
         }
     }
@@ -335,6 +492,8 @@ impl Compiler {
         return Bytecode {
             instructions: self.current_instruction().clone(),
             constants: self.constants.clone(),
+            debug_info: self.current_debug_info().clone(),
+            function_debug_info: self.function_debug_info.clone(),
         };
     }
 
@@ -349,6 +508,12 @@ impl Compiler {
         self.set_last_instruction(op, pos);
 
         return pos;
+    }
+
+    pub fn emit_with_span(&mut self, op: Opcode, operands: &Vec<usize>, span: &Span) -> usize {
+        let pos = self.emit(op, operands);
+        self.add_pc_span(pos, span);
+        pos
     }
 
     fn compile_block_statement(
@@ -392,6 +557,9 @@ impl Compiler {
         let new = old[..last.position].to_vec();
 
         self.scopes[self.scope_index].instructions.data = new;
+        self.scopes[self.scope_index]
+            .debug_info
+            .truncate_from_pc(last.position);
         self.scopes[self.scope_index].last_instruction = previous;
     }
 
@@ -418,23 +586,62 @@ impl Compiler {
         return &self.scopes[self.scope_index].instructions;
     }
 
+    fn current_debug_info(&self) -> &DebugInfo {
+        return &self.scopes[self.scope_index].debug_info;
+    }
+
+    fn function_debug_info_mut(&mut self) -> &mut HashMap<usize, DebugInfo> {
+        return &mut self.function_debug_info;
+    }
+
+    fn add_pc_span(&mut self, pc: usize, span: &Span) {
+        self.scopes[self.scope_index]
+            .debug_info
+            .add_pc_span(pc, span);
+    }
+
     fn enter_scope(&mut self) {
         let scope = CompilationScope {
             instructions: Instructions { data: vec![] },
             last_instruction: EmittedInstruction { opcode: OpNull, position: 0 },
             previous_instruction: EmittedInstruction { opcode: OpNull, position: 0 },
+            debug_info: DebugInfo::default(),
         };
         self.scopes.push(scope);
         self.scope_index += 1;
         self.symbol_table = SymbolTable::new_enclosed_symbol_table(self.symbol_table.clone());
     }
 
-    fn leave_scope(&mut self) -> Instructions {
+    fn leave_scope(&mut self) -> ScopedInstructions {
         let instructions = self.current_instruction().clone();
+        let debug_info = self.current_debug_info().clone();
         self.scopes.pop();
         self.scope_index -= 1;
         let s = self.symbol_table.outer.as_ref().unwrap().as_ref().clone();
         self.symbol_table = s;
-        return instructions;
+        return ScopedInstructions { instructions, debug_info };
+    }
+}
+
+fn expression_span(expression: &Expression) -> &Span {
+    match expression {
+        Expression::IDENTIFIER(identifier) => &identifier.span,
+        Expression::LITERAL(literal) => literal_span(literal),
+        Expression::PREFIX(prefix) => &prefix.span,
+        Expression::INFIX(infix) => &infix.span,
+        Expression::IF(if_expression) => &if_expression.span,
+        Expression::FUNCTION(function) => &function.span,
+        Expression::FunctionCall(function_call) => &function_call.span,
+        Expression::Index(index) => &index.span,
+    }
+}
+
+fn literal_span(literal: &Literal) -> &Span {
+    match literal {
+        Literal::Integer(integer) => &integer.span,
+        Literal::Boolean(boolean) => &boolean.span,
+        Literal::String(string) => &string.span,
+        Literal::Array(array) => &array.span,
+        Literal::Hash(hash) => &hash.span,
     }
 }

--- a/compiler/compiler_test.rs
+++ b/compiler/compiler_test.rs
@@ -52,6 +52,7 @@ mod tests {
     use super::*;
     use crate::op_code::make_instructions;
     use crate::op_code::Opcode::*;
+    use parser::lexer::token::Span;
 
     #[test]
     fn integer_arithmetic() {
@@ -144,6 +145,107 @@ mod tests {
         assert!(output.contains("       0002 OpGetLocal 1\n"));
         assert!(output.contains("       0004 OpAdd\n"));
         assert!(output.contains("       0005 OpReturnValue\n"));
+    }
+
+    #[test]
+    fn bytecode_tracks_pc_to_source_spans() {
+        let program = parse("1;\n22").unwrap();
+        let mut compiler = Compiler::new();
+        let bytecode = compiler.compile(&program).unwrap();
+
+        assert_eq!(
+            bytecode.debug_info.pc_spans,
+            vec![
+                crate::compiler::PcSpan { pc: 0, span: Span { start: 0, end: 1 } },
+                crate::compiler::PcSpan { pc: 4, span: Span { start: 3, end: 5 } },
+            ]
+        );
+        assert_eq!(bytecode.debug_info.span_for_pc(3), Some(&Span { start: 0, end: 1 }));
+        assert_eq!(bytecode.debug_info.span_for_pc(7), Some(&Span { start: 3, end: 5 }));
+    }
+
+    #[test]
+    fn bytecode_tracks_function_constant_pc_to_source_spans() {
+        let input = "let add = fn(a, b) { a + b; };";
+        let program = parse(input).unwrap();
+        let mut compiler = Compiler::new();
+        let bytecode = compiler.compile(&program).unwrap();
+
+        let expression_start = input.find("a + b").unwrap();
+        let function_debug_info = bytecode.function_debug_info.get(&0).unwrap();
+
+        assert_eq!(
+            function_debug_info.span_for_pc(4),
+            Some(&Span { start: expression_start, end: expression_start + "a + b".len() })
+        );
+    }
+
+    #[test]
+    fn bytecode_debug_view_maps_instruction_lines_to_pc() {
+        let input = "1;\n22";
+        let program = parse(input).unwrap();
+        let mut compiler = Compiler::new();
+        let bytecode = compiler.compile(&program).unwrap();
+        let view = bytecode.debug_view();
+
+        assert_eq!(view.detail, bytecode.string());
+        assert_eq!(
+            view.instruction_lines,
+            vec![
+                crate::compiler::InstructionLineMapping {
+                    line: 1,
+                    pc: 0,
+                    scope: crate::compiler::InstructionScope::Main,
+                },
+                crate::compiler::InstructionLineMapping {
+                    line: 2,
+                    pc: 3,
+                    scope: crate::compiler::InstructionScope::Main,
+                },
+                crate::compiler::InstructionLineMapping {
+                    line: 3,
+                    pc: 4,
+                    scope: crate::compiler::InstructionScope::Main,
+                },
+                crate::compiler::InstructionLineMapping {
+                    line: 4,
+                    pc: 7,
+                    scope: crate::compiler::InstructionScope::Main,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn bytecode_debug_view_maps_function_instruction_lines() {
+        let input = "let add = fn(a, b) { a + b; };";
+        let program = parse(input).unwrap();
+        let mut compiler = Compiler::new();
+        let bytecode = compiler.compile(&program).unwrap();
+        let view = bytecode.debug_view();
+
+        let add_line = view
+            .instruction_lines
+            .iter()
+            .find(|line| {
+                matches!(
+                    line.scope,
+                    crate::compiler::InstructionScope::Function { constant_index: 0 }
+                ) && line.pc == 4
+            })
+            .expect("OpAdd instruction line");
+
+        let expression_start = input.find("a + b").unwrap();
+        let function_debug_info = view.function_debug_info.get(&0).unwrap();
+
+        assert_eq!(add_line.line > 0, true);
+        assert_eq!(
+            function_debug_info.span_for_pc(add_line.pc),
+            Some(&Span {
+                start: expression_start,
+                end: expression_start + "a + b".len(),
+            })
+        );
     }
 
     #[test]

--- a/docs/compiler-debug-info-design.md
+++ b/docs/compiler-debug-info-design.md
@@ -1,0 +1,431 @@
+# Monkey Compiler Debug Info 设计文档
+
+> 本文说明 Monkey compiler 中源码位置到字节码 PC 的映射设计，并对比 QuickJS 的 `OP_source_loc` 临时 opcode 方案。
+
+## 目录
+
+1. [背景](#1-背景)
+2. [目标与非目标](#2-目标与非目标)
+3. [当前实现](#3-当前实现)
+4. [数据结构](#4-数据结构)
+5. [编译流程](#5-编译流程)
+6. [与 QuickJS 的差异](#6-与-quickjs-的差异)
+7. [测试策略](#7-测试策略)
+8. [后续演进](#8-后续演进)
+9. [WASM 与 Playground 集成](#9-wasm-与-playground-集成)
+
+---
+
+## 1. 背景
+
+Monkey 的 lexer/parser 已经为 token 和 AST 节点保留了源码 `Span`：
+
+```rust
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+```
+
+这些 span 是源码 byte offset，而不是 line/column。compiler 原先只产出 `Instructions` 和 `constants`，没有保存字节码 PC 与源码位置的关系，因此后续要做 VM 错误定位、调用栈、编辑器诊断或断点时缺少基础数据。
+
+QuickJS 的做法是：编译早期插入临时 `OP_source_loc` opcode，后续优化/resolve 阶段移除该 opcode，并生成独立压缩的 `pc2line` 表。最终 VM 执行的字节码不包含 `OP_source_loc`。
+
+Monkey 当前 compiler 还没有类似 QuickJS 的多阶段 label resolve / bytecode finalize pass，因此第一版采用更直接的旁路表设计。
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 为主程序字节码保存 `pc -> Span` 映射。
+- 为函数常量内部字节码保存独立的 `pc -> Span` 映射。
+- 不改变最终 VM 执行的 opcode 流。
+- 不影响现有 compiler/vm 测试中对 `Instructions` 的断言。
+- 为未来 line/column、stack trace、debugger、WASM API 暴露位置数据留接口。
+
+### 2.2 非目标
+
+- 当前不引入 `OpSourceLoc` 临时 opcode。
+- 当前不实现压缩编码。
+- 当前不把 byte offset 转换为 line/column。
+- 当前不修改 VM 运行时错误模型。
+- 当前不修改 `object::CompiledFunction` 结构，避免大量测试和对象层变更。
+- 当前不实现源码 span 到 bytecode PC 的反向查询（Playground 仅支持 bytecode 行 → 源码高亮）。
+
+---
+
+## 3. 当前实现
+
+当前实现位于 `compiler/compiler.rs`。
+
+核心思路：
+
+1. 编译每条有源码归属的指令时调用 `emit_with_span(op, operands, span)`。
+2. `emit_with_span` 先正常 emit 原始 opcode，再把返回的 PC 和 AST span 写入当前 scope 的 `DebugInfo`。
+3. `Bytecode` 除了 `instructions` 和 `constants` 外，额外携带主程序 `debug_info`。
+4. 函数字面量进入独立 compiler scope，离开 scope 时同时返回函数内部 `Instructions` 和 `DebugInfo`。
+5. 函数内部 debug info 不写入 `CompiledFunction`，而是保存在 `Bytecode.function_debug_info` 中，key 为函数常量在 constant pool 中的 index。
+
+最终 VM 仍然只执行 `Instructions`，debug info 是旁路元数据。
+
+---
+
+## 4. 数据结构
+
+### 4.1 `PcSpan`
+
+```rust
+pub struct PcSpan {
+    pub pc: usize,
+    pub span: Span,
+}
+```
+
+表示从某个 bytecode PC 开始，对应源码中的某个 AST span。
+
+### 4.2 `DebugInfo`
+
+```rust
+pub struct DebugInfo {
+    pub pc_spans: Vec<PcSpan>,
+}
+```
+
+提供两个关键操作：
+
+- `add_pc_span(pc, span)`：追加一条 PC 到 span 的映射。如果连续记录的 span 相同，会跳过重复记录。
+- `span_for_pc(pc)`：从后向前查找最后一个 `pc_span.pc <= pc` 的 span。
+
+这种结构语义接近 `pc2line`：它记录的是位置变化点，而不是每个 byte 都记录一条位置。
+
+### 4.3 `Bytecode`
+
+```rust
+pub struct Bytecode {
+    pub instructions: Instructions,
+    pub constants: Vec<Rc<Object>>,
+    pub debug_info: DebugInfo,
+    pub function_debug_info: HashMap<usize, DebugInfo>,
+}
+```
+
+- `debug_info`：主程序指令的 PC 到源码 span 映射。
+- `function_debug_info`：函数常量的 PC 到源码 span 映射。key 是 constant pool index。
+
+### 4.4 `CompilationScope`
+
+每个 compiler scope 维护自己的 `DebugInfo`：
+
+```rust
+struct CompilationScope {
+    instructions: Instructions,
+    last_instruction: EmittedInstruction,
+    previous_instruction: EmittedInstruction,
+    debug_info: DebugInfo,
+}
+```
+
+函数编译时会 `enter_scope()` 创建新 scope，函数完成后 `leave_scope()` 返回该 scope 的指令和 debug info。
+
+---
+
+## 5. 编译流程
+
+### 5.1 普通 opcode emit
+
+原有 `emit` 保持不变：
+
+```rust
+pub fn emit(&mut self, op: Opcode, operands: &Vec<usize>) -> usize {
+    let ins = make_instructions(op, operands);
+    let pos = self.add_instructions(&ins);
+    self.set_last_instruction(op, pos);
+    pos
+}
+```
+
+新增 `emit_with_span`：
+
+```rust
+pub fn emit_with_span(&mut self, op: Opcode, operands: &Vec<usize>, span: &Span) -> usize {
+    let pos = self.emit(op, operands);
+    self.add_pc_span(pos, span);
+    pos
+}
+```
+
+编译表达式和语句时，优先使用 AST 节点自己的 span：
+
+- integer/string/boolean literal 使用 literal span。
+- identifier load 使用 identifier span。
+- infix/prefix 使用整个表达式 span。
+- let/return 最终 store/return 指令使用 statement span。
+- function call 使用 call expression span。
+
+### 5.2 删除或替换指令时维护 debug info
+
+compiler 中已有 peephole 行为，例如：
+
+- `remove_last_pop()`
+- `replace_last_pop_with_return()`
+- `change_operand()`
+
+当前实现中，`remove_last_pop()` 会同步删除被移除 PC 之后的 debug info：
+
+```rust
+self.scopes[self.scope_index]
+    .debug_info
+    .truncate_from_pc(last.position);
+```
+
+`replace_last_pop_with_return()` 不改变 PC，因此保留原 span。语义上这表示被替换后的 `OpReturnValue` 仍归属于原表达式 span。
+
+`change_operand()` 只 patch operand，不改变 PC，因此无需调整 debug info。
+
+### 5.3 函数常量
+
+函数编译流程：
+
+1. `enter_scope()` 创建函数内部 scope。
+2. 编译函数 body。
+3. 必要时把尾部 `OpPop` 替换为 `OpReturnValue`。
+4. `leave_scope()` 返回 `ScopedInstructions { instructions, debug_info }`。
+5. `instructions.data` 写入 `CompiledFunction`。
+6. `debug_info` 写入 `Bytecode.function_debug_info[constant_index]`。
+7. 外层 emit `OpClosure`，并把它映射到函数字面量 span。
+
+这样可以避免修改 `object::CompiledFunction`，同时仍能找到函数内部 PC 对应的源码位置。
+
+---
+
+## 6. 与 QuickJS 的差异
+
+### 6.1 QuickJS 方案
+
+QuickJS 的流程可以概括为：
+
+```text
+parse/compile
+  -> emit normal opcodes + OP_source_loc
+  -> optimize / resolve labels
+  -> remove OP_source_loc
+  -> generate compressed pc2line table
+  -> final bytecode + debug table
+```
+
+特点：
+
+- `OP_source_loc` 是临时 opcode。
+- debug 信息最初内嵌在 bytecode 流中。
+- 后续 pass 会删除临时 opcode。
+- 删除临时 opcode 后需要重新计算或修正 PC、jump offset、label 地址。
+- 最终 VM 不执行 `OP_source_loc`。
+
+### 6.2 当前 Monkey 方案
+
+当前 Monkey 流程：
+
+```text
+parse/compile
+  -> emit normal opcodes
+  -> record pc -> Span side table
+  -> final bytecode + debug table
+```
+
+特点：
+
+- 没有临时 opcode。
+- debug 信息从一开始就是旁路表。
+- 不需要删除 debug opcode。
+- 不需要额外 patch jump 地址。
+- 实现更小，适合当前单 pass compiler。
+
+### 6.3 取舍
+
+当前方案的优点：
+
+- 改动小，不影响 `Opcode` enum 和 `Instructions` 编码。
+- 不影响 VM 指令读取逻辑。
+- 不破坏现有 bytecode snapshot/断言。
+- 不需要引入 finalize pass。
+
+当前方案的缺点：
+
+- 不像 QuickJS 那样把源码位置作为中间 bytecode 的一部分，后续如果实现复杂优化 pass，需要记得同步更新 debug side table。
+- 还没有压缩编码。
+- 还没有 line/column，只能返回 byte span。
+
+---
+
+## 7. 测试策略
+
+当前新增测试位于 `compiler/compiler_test.rs`：
+
+### 7.1 主程序 PC 到 Span
+
+输入：
+
+```monkey
+1;
+22
+```
+
+断言：
+
+- 第一条表达式的 PC 映射到 `Span { start: 0, end: 1 }`。
+- 第二条表达式的 PC 映射到 `Span { start: 3, end: 5 }`。
+- `span_for_pc` 可以在指令内部 PC 上查到最近位置。
+
+### 7.2 函数常量 PC 到 Span
+
+输入：
+
+```monkey
+let add = fn(a, b) { a + b; };
+```
+
+断言：
+
+- constant pool index `0` 的函数 debug info 存在。
+- 函数内部 `OpAdd` 附近的 PC 能映射到 `a + b` 的 span。
+
+### 7.3 回归验证
+
+需要持续保证：
+
+```bash
+cargo test -p monkey-compiler
+cargo test
+```
+
+---
+
+## 8. 后续演进
+
+### 8.1 转换为 line/column
+
+当前 `Span` 是 byte offset。可以新增一个 source map helper：
+
+```rust
+pub struct SourceMap {
+    line_starts: Vec<usize>,
+}
+```
+
+通过 `line_starts` 把 `Span.start` 转换成 line/column，用于错误提示和编辑器 range。
+
+### 8.2 压缩 debug info
+
+当前 `DebugInfo` 直接保存 `Vec<PcSpan>`。后续可以改为 delta 编码：
+
+```text
+pc_delta, start_delta, end_delta
+```
+
+或者只保存 `pc_delta, start_delta, len`。这会更接近 QuickJS 的压缩表。
+
+### 8.3 引入 QuickJS 风格临时 opcode
+
+如果未来 compiler 引入多阶段优化/label resolve，可以考虑改为：
+
+1. 在 `Opcode` 中新增 `OpSourceLoc`。
+2. 编译 AST 时 emit `OpSourceLoc(start, end)`。
+3. 新增 `finalize_bytecode()` pass：
+   - 扫描 instructions。
+   - 遇到 `OpSourceLoc` 时更新当前 source span。
+   - 遇到普通 opcode 时写入新 instructions，并记录旧 PC 到新 PC 的映射。
+   - 删除所有 `OpSourceLoc`。
+   - 根据旧 PC 到新 PC 映射 patch jump operand。
+   - 生成 `DebugInfo`。
+4. VM 只接收 finalize 后的 instructions。
+
+这个方案更接近 QuickJS，但需要先把当前 compiler 的直接 jump patch 逻辑演进成 label 或 relocation 模型，否则删除临时 opcode 后 patch jump 会比较脆弱。
+
+### 8.4 写入 `CompiledFunction`
+
+当前函数 debug info 存在 `Bytecode.function_debug_info` 中。后续如果 VM runtime 需要在调用栈里直接访问函数 debug info，可以考虑把 debug info 放入 `object::CompiledFunction`：
+
+```rust
+pub struct CompiledFunction {
+    pub instructions: Vec<u8>,
+    pub num_locals: usize,
+    pub num_parameters: usize,
+    pub debug_info: DebugInfo,
+}
+```
+
+这样 VM frame 可以直接通过当前 closure 找到 debug info。代价是 `object` crate 会依赖 compiler debug 类型，或者需要把 debug 类型下沉到共享 crate。
+
+更保守的做法是新建共享 debug 类型模块，避免 `object` 反向依赖 `compiler`。
+
+---
+
+## 9. WASM 与 Playground 集成
+
+### 9.1 WASM API
+
+`wasm/src/lib.rs` 新增 `compile_with_debug(input: &str) -> String`，返回 JSON 序列化的 `BytecodeDebugView`：
+
+```json
+{
+  "detail": "Instructions:\n0000 OpConst 0\n...",
+  "mainDebugInfo": {
+    "pcSpans": [{ "pc": 0, "span": { "start": 0, "end": 1 } }]
+  },
+  "functionDebugInfo": {
+    "0": { "pcSpans": [{ "pc": 4, "span": { "start": 21, "end": 26 } }] }
+  },
+  "instructionLines": [
+    { "line": 1, "pc": 0, "scope": { "type": "main" } },
+    { "line": 8, "pc": 4, "scope": { "type": "function", "constantIndex": 0 } }
+  ]
+}
+```
+
+字段说明：
+
+- `detail`：与 `compile_detail` 相同的可读 bytecode 文本，供 Playground 展示。
+- `mainDebugInfo` / `functionDebugInfo`：主程序与函数常量的 PC → span 表。
+- `instructionLines`：`detail` 文本中每条指令行对应的 0-based 行号、PC 和 scope。Playground 用它在用户点击 bytecode 行时定位 PC，避免解析缩进文本。
+
+原有 `compile` / `compile_detail` 保持不变，不携带 debug info。
+
+### 9.2 `BytecodeDebugView`
+
+`compiler/compiler.rs` 提供 `Bytecode::debug_view()`，统一生成 `detail` 文本和 `instructionLines`。`Bytecode::string()` 委托给 `debug_view().detail`，保证展示文本与 line map 一致。
+
+### 9.3 Playground 联动
+
+Playground（`packages/playground/src/App.tsx`）在 bytecode 面板使用 `compile_with_debug`：
+
+1. 解析 JSON 得到 `BytecodeDebugView`。
+2. 用 `detail` 填充 bytecode 只读编辑器。
+3. 监听 bytecode 编辑器选区变化，根据光标 offset 计算行号。
+4. 在 `instructionLines` 中查找对应行，取得 PC 和 scope。
+5. 从 `mainDebugInfo` 或 `functionDebugInfo` 调用 `spanForPc`，得到源码 byte span。
+6. 在左侧源码编辑器高亮对应范围（复用 AST 联动的 `highlightRange`）。
+
+辅助函数位于 `packages/playground/src/bytecodeDebug.ts`。
+
+交互方向：**bytecode 行 → 源码高亮**。源码 → bytecode 反向高亮尚未实现。
+
+### 9.4 本地开发
+
+修改 compiler 或 wasm 后需要重新构建 wasm 包，Playground 才能加载新 API：
+
+```bash
+cd wasm && wasm-pack build --release --scope=gengjiawen
+pnpm -C packages/playground dev
+```
+
+### 9.5 测试
+
+compiler 侧新增 `bytecode_debug_view_*` 测试，验证：
+
+- `debug_view().detail` 与 `string()` 输出一致。
+- 主程序与函数 instruction line 的 line / pc / scope 映射正确。
+
+Playground 联动目前依赖手动验证；后续可考虑 Playwright 或 wasm 层 JSON 快照测试。
+

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Box, Button, Flex, SegmentedControl, Select } from '@radix-ui/themes'
-import { compile_detail, parse } from '@gengjiawen/monkey-wasm'
+import { compile_with_debug, parse } from '@gengjiawen/monkey-wasm'
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import debounce from 'lodash.debounce'
@@ -9,6 +9,10 @@ import type { Plugin } from 'prettier'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { AstTreeView } from './AstTreeView'
+import {
+  type BytecodeDebugView,
+  spanForBytecodeCursor,
+} from './bytecodeDebug'
 import { Editor, type EditorHandle } from './Editor'
 
 interface Snippet {
@@ -86,6 +90,8 @@ function App() {
     to: number
   } | null>(null)
   const [compilerOutput, setCompilerOutput] = useState('')
+  const [bytecodeDebugView, setBytecodeDebugView] =
+    useState<BytecodeDebugView | null>(null)
   const [vimMode, setVimMode] = useState(true)
   const [isFormatting, setIsFormatting] = useState(false)
   const editorRef = useRef<EditorHandle>(null)
@@ -103,8 +109,12 @@ function App() {
     }
 
     try {
-      setCompilerOutput(compile_detail(source))
+      const debugJson = compile_with_debug(source)
+      const view = JSON.parse(debugJson) as BytecodeDebugView
+      setBytecodeDebugView(view)
+      setCompilerOutput(view.detail)
     } catch (error) {
+      setBytecodeDebugView(null)
       setCompilerOutput(getErrorMessage(error))
     }
   }, [])
@@ -163,6 +173,30 @@ function App() {
   const handleNodeSelect = useCallback((start: number, end: number) => {
     editorRef.current?.highlightRange(start, end)
   }, [])
+
+  const handleBytecodeSelection = useCallback(
+    (selection: { from: number; to: number }) => {
+      if (bytecodeDebugView == null) {
+        editorRef.current?.clearHighlight()
+        return
+      }
+
+      const span = spanForBytecodeCursor(bytecodeDebugView, selection.from)
+      if (span == null) {
+        editorRef.current?.clearHighlight()
+        return
+      }
+
+      editorRef.current?.highlightRange(span.start, span.end)
+    },
+    [bytecodeDebugView],
+  )
+
+  useEffect(() => {
+    if (outputView !== 'bytecode') {
+      editorRef.current?.clearHighlight()
+    }
+  }, [outputView])
 
   return (
     <Flex className="playground-shell">
@@ -242,6 +276,9 @@ function App() {
             <Editor
               code={outputView === 'ast' ? astOutput : compilerOutput}
               extra={{ readOnly: true, editable: false }}
+              onSelectionChange={
+                outputView === 'bytecode' ? handleBytecodeSelection : undefined
+              }
               vimMode={false}
               fill
             />

--- a/packages/playground/src/bytecodeDebug.ts
+++ b/packages/playground/src/bytecodeDebug.ts
@@ -1,0 +1,95 @@
+export interface Span {
+  start: number
+  end: number
+}
+
+export interface PcSpan {
+  pc: number
+  span: Span
+}
+
+export interface DebugInfo {
+  pcSpans: PcSpan[]
+}
+
+export type InstructionScope =
+  | { type: 'main' }
+  | { type: 'function'; constantIndex: number }
+
+export interface InstructionLineMapping {
+  line: number
+  pc: number
+  scope: InstructionScope
+}
+
+export interface BytecodeDebugView {
+  detail: string
+  mainDebugInfo: DebugInfo
+  functionDebugInfo: Record<string, DebugInfo>
+  instructionLines: InstructionLineMapping[]
+}
+
+export function spanForPc(
+  debugInfo: DebugInfo,
+  pc: number,
+): Span | null {
+  for (let index = debugInfo.pcSpans.length - 1; index >= 0; index -= 1) {
+    const entry = debugInfo.pcSpans[index]
+    if (entry.pc <= pc) {
+      return entry.span
+    }
+  }
+
+  return null
+}
+
+export function lineAtOffset(text: string, offset: number): number {
+  if (offset <= 0) {
+    return 0
+  }
+
+  let line = 0
+  for (let index = 0; index < offset && index < text.length; index += 1) {
+    if (text[index] === '\n') {
+      line += 1
+    }
+  }
+
+  return line
+}
+
+export function findInstructionLineAt(
+  instructionLines: InstructionLineMapping[],
+  line: number,
+): InstructionLineMapping | null {
+  return instructionLines.find((entry) => entry.line === line) ?? null
+}
+
+export function debugInfoForScope(
+  view: BytecodeDebugView,
+  scope: InstructionScope,
+): DebugInfo | null {
+  if (scope.type === 'main') {
+    return view.mainDebugInfo
+  }
+
+  return view.functionDebugInfo[String(scope.constantIndex)] ?? null
+}
+
+export function spanForBytecodeCursor(
+  view: BytecodeDebugView,
+  offset: number,
+): Span | null {
+  const line = lineAtOffset(view.detail, offset)
+  const mapping = findInstructionLineAt(view.instructionLines, line)
+  if (mapping == null) {
+    return null
+  }
+
+  const debugInfo = debugInfoForScope(view, mapping.scope)
+  if (debugInfo == null) {
+    return null
+  }
+
+  return spanForPc(debugInfo, mapping.pc)
+}

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -20,6 +20,7 @@ monkey-parser = { path = "../parser", version = "0.14.0" }
 monkey-compiler = { path = "../compiler", version = "0.14.0" }
 
 wasm-bindgen = "0.2.88"
+serde_json = "1.0.140"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -51,3 +51,21 @@ pub fn compile_detail(input: &str) -> String {
         Err(e) => throw_str(format!("compile error: {}", e).as_str()),
     }
 }
+
+#[wasm_bindgen]
+pub fn compile_with_debug(input: &str) -> String {
+    set_panic_hook();
+
+    let program = match parser_pase(input) {
+        Ok(ast) => ast,
+        Err(e) => throw_str(format!("parse error: {}", e[0]).as_str()),
+    };
+    let mut compiler = Compiler::new();
+    match compiler.compile(&program) {
+        Ok(bytecode) => match serde_json::to_string(&bytecode.debug_view()) {
+            Ok(json) => json,
+            Err(e) => throw_str(format!("json error: {}", e).as_str()),
+        },
+        Err(e) => throw_str(format!("compile error: {}", e).as_str()),
+    }
+}


### PR DESCRIPTION
## Summary

- Add compiler-side PC-to-source span mapping (`DebugInfo`, `emit_with_span`) as a side table alongside bytecode, including per-function constant debug info.
- Expose structured debug data via new wasm `compile_with_debug` API returning `BytecodeDebugView` JSON (detail text, pc spans, instruction line map).
- Wire Playground bytecode panel: selecting an instruction line highlights the corresponding source range in the editor.
- Add design doc at `docs/compiler-debug-info-design.md` covering compiler, wasm, and playground integration.

## Test plan

- [x] `cargo test -p monkey-compiler` (38 tests)
- [ ] CI Rust workspace tests
- [ ] `cd wasm && wasm-pack build --release --scope=gengjiawen` (CI / Vercel)
- [ ] Playground manual: switch to Bytecode view, click main-program and nested function instruction lines, verify source highlight


Made with [Cursor](https://cursor.com)