### PR TITLE
feat(gc): add QuickJS-style GC runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "monkey-gc"
+version = "0.14.0"
+dependencies = [
+ "byteorder",
+ "insta",
+ "monkey-compiler",
+ "monkey-object",
+ "monkey-parser",
+]
+
+[[package]]
 name = "monkey-interpreter"
 version = "0.14.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "lexer",
   "parser",
+  "gc",
   "object",
   "interpreter",
   "compiler",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Monkey has a C-like syntax, supports **variable bindings**, **prefix** and **inf
 - **Prettier Plugin**: Format Monkey source code with [Prettier](https://prettier.io/) via `prettier-plugin-monkey`.
 - **VS Code Extension**: First-class editor support with syntax highlighting, snippets, WASM-powered diagnostics, AST preview, and bytecode compilation commands.
 - bytecode viewer from source
+- **GC** ([`monkey-gc`](gc/README.md)): alternate bytecode VM with QuickJS-style refcounting and three-phase cycle collection (`gc_decref` → `gc_scan` → `gc_free_cycles`) on a `GcHeap`, so cyclic object graphs can be reclaimed without changing `object` or the default `Rc` VM.
 
 ## Resources
 Official site is: https://monkeylang.org/. It's has various implementation languages :).

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -190,7 +190,7 @@ Phase 3: gc_free_cycles  释放 tmp 列表中真正不可达的环
 
 - 设置 `gc_phase = RemoveCycles`。
 - 逐个释放 `tmp_obj_list` 中的对象（真正不可达的环）。
-- `free_js_object` 先释放 `trace` 出来的子边，再运行 `on_free`，最后移出 GC 链表。
+- `free_heap_object` 先释放 `trace` 出来的子边，再运行 `on_free`，最后移出 GC 链表。
 - 若释放子边和 finalizer 后 `ref_count != 0`，只把物理释放 **延迟** 到 `gc_zero_ref_count_list`；`on_free` 不会在延迟释放阶段重复执行。
 
 ### 5.5 即时释放路径
@@ -198,10 +198,10 @@ Phase 3: gc_free_cycles  释放 tmp 列表中真正不可达的环
 `ref_count` 减到 0 且不在 `RemoveCycles` 阶段时：
 
 ```
-free_gc → gc_zero_ref_count_list → free_zero_refcount → free_js_object
+free_gc → gc_zero_ref_count_list → free_zero_refcount → free_heap_object
 ```
 
-`free_js_object` 会 `trace` 子节点并递归 `free_gc`，形成级联释放。对已释放的子节点，`free_gc` 通过 `object_exists` 检查避免沿陈旧边 panic。
+`free_heap_object` 会 `trace` 子节点并递归 `free_gc`，形成级联释放。对已释放的子节点，`free_gc` 通过 `object_exists` 检查避免沿陈旧边 panic。
 
 ### 5.6 GC 触发策略
 
@@ -360,11 +360,11 @@ let result = vm.export_last_result();  // Option<Object>
 
 | 限制 | 说明 |
 |------|------|
-| QuickJS 对象模型未完整移植 | 当前只实现 Monkey `ValueCell` 所需的 `JsObject`/`FunctionBytecode` 风格路径，没有 shape、realm、var ref、async function 等完整对象系统 |
+| QuickJS 对象模型未完整移植 | 当前只实现 Monkey `ValueCell` 所需的 `MonkeyObject`/`FunctionBytecode` 风格路径，没有 shape、realm、var ref、async function 等完整对象系统 |
 | finalizer 能力较小 | `on_free` 对应 QuickJS finalizer；调用前 trace 边已经释放，但 Rust 对象字段不会像 QuickJS C 结构那样逐字段置空，因此 `on_free` 不应再次释放 trace 边 |
 | 陈旧边防护 | `free_gc` 对已释放子节点做 `object_exists` 检查，避免沿已拆除的环边 panic |
 | 字符串未拆堆 | `Value::String` 内联在 `ValueCell` 中，未使用 `RefCountHeader` 路径 |
-| `GcObjectType` 预留 | `Shape`, `VarRef`, `AsyncFunction`, `JsContext` 等 tag 已定义但未使用 |
+| `GcObjectType` 预留 | `FunctionBytecode`, `Shape`, `VarRef`, `AsyncFunction`, `JsContext` 等 tag 已定义但未使用 |
 | 无写屏障 | 与 QuickJS 一致，依赖显式 `dup`/`free` 维护 refcount |
 | 单线程 | 无 `Send`/`Sync` 保证，设计为单线程 VM |
 

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -1,0 +1,411 @@
+# monkey-gc 设计文档
+
+> 本文说明 `monkey-gc` crate 的设计：QuickJS 风格的引用计数 + 三阶段环检测 GC，以及基于同一套 bytecode 的 `GcVM` 运行时。
+
+## 目录
+
+1. [背景](#1-背景)
+2. [目标与非目标](#2-目标与非目标)
+3. [整体架构](#3-整体架构)
+4. [模块设计](#4-模块设计)
+5. [GC 算法](#5-gc-算法)
+6. [值模型与桥接层](#6-值模型与桥接层)
+7. [GcVM 设计](#7-gcvm-设计)
+8. [与现有系统的关系](#8-与现有系统的关系)
+9. [已知限制](#9-已知限制)
+10. [测试策略](#10-测试策略)
+11. [后续演进](#11-后续演进)
+12. [文件索引](#12-文件索引)
+
+---
+
+## 1. 背景
+
+Monkey 语言在 `monkey-rust` 中已有完整的编译执行管线：
+
+```
+lexer → parser → compiler (bytecode) → VM
+```
+
+其中 `compiler::VM` 与 `object::Object` 使用 `Rc<Object>` 管理堆对象。引用计数无法回收**纯环状引用**（例如两个闭包互相持有），且 `Rc` 循环会导致内存泄漏。
+
+`monkey-gc` crate 提供一套 **QuickJS 风格的 GC 运行时**，作为现有 bytecode VM 的**并行替代实现**：
+
+| 维度 | `compiler::VM` | `monkey-gc::GcVM` |
+|------|----------------|-------------------|
+| 堆管理 | `Rc<Object>` | `GcHeap` + `GcRef` |
+| 环回收 | 不支持 | 三阶段 cycle collector |
+| `object` crate | 直接使用 | 不修改；通过 import/export 桥接 |
+| 字节码 | `Bytecode` | 复用同一套 `Bytecode` |
+
+算法参考 QuickJS 源码（`JS_RunGC`、`gc_decref`、`gc_scan`、`gc_free_cycles`）。
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 在独立 crate 中实现可环回收的堆，不修改 `object` / `interpreter`。
+- 复用 `compiler` 产出的 `Bytecode` 与 opcode 定义。
+- 提供与 `compiler::VM` 等价的 Monkey 语义（算术、闭包、builtins 等）。
+- 对外暴露 `eval_source` 等便捷 API，返回 `object::Object` 以便与现有工具链对接。
+- 保持与 QuickJS GC 算法结构一致，便于对照阅读和后续优化。
+
+### 2.2 非目标
+
+- 当前不替换 `wasm` / `playground` 中的默认 VM。
+- 当前不把 `object::Object` 本身改为 GC 管理。
+- 当前不实现多线程 / `Send` / `Sync` 保证。
+- 当前不实现写屏障；引用维护依赖显式 `dup` / `free`。
+- 当前字符串内联在 `ValueCell` 中，未拆到纯 refcount 堆。
+
+---
+
+## 3. 整体架构
+
+```
+                    Monkey 源码
+                         │
+                         ▼
+              lexer ──► parser ──► compiler
+                         │              │
+                         │         Bytecode
+                         │         ╱      ╲
+                         │        ╱        ╲
+                         ▼       ▼          ▼
+                   interpreter  compiler::VM  gc::GcVM
+                   (AST 求值)   Rc<Object>   GcRef
+                         │           │          │
+                         └───────────┴──────────┘
+                                     │
+                              object::Object
+```
+
+### 依赖关系
+
+```
+monkey-gc
+  ├── monkey-compiler  (Bytecode, Opcode, Compiler)
+  ├── monkey-object    (Object, BuiltinFunc, BuiltIns)
+  ├── monkey-parser    (eval_source 解析)
+  └── byteorder        (指令解码)
+```
+
+Workspace 成员：根 `Cargo.toml` → `"gc"`。
+
+---
+
+## 4. 模块设计
+
+| 模块 | 文件 | 职责 |
+|------|------|------|
+| 入口 | `lib.rs` | 导出公共 API；`compile` / `eval` / `eval_source` |
+| 堆 API | `heap.rs` | `GcHeap`、`GcRef`；分配 / 释放 / GC 触发 |
+| 运行时核心 | `runtime.rs` | `GcRuntime`：refcount、三阶段 GC、对象槽管理 |
+| 对象头 | `header.rs` | `GcObjectHeader`、`GcPhase`、`GcObjectType` |
+| 侵入式链表 | `list.rs` | `GcList`：`gc_obj` / `tmp` / `zero_ref` 三条链表 |
+| 分配统计 | `malloc.rs` | `MallocState`、GC 阈值触发 |
+| 值模型 | `value.rs` | `Value`、`ValueCell`、import/export 桥接 |
+| 调用帧 | `frame.rs` | `Frame`（闭包 + IP + 栈基址） |
+| 虚拟机 | `vm.rs` | `GcVM`：opcode 解释执行 |
+
+### 4.1 核心类型
+
+```rust
+// 不透明句柄，本质是堆内索引
+pub struct GcRef(pub GcId);  // GcId = usize
+
+// 高层堆 API
+pub struct GcHeap { rt: GcRuntime }
+
+// 可参与环检测的 GC 对象
+pub trait GcObject: Any {
+    fn trace(&self, visit: &mut dyn FnMut(GcId));  // 报告出边
+    fn on_free(&mut self, rt: &mut GcRuntime) {}     // 释放回调
+}
+```
+
+所有 Monkey 运行时值包装在 `ValueCell` 中，实现 `GcObject::trace` 以遍历 `Array` / `Hash` / `Closure` 的子引用。
+
+---
+
+## 5. GC 算法
+
+### 5.1 两类对象
+
+| 类型 | Header | 环检测 | 用途 |
+|------|--------|--------|------|
+| GC 对象 | `GcObjectHeader` | 是 | `ValueCell`、未来可扩展的 function bytecode 等 |
+| 纯 refcount 对象 | `RefCountHeader` | 否 | 字符串等（API 已预留，`add_ref_counted`） |
+
+### 5.2 对象头
+
+```rust
+pub struct GcObjectHeader {
+    pub ref_count: i32,        // 引用计数
+    pub gc_obj_type: GcObjectType,
+    pub mark: u8,               // GC 阶段临时标记（非永久 mark bit）
+    pub free_mark: bool,        // 僵尸检测（cycle free 期间）
+    pub list_prev: Option<GcId>,
+    pub list_next: Option<GcId>,
+}
+```
+
+### 5.3 三条侵入式链表
+
+```
+gc_obj_list           — 所有存活 GC 对象（ref_count > 0）
+tmp_obj_list          — trial deletion 中 ref_count 归零的候选
+gc_zero_ref_count_list — 延迟释放队列（cycle 移除时 ref 被恢复的对象）
+```
+
+链表通过 `GcId` 索引 + header 内嵌 `list_prev/next` 实现，等价于 QuickJS `list.h`。
+
+### 5.4 三阶段 Cycle Collection
+
+```
+Phase 1: gc_decref     trial deletion，沿 trace 边试探性减引用
+        │
+        ▼
+Phase 2: gc_scan       对仍存活对象恢复被误减的引用
+        │
+        ▼
+Phase 3: gc_free_cycles  释放 tmp 列表中真正不可达的环
+```
+
+**Phase 1 — `gc_decref`**
+
+- 遍历 `gc_obj_list` 中每个对象。
+- 对每个对象 `mark_children(Decref)`，沿 `trace` 边将子节点 `ref_count -= 1`。
+- 若对象自身 `ref_count == 0`，移入 `tmp_obj_list`。
+
+**Phase 2 — `gc_scan`**
+
+- 对 `gc_obj_list` 中仍存活（`ref_count > 0`）的对象：`mark_children(ScanIncref)`，恢复被误减的引用。
+- 对 `tmp_obj_list` 中的对象：`mark_children(ScanIncref2)`，仅增引用不计入链表迁移。
+
+**Phase 3 — `gc_free_cycles`**
+
+- 设置 `gc_phase = RemoveCycles`。
+- 逐个释放 `tmp_obj_list` 中的对象（真正不可达的环）。
+- 若释放时 `ref_count != 0`（被外部引用恢复），**延迟**到 `gc_zero_ref_count_list`，待 phase 结束后再释放。
+
+### 5.5 即时释放路径
+
+`ref_count` 减到 0 且不在 `RemoveCycles` 阶段时：
+
+```
+free_gc → gc_zero_ref_count_list → free_zero_refcount → free_js_object
+```
+
+`free_js_object` 会 `trace` 子节点并递归 `free_gc`，形成级联释放。对已释放的子节点，`free_gc` 通过 `object_exists` 检查避免沿陈旧边 panic。
+
+### 5.6 GC 触发策略
+
+```rust
+pub const DEFAULT_GC_THRESHOLD: usize = 256 * 1024;  // 256 KB
+```
+
+- 每次 `GcHeap::alloc` 前调用 `trigger_gc(alloc_size)`。
+- 当 `malloc_size + alloc_size > threshold` 时执行 `run_gc()`。
+- 触发后阈值上调为 `malloc_size + malloc_size/2`（与 QuickJS 一致）。
+- `set_gc_threshold(usize::MAX)` 可禁用自动 GC。
+
+### 5.7 重入保护
+
+```rust
+pub enum GcPhase {
+    None,
+    Decref,        // free_zero_refcount 期间
+    RemoveCycles,  // gc_free_cycles 期间
+}
+```
+
+在 `RemoveCycles` 阶段，`ref_count != 0` 的对象不立即物理释放，而是 defer 到 phase 结束，避免与环拆除逻辑冲突。
+
+---
+
+## 6. 值模型与桥接层
+
+### 6.1 `Value` vs `Object`
+
+`Value` 镜像 `object::Object`，但容器类型的边使用 `GcRef` 而非 `Rc<Object>`：
+
+```rust
+pub enum Value {
+    Integer(i64),
+    Boolean(bool),
+    String(String),
+    Array(Vec<GcRef>),
+    Hash(HashMap<HashKey, GcRef>),
+    Null,
+    Error(String),
+    CompiledFunction(CompiledFunction),
+    Closure(GcClosure),       // { func: GcRef, free: Vec<GcRef> }
+    Builtin(BuiltinFunc),
+}
+```
+
+### 6.2 所有权语义
+
+| 操作 | 行为 |
+|------|------|
+| `alloc_value` | `with_owned_edges` 对所有子 `GcRef` 执行 `dup`，再分配 |
+| VM `push` | `dup` 后写入栈（栈槽持有一份引用） |
+| VM `pop` | `dup` 返回值，栈槽引用仍保留直到被覆盖 |
+| VM 覆盖栈槽/全局变量 | 先 `free` 旧值，再写入新 `GcRef` |
+| 运算消费操作数 | `free(left)` + `free(right)` |
+
+### 6.3 import / export 桥接
+
+```
+object::Object (Rc)  ──import_object──►  GcRef (Value)
+GcRef (Value)          ──export_object──►  object::Object (Rc)
+```
+
+- **import**：递归深拷贝到 GC 堆，建立 `GcRef` 边。
+- **export**：递归导出为 `Rc<Object>`，供 builtins 和外部 API 使用。
+- **builtins**：`call_builtin` 先 export 参数 → 调用 `BuiltinFunc` → import 结果。
+
+`Object::Function`（解释器 AST 函数）**不可导入**，会 panic。
+
+---
+
+## 7. GcVM 设计
+
+### 7.1 结构
+
+```rust
+pub struct GcVM {
+    heap: GcHeap,
+    constants: Vec<GcRef>,      // 由 bytecode.constants import 而来
+    stack: Vec<GcRef>,          // 容量 2048
+    sp: usize,
+    globals: Vec<GcRef>,         // 容量 65536
+    frames: Vec<Frame>,         // 最多 1024 帧
+    frame_index: usize,
+    null: GcRef,                 // 共享 null 单例
+}
+```
+
+与 `compiler::VM` 布局一致，仅将 `Rc<Object>` 替换为 `GcRef`。
+
+### 7.2 支持的 Opcode
+
+完整覆盖当前 Monkey bytecode 指令集：
+
+| 类别 | Opcodes |
+|------|---------|
+| 常量/字面量 | `OpConst`, `OpTrue`, `OpFalse`, `OpNull` |
+| 算术 | `OpAdd`, `OpSub`, `OpMul`, `OpDiv`, `OpMinus` |
+| 比较/逻辑 | `OpEqual`, `OpNotEqual`, `OpGreaterThan`, `OpBang` |
+| 控制流 | `OpJump`, `OpJumpNotTruthy` |
+| 栈 | `OpPop` |
+| 全局/局部 | `OpGetGlobal`, `OpSetGlobal`, `OpGetLocal`, `OpSetLocal` |
+| 复合类型 | `OpArray`, `OpHash`, `OpIndex` |
+| 函数 | `OpCall`, `OpReturn`, `OpReturnValue` |
+| 闭包 | `OpClosure`, `OpGetFree`, `OpCurrentClosure` |
+| 内置 | `OpGetBuiltin` |
+
+### 7.3 借用检查策略
+
+Rust 借用规则要求 VM 在「读堆」与「写堆」之间拆分步骤：
+
+- `callee_kind()` — 先 clone `GcClosure` / 读取 builtin，再 mutate。
+- `alloc_and_push` / `dup_and_push` / `push_raw` — 分离分配与栈写入。
+- 运算函数 — 先 `get_value` 读操作数，再 `alloc_and_push` 写结果，最后 `free` 操作数。
+
+### 7.4 公共 API
+
+```rust
+// 便捷入口
+pub fn eval_source(source: &str) -> Result<Object, String>;
+pub fn eval(program: &Node) -> Result<Object, String>;
+pub fn compile(program: &Node) -> Result<Bytecode, String>;
+
+// 手动控制
+let bytecode = Compiler::new().compile(&program)?;
+let mut vm = GcVM::new(bytecode);
+vm.run();
+let result = vm.export_last_result();  // Option<Object>
+```
+
+---
+
+## 8. 与现有系统的关系
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   monkey-rust workspace              │
+├──────────────┬──────────────┬───────────────────────┤
+│ interpreter  │ compiler     │ gc (本 crate)          │
+│ AST 求值     │ 编译 + Rc VM │ 编译 + GC VM           │
+│ Rc<Object>   │ Rc<Object>   │ GcRef                  │
+├──────────────┴──────────────┴───────────────────────┤
+│ object (共享类型定义，未修改)                          │
+│ parser / lexer (共享前端)                             │
+│ wasm / playground (当前仍用 compiler::VM)             │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 9. 已知限制
+
+| 限制 | 说明 |
+|------|------|
+| 间接外部引用不保全环 | 若外部仅引用环中某一节点，环内其他节点可能在 GC 后被回收，但入口节点仍存活 |
+| 陈旧边防护 | `free_gc` 对已释放子节点做 `object_exists` 检查，避免沿已拆除的环边 panic |
+| 字符串未拆堆 | `Value::String` 内联在 `ValueCell` 中，未使用 `RefCountHeader` 路径 |
+| `GcObjectType` 预留 | `Shape`, `VarRef`, `AsyncFunction`, `JsContext` 等 tag 已定义但未使用 |
+| 无写屏障 | 与 QuickJS 一致，依赖显式 `dup`/`free` 维护 refcount |
+| 单线程 | 无 `Send`/`Sync` 保证，设计为单线程 VM |
+
+---
+
+## 10. 测试策略
+
+当前 **38 个测试**，分三层：
+
+| 层 | 文件 | 覆盖 |
+|----|------|------|
+| GC 算法 | `gc_test.rs` (16) | refcount、dup、2/3/4 节点环、自环、外部根保活、无环图、on_free、GC 阈值、mark 函数、幂等性 |
+| 值桥接 | `value_test.rs` (8) | import/export 往返、HashKey、子 refcount、Value 层环回收 |
+| 端到端 VM | `vm_test.rs` (14) | 算术、布尔、条件、let、字符串、数组、哈希、索引、函数、闭包、builtins |
+
+运行：
+
+```bash
+cargo test -p monkey-gc
+```
+
+---
+
+## 11. 后续演进
+
+1. **wasm 集成** — 在 wasm crate 增加 `GcVM` 导出，供 playground 切换。
+2. **字符串拆堆** — 大字符串走 `RefCountHeader`，减 `ValueCell` 体积。
+3. **闭包递归 / 高阶函数** — 补充 VM 测试，验证环场景下的生产行为。
+4. **GC 统计 API** — 暴露 `gc_object_count`、`malloc_state` 供 playground 调试面板。
+5. **性能对比** — 与 `Rc` VM 建立 benchmark（分配速率、GC 暂停）。
+
+---
+
+## 12. 文件索引
+
+```
+gc/
+├── lib.rs          # 入口 + eval API
+├── heap.rs         # GcHeap / GcRef
+├── runtime.rs      # GcRuntime + GC 三阶段
+├── header.rs       # 对象头 + 类型 tag
+├── list.rs         # 侵入式链表
+├── malloc.rs       # 分配统计 + 阈值
+├── value.rs        # Value + import/export
+├── frame.rs        # 调用帧
+├── vm.rs           # GcVM
+├── gc_test.rs      # GC 单元测试
+├── value_test.rs   # 值层测试
+└── vm_test.rs      # VM 集成测试
+```

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -364,7 +364,7 @@ let result = vm.export_last_result();  // Option<Object>
 | finalizer 能力较小 | `on_free` 对应 QuickJS finalizer；调用前 trace 边已经释放，但 Rust 对象字段不会像 QuickJS C 结构那样逐字段置空，因此 `on_free` 不应再次释放 trace 边 |
 | 陈旧边防护 | `free_gc` 对已释放子节点做 `object_exists` 检查，避免沿已拆除的环边 panic |
 | 字符串未拆堆 | `Value::String` 内联在 `ValueCell` 中，未使用 `RefCountHeader` 路径 |
-| `GcObjectType` 预留 | `FunctionBytecode`, `Shape`, `VarRef`, `AsyncFunction`, `JsContext` 等 tag 已定义但未使用 |
+| `GcObjectType` 预留 | `FunctionBytecode`, `Shape`, `VarRef`, `AsyncFunction`, `MonkeyContext` 等 tag 已定义但未使用 |
 | 无写屏障 | 与 QuickJS 一致，依赖显式 `dup`/`free` 维护 refcount |
 | 单线程 | 无 `Send`/`Sync` 保证，设计为单线程 VM |
 

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -183,13 +183,15 @@ Phase 3: gc_free_cycles  释放 tmp 列表中真正不可达的环
 **Phase 2 — `gc_scan`**
 
 - 对 `gc_obj_list` 中仍存活（`ref_count > 0`）的对象：`mark_children(ScanIncref)`，恢复被误减的引用。
+- `gc_obj_list` 按链表动态遍历；`ScanIncref` 从 `tmp_obj_list` 迁回来的对象会追加到 `gc_obj_list` 尾部，并在同一轮 scan 中继续扫描。这一点与 QuickJS `list_for_each(el, &rt->gc_obj_list)` 保持一致，确保外部根间接保活的整段环都被恢复。
 - 对 `tmp_obj_list` 中的对象：`mark_children(ScanIncref2)`，仅增引用不计入链表迁移。
 
 **Phase 3 — `gc_free_cycles`**
 
 - 设置 `gc_phase = RemoveCycles`。
 - 逐个释放 `tmp_obj_list` 中的对象（真正不可达的环）。
-- 若释放时 `ref_count != 0`（被外部引用恢复），**延迟**到 `gc_zero_ref_count_list`，待 phase 结束后再释放。
+- `free_js_object` 先释放 `trace` 出来的子边，再运行 `on_free`，最后移出 GC 链表。
+- 若释放子边和 finalizer 后 `ref_count != 0`，只把物理释放 **延迟** 到 `gc_zero_ref_count_list`；`on_free` 不会在延迟释放阶段重复执行。
 
 ### 5.5 即时释放路径
 
@@ -251,10 +253,12 @@ pub enum Value {
 
 | 操作 | 行为 |
 |------|------|
-| `alloc_value` | `with_owned_edges` 对所有子 `GcRef` 执行 `dup`，再分配 |
-| VM `push` | `dup` 后写入栈（栈槽持有一份引用） |
-| VM `pop` | `dup` 返回值，栈槽引用仍保留直到被覆盖 |
+| `alloc_value` | `with_owned_edges` 对所有子 `GcRef` 执行 `dup`，再分配；调用方仍负责释放传入的临时边 |
+| `import_object` | 递归 import 子对象，父对象分配完成后释放这些临时子引用，只保留父对象持有的边 |
+| VM `push` | 对已有引用执行 `dup` 后入栈；`push_raw` 表示转移一份已拥有的引用 |
+| VM `pop` | 将栈槽持有的引用转移给调用方，并把槽位重置为 `null` 引用 |
 | VM 覆盖栈槽/全局变量 | 先 `free` 旧值，再写入新 `GcRef` |
+| VM 构造数组/哈希/闭包 | 用栈上的临时引用分配父对象，随后清空对应栈区间，避免临时引用泄漏 |
 | 运算消费操作数 | `free(left)` + `free(right)` |
 
 ### 6.3 import / export 桥接
@@ -286,6 +290,7 @@ pub struct GcVM {
     frames: Vec<Frame>,         // 最多 1024 帧
     frame_index: usize,
     null: GcRef,                 // 共享 null 单例
+    last_popped: GcRef,          // 最近一次 OpPop 的结果
 }
 ```
 
@@ -355,7 +360,8 @@ let result = vm.export_last_result();  // Option<Object>
 
 | 限制 | 说明 |
 |------|------|
-| 间接外部引用不保全环 | 若外部仅引用环中某一节点，环内其他节点可能在 GC 后被回收，但入口节点仍存活 |
+| QuickJS 对象模型未完整移植 | 当前只实现 Monkey `ValueCell` 所需的 `JsObject`/`FunctionBytecode` 风格路径，没有 shape、realm、var ref、async function 等完整对象系统 |
+| finalizer 能力较小 | `on_free` 对应 QuickJS finalizer；调用前 trace 边已经释放，但 Rust 对象字段不会像 QuickJS C 结构那样逐字段置空，因此 `on_free` 不应再次释放 trace 边 |
 | 陈旧边防护 | `free_gc` 对已释放子节点做 `object_exists` 检查，避免沿已拆除的环边 panic |
 | 字符串未拆堆 | `Value::String` 内联在 `ValueCell` 中，未使用 `RefCountHeader` 路径 |
 | `GcObjectType` 预留 | `Shape`, `VarRef`, `AsyncFunction`, `JsContext` 等 tag 已定义但未使用 |
@@ -366,13 +372,13 @@ let result = vm.export_last_result();  // Option<Object>
 
 ## 10. 测试策略
 
-当前 **38 个测试**，分三层：
+当前 **42 个测试**，分三层：
 
 | 层 | 文件 | 覆盖 |
 |----|------|------|
-| GC 算法 | `gc_test.rs` (16) | refcount、dup、2/3/4 节点环、自环、外部根保活、无环图、on_free、GC 阈值、mark 函数、幂等性 |
-| 值桥接 | `value_test.rs` (8) | import/export 往返、HashKey、子 refcount、Value 层环回收 |
-| 端到端 VM | `vm_test.rs` (14) | 算术、布尔、条件、let、字符串、数组、哈希、索引、函数、闭包、builtins |
+| GC 算法 | `gc_test.rs` (17) | refcount、dup、2/3/4 节点环、自环、外部根间接保活整个环、无环图、on_free 顺序、GC 阈值、mark 函数、幂等性 |
+| 值桥接 | `value_test.rs` (9) | import/export 往返、HashKey、子 refcount、import 临时引用释放、Value 层环回收 |
+| 端到端 VM | `vm_test.rs` (16) | 算术、布尔、条件、let、字符串、数组、哈希、索引、函数、闭包、builtins、调用后临时引用清理 |
 
 运行：
 
@@ -386,7 +392,7 @@ cargo test -p monkey-gc
 
 1. **wasm 集成** — 在 wasm crate 增加 `GcVM` 导出，供 playground 切换。
 2. **字符串拆堆** — 大字符串走 `RefCountHeader`，减 `ValueCell` 体积。
-3. **闭包递归 / 高阶函数** — 补充 VM 测试，验证环场景下的生产行为。
+3. **递归 / 复杂环场景** — 继续补充真实程序级回归，验证闭包与容器组合后的生产行为。
 4. **GC 统计 API** — 暴露 `gc_object_count`、`malloc_state` 供 playground 调试面板。
 5. **性能对比** — 与 `Rc` VM 建立 benchmark（分配速率、GC 暂停）。
 

--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "monkey-gc"
+version = "0.14.0"
+description = "QuickJS-style GC runtime for Monkey (bytecode VM with cycle collector)"
+homepage = "https://github.com/gengjiawen/monkey-rust"
+repository = "https://github.com/gengjiawen/monkey-rust"
+authors = ["gengjiawen <technicalcute@gmail.com>"]
+edition = "2018"
+license = "MIT"
+
+[lib]
+name = "gc"
+path = "lib.rs"
+
+[dependencies]
+byteorder = "1.5.0"
+monkey-compiler = { path = "../compiler", version = "0.14.0" }
+monkey-object = { path = "../object", version = "0.14.0" }
+monkey-parser = { path = "../parser", version = "0.14.0" }
+
+[dev-dependencies]
+insta = "1.42.2"

--- a/gc/README.md
+++ b/gc/README.md
@@ -1,0 +1,87 @@
+# monkey-gc
+
+QuickJS-style GC runtime for the Monkey programming language.
+
+This crate is a GC-backed runtime that runs the same bytecode produced by
+`monkey-compiler`, but stores Monkey runtime values in a `GcHeap` instead of
+using `Rc<Object>` directly. It combines reference counting with a three-phase
+cycle collector so cyclic object graphs can be reclaimed.
+
+For the full design notes, see [`docs/gc.md`](../docs/gc.md).
+
+## Usage
+
+Parse, compile, and execute Monkey source:
+
+```rust
+let result = gc::eval_source("let add = fn(a, b) { a + b }; add(1, 2);").unwrap();
+assert_eq!(result, object::Object::Integer(3));
+```
+
+Run an already parsed program:
+
+```rust
+let program = parser::parse("[1, 2, 3][1]").unwrap();
+let result = gc::eval(&program).unwrap();
+assert_eq!(result, object::Object::Integer(2));
+```
+
+Use the lower-level VM when you need direct access to the heap:
+
+```rust
+let program = parser::parse("let double = fn(x) { x * 2 }; double(21)").unwrap();
+let bytecode = gc::compile(&program).unwrap();
+let mut vm = gc::GcVM::new(bytecode);
+
+vm.run();
+vm.heap_mut().run_gc();
+
+let result = vm.export_last_result().expect("no result on stack");
+assert_eq!(result, object::Object::Integer(42));
+```
+
+## Public API
+
+- `eval_source` parses, compiles, and runs Monkey source.
+- `eval` runs a parsed AST node through the bytecode compiler and GC VM.
+- `compile` reuses `monkey-compiler` to produce bytecode.
+- `GcVM` executes Monkey bytecode with GC-managed values.
+- `GcHeap` exposes allocation, `dup`/`free`, GC triggering, and heap inspection.
+- `Value`, `GcClosure`, `import_object`, and `export_object` bridge between
+  GC-managed values and `object::Object`.
+
+## Runtime Model
+
+`monkey-gc` is designed as a parallel runtime for the existing pipeline:
+
+```text
+lexer -> parser -> compiler -> gc::GcVM
+```
+
+The crate does not replace the default `compiler::VM`, `wasm`, or playground
+runtime. Instead, it reuses the same `Bytecode` and opcode definitions while
+testing an alternate heap implementation.
+
+## Modules
+
+- `heap.rs` provides the high-level `GcHeap` and opaque `GcRef` handle.
+- `runtime.rs` implements reference counting and three-phase cycle collection.
+- `header.rs`, `list.rs`, and `malloc.rs` hold GC object metadata and allocator
+  accounting.
+- `value.rs` defines GC-managed Monkey values plus import/export helpers.
+- `frame.rs` and `vm.rs` implement the bytecode VM runtime.
+
+## Development
+
+Run the crate tests from the workspace root:
+
+```sh
+cargo test -p monkey-gc
+```
+
+Run the whole Rust workspace when changing shared compiler, object, or parser
+behavior:
+
+```sh
+cargo test
+```

--- a/gc/frame.rs
+++ b/gc/frame.rs
@@ -3,6 +3,8 @@ use compiler::op_code::Instructions;
 
 #[derive(Debug, Clone)]
 pub struct Frame {
+    /// Borrowed closure refs. Frames do not own or free these handles; the
+    /// callee stack slot, main function root, or closure object keeps them live.
     pub cl: GcClosure,
     pub ip: i32,
     pub base_pointer: usize,

--- a/gc/frame.rs
+++ b/gc/frame.rs
@@ -1,0 +1,27 @@
+use crate::value::GcClosure;
+use compiler::op_code::Instructions;
+
+#[derive(Debug, Clone)]
+pub struct Frame {
+    pub cl: GcClosure,
+    pub ip: i32,
+    pub base_pointer: usize,
+    pub instructions: Vec<u8>,
+}
+
+impl Frame {
+    pub fn new(closure: GcClosure, instructions: Vec<u8>, base_pointer: usize) -> Self {
+        Frame {
+            cl: closure,
+            ip: -1,
+            base_pointer,
+            instructions,
+        }
+    }
+
+    pub fn instruction_view(&self) -> Instructions {
+        Instructions {
+            data: self.instructions.clone(),
+        }
+    }
+}

--- a/gc/gc-report.md
+++ b/gc/gc-report.md
@@ -1,0 +1,1674 @@
+# 给 Monkey VM 加上 GC
+
+## 行文原则
+
+这份报告是一份**概念先行、测试驱动**的实现教程。假设你会 Rust，但没有 GC 背景。读的时候按下面几条预期来：
+
+1. **先讲概念，再写代码。** 每一章开头先用对象图和日常类比把依赖的概念讲清楚，再贴测试、再落到实现。不会在第 6 章才第一次解释"根"是什么。
+2. **测试即规格。** 正文里的测试都来自 `gc/` crate 的真实代码。每个测试都按 Given / When / Then 逐行解读：它在钉什么行为、为什么这个断言非有不可。
+3. **手工推演。** 复杂算法配 ref_count 逐步变化表或对象图快照，拿纸笔能跟着算——证明"不是碰巧对的"。
+4. **语言平实，偶尔口语化。** 读起来像有经验的工程师带你做项目，会有"别问我们怎么知道的""现在还不值得"这类判断和妥协。
+5. **聚焦最小可用系统。** 只做到让 `monkey-gc` 跑起来、测得过为止。没做的会在后面坦白。
+
+算法参考 QuickJS（`JS_RunGC`、`gc_decref`、`gc_scan`、`gc_free_cycles`），函数名刻意保持一致，方便对照原版源码。
+
+---
+
+## 0. 导读
+
+### 0.1 这份报告讲什么
+
+我们的 Monkey 字节码 VM 一直用 `Rc<Object>` 管理堆对象。它工作得不错——直到对象图里出现循环。两个对象互相持有，引用计数永远掉不到 0，内存就这么漏了。
+
+这份报告记录我们怎么在 `gc/` crate 里从零搭一套能回收循环的 GC，并把同一套字节码跑在一个新的 `GcVM` 上。
+
+### 0.2 读者假设
+
+- 会 Rust：看得懂 `Vec`、`trait`、借用检查。
+- **没有 GC 背景**：不知道 mark-sweep、trial deletion 也没关系，第 1 章会把后文全部概念一次讲透。
+- 愿意跟着测试跑：边读边执行 `cargo test -p monkey-gc` 效果最好。
+
+### 0.3 全文地图
+
+报告分四层，从抽象概念一路接到可运行的 Monkey 程序：
+
+```mermaid
+flowchart TB
+    subgraph concept [概念层]
+        Ch1[第1章 概念地基]
+    end
+    subgraph heap [堆层]
+        Ch2[第2章 最小堆]
+        Ch3[第3章 dup]
+        Ch4[第4章 trace]
+        Ch5[第5章 循环红灯]
+        Ch6[第6章 三阶段回收]
+        Ch7[第7章 活着的环]
+        Ch8[第8章 触发策略]
+    end
+    subgraph value [值层]
+        Ch9[第9章 Monkey Value]
+    end
+    subgraph vm [VM层]
+        Ch10[第10章 GcVM]
+    end
+  Ch1 --> Ch2 --> Ch3 --> Ch4 --> Ch5 --> Ch6 --> Ch7 --> Ch8 --> Ch9 --> Ch10
+```
+
+| 层 | 章节 | 测试文件 | 测试数 |
+|----|------|----------|--------|
+| 堆 | 第 2–8 章 | `gc/gc_test.rs` | 17 |
+| 值 | 第 9 章 | `gc/value_test.rs` | 9 |
+| VM | 第 10 章 | `gc/vm_test.rs` | 16 |
+| **合计** | | | **42** |
+
+### 0.4 怎么跟读
+
+1. 克隆或打开本仓库，进入根目录。
+2. 每读完一章，跑对应测试：
+
+```bash
+# 全部
+cargo test -p monkey-gc
+
+# 只看堆层
+cargo test -p monkey-gc -- gc_test
+
+# 只看值层
+cargo test -p monkey-gc -- value_test
+
+# 只看 VM
+cargo test -p monkey-gc -- vm_test
+```
+
+3. 每章末尾有 **本章测试** 列表，可以按名过滤，例如：
+
+```bash
+cargo test -p monkey-gc collects_simple_cycle
+```
+
+### 0.5 每章固定四拍
+
+后文每一章（第 2 章起）尽量按同一节奏写：
+
+| 节拍 | 内容 |
+|------|------|
+| **概念** | 这一章依赖什么、为什么需要它（配图，暂不讲代码） |
+| **测试即规格** | 贴真实测试，Given / When / Then 逐行解读 |
+| **实现** | 最小实现让测试变绿，只解释非显然的设计 |
+| **推演验证** | 手工走一遍 ref_count 或对象图，确认不是碰巧 |
+
+---
+
+## 1. 概念地基
+
+本章**不写任何项目代码**。把后文反复出现的概念一次讲透。读不懂后面某节时，回来查这一章或文末术语表。
+
+### 1.1 堆、对象、引用、对象图
+
+程序运行时，有些数据活得比单个函数调用更长：数组、闭包、全局变量里的值。这类数据放在**堆**上；栈和寄存器里放的是**引用**——"去堆的第 N 号柜子拿东西"的凭据，不是柜子本身。
+
+多个引用可以指向同一个堆对象。如果对象 A 的字段里存着指向 B 的引用，我们就说有一条**边** A → B。所有堆对象和它们之间的边合在一起，叫**对象图**：
+
+```mermaid
+flowchart LR
+    root[根: globals x] --> A[array_A]
+    A --> B[array_B]
+    B --> C[integer_1]
+```
+
+- **节点**：堆上的对象（数组、闭包、整数包装等）。
+- **边**：一个对象持有另一个对象的引用（数组的元素、闭包的捕获等）。
+- **引用 / 句柄**：VM 栈槽、全局槽、局部变量里保存的"指向堆对象的凭据"。
+
+后文里 `GcRef` 就是这种凭据，本质是一个整数下标，不是裸指针。
+
+### 1.2 根（root）
+
+**根**是对象图在堆**外面**的入口：程序还能直接摸到的引用，不经过其他堆对象。
+
+在 Monkey VM 里，根主要包括：
+
+| 根来源 | 例子 |
+|--------|------|
+| 全局变量槽 | `globals[i]` |
+| 操作数栈槽 | `stack[0..sp)` |
+| 常量表 | 编译期字面量 |
+| 调用过程中的临时持有 | `last_popped` 等 |
+
+测试里的 `TestHeap` 没有真正的 VM，**根**就是测试代码手里的 `GcRef`：你 `alloc()` 拿到的那个句柄，以及你显式 `dup()` 出来的副本。
+
+根的重要性：**只有从根出发沿边能走到的对象才是活的**；走不到的，无论内部结构多复杂，都是垃圾。
+
+```mermaid
+flowchart LR
+    subgraph roots [根集合]
+        R1[测试里的 GcRef]
+        R2[VM 栈槽]
+        R3[全局变量]
+    end
+    R1 --> O1
+    R2 --> O2
+    R3 --> O3
+    O1 --> O4
+```
+
+### 1.3 可达性与垃圾
+
+**可达**：存在一条从某个根出发、沿有向边行走的路径，能到达该对象。
+
+**垃圾**：堆上还占着槽位，但从**所有**根都不可达。
+
+这是 GC 唯一的判据——不是"有没有被引用"（环里互相引用也算被引用），而是**能不能从程序还活着的入口走到**。
+
+| 情形 | 可达？ | 是垃圾？ |
+|------|--------|----------|
+| 全局变量指着它 | 是 | 否 |
+| 只有栈上的临时值指着它 | 是 | 否 |
+| 两个对象互相指，外部谁都没有 | 否 | **是** |
+| 链式结构，头被 drop 了 | 否 | **是** |
+
+### 1.4 引用计数：局部视角的近似
+
+**引用计数**给每个堆对象维护一个整数 `ref_count`："当前有多少个持有者指着我"。
+
+- 多一个持有者 → `dup`，计数 +1
+- 少一个持有者 → `free`，计数 −1
+- 计数归零 → 立刻释放
+
+优点：**无环时**对象在最后一个持有者放手的瞬间就死了，不用等全局 GC，延迟低。
+
+缺点：计数是**局部**信息——对象只知道"有几个人指着我"，不知道"指着我的那些人自己是不是垃圾"。
+
+#### 何时计数 ≡ 可达？
+
+在**无环**对象图上，如果每个 `ref_count` 的 +1 都对应一条真实的边或根持有，且每个 −1 都对应放弃持有，那么：
+
+- `ref_count > 0` ⟺ 至少还有一个根或堆内边指着它 ⟺ 它还活着
+
+这时引用计数 alone 就够用了。
+
+#### 何时计数 ≠ 可达？
+
+**循环引用**是唯一常见的不等价情形：
+
+```mermaid
+flowchart LR
+    A[node_A] --> B[node_B]
+    B --> A
+```
+
+外部根已经放手，但 A.rc = 1（来自 B），B.rc = 1（来自 A）。从可达性看两个都是垃圾；从计数看两个都"还有人要"。
+
+#### Rc 循环泄漏示例
+
+Rust 标准库的 `Rc` 就是引用计数，循环一样漏：
+
+```rust
+use std::cell::RefCell;
+use std::rc::Rc;
+
+struct Node {
+    next: RefCell<Option<Rc<Node>>>,
+}
+
+fn main() {
+    let a = Rc::new(Node { next: RefCell::new(None) });
+    let b = Rc::new(Node { next: RefCell::new(None) });
+    *a.next.borrow_mut() = Some(b.clone());
+    *b.next.borrow_mut() = Some(a.clone());
+    // 离开作用域时 a、b 的 rc 都是 2，永远不会归零
+}
+```
+
+我们的 Monkey VM 用 `Rc<Object>` 时，闭包互相捕获、可变数组互相引用，迟早会遇到这张图。
+
+### 1.5 两大流派：tracing vs 引用计数 + 环收集
+
+| 流派 | 思路 | 代表 |
+|------|------|------|
+| **Tracing** | 从根出发标记所有可达对象，没标记的是垃圾 | mark-sweep、分代 GC |
+| **Refcount + cycle collector** | 平时靠计数即时释放；定期用额外算法拆掉环 | CP Python、QuickJS |
+
+**Mark-sweep**：要维护完整的根集合，扫一遍栈、全局表、寄存器，再 DFS/BFS 标记。实现干净，但要么 STW，要么要写屏障配合增量标记。
+
+**QuickJS 路线**（我们选的）：平时仍是引用计数；环由**三阶段 trial deletion** 回收。核心观察是——
+
+> 对象的 `ref_count` = 根持有它的次数 + 堆内其他对象指向它的边数
+
+因此：**把所有堆内边从计数里减掉之后，剩下的计数恰好等于根持有它的次数**。不必枚举根，就能区分"被根拽着"和"只在环里互相撑着"。
+
+我们选这条路的理由：
+
+1. 和现有"每条边手动 dup/free"的纪律兼容，无环路径零 GC 开销。
+2. 不必在 VM 里维护"根扫描器"——trial deletion 从堆内对象出发反推根的影响。
+3. QuickJS 已验证工程可行，函数名一一对应，方便对照源码。
+
+### 1.6 后文路线图（概念 → 章节）
+
+| 概念 | 首次深入 | 测试锚点 |
+|------|----------|----------|
+| 句柄 vs 指针 | 第 2 章 | `refcount_frees_immediately_without_gc` |
+| dup / free 纪律 | 第 3 章 | `dup_extends_lifetime` |
+| trace / 级联释放 | 第 4 章 | `acyclic_holder_extends_child_lifetime` |
+| 循环泄漏 | 第 5 章 | `collects_simple_cycle`（先红后绿） |
+| trial deletion 三阶段 | 第 6 章 | `mark_func_decref_zeros_isolated_cycle` 等 |
+| 有根的环必须活 | 第 7 章 | `cycle_with_external_root_survives` |
+| 自动触发 | 第 8 章 | `trigger_gc_on_threshold` |
+| Monkey 值 / 桥接 | 第 9 章 | `value_cycle_collected_by_gc` |
+| VM 根集合 | 第 10 章 | `builtin_call_releases_callee_args_and_stack_temporaries` |
+
+### 1.7 术语表
+
+| 术语 | 含义 |
+|------|------|
+| **根（root）** | 堆外可直接访问的引用：栈槽、全局变量、测试代码手里的 `GcRef` 等 |
+| **可达（reachable）** | 从某个根沿边能走到的对象 |
+| **引用计数（refcount）** | 每个对象的持有者数量；`dup` +1，`free` −1 |
+| **trace** | 对象报告自己引用的所有子对象（出边） |
+| **trial deletion** | 三阶段 GC 的第一阶段：试探性减掉所有堆内边 |
+| **mark（header 字段）** | 阶段内临时标记："我的出边已经减过了"，不是永久 mark bit |
+| **侵入式链表** | `list_prev` / `list_next` 嵌在对象 header 里，GC 不再额外分配链表节点 |
+| **gc_obj_list** | 存活 GC 对象链表 |
+| **tmp_obj_list** | trial deletion 后计数归零的**嫌疑人**名单（尚未释放） |
+| **gc_zero_ref_count_list** | 延迟释放队列（级联释放、拆环时的僵尸槽） |
+| **僵尸（free_mark）** | 逻辑上已 `on_free`，但槽位因环内边未拆完而暂时保留 |
+| **写屏障（write barrier）** | 编译器/运行时在引用写入时自动维护计数的机制；**我们没做** |
+
+---
+
+## 2. 最小的堆：分配和释放
+
+### 2.1 概念：句柄 vs 指针
+
+堆对象可能搬家、可能复用槽位。如果到处传裸指针，释放后容易**悬垂指针**——指着一块已经分配给别人的内存。
+
+常见做法是发**句柄**（不透明 ID）：调用者只拿"第 7 号槽位"这种凭据，通过运行时查表访问本体。完整的生产实现通常会给句柄带上 generation，槽位复用后旧句柄也能被识别出来。
+
+我们的 `GcRef(GcId)` 是最小版下标句柄。对象表是 `Vec<Option<GcObjectEntry>>`：释放 = 槽位置 `None` + 下标扔进 `free_slots` 复用。因此旧句柄只在槽位**尚未复用**时查到 `None`；一旦同一个下标被新对象复用，旧句柄可能误命中新对象。本项目不提供 use-after-free 硬防御，正确性靠 `dup` / `free` 所有权纪律：某个持有者 `free` 之后，不能再使用那份句柄。若要硬性防御，应把 `GcRef` 扩成 `(slot, generation)`。
+
+```mermaid
+flowchart LR
+    subgraph handles [句柄]
+        H0["GcRef(0)"]
+        H1["GcRef(1)"]
+    end
+    subgraph table [对象表 Vec]
+        S0["slot 0: Some(obj_A)"]
+        S1["slot 1: None 已释放（复用前）"]
+        S2["slot 2: Some(obj_C)"]
+    end
+    H0 --> S0
+    H1 -.->|复用前查不到；复用后可能命中新对象| S1
+```
+
+### 2.2 测试即规格
+
+```rust
+// gc/gc_test.rs
+#[test]
+fn refcount_frees_immediately_without_gc() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    assert!(heap.gc.exists(a));
+    heap.gc.free(a);
+    assert!(!heap.gc.exists(a));
+}
+```
+
+| 阶段 | 代码 | 含义 |
+|------|------|------|
+| **Given** | `TestHeap::new()` | 空堆 |
+| **When** | `alloc()` | 分配一个对象，调用者拿到句柄 `a`，ref_count 从 1 开始 |
+| **Then** | `exists(a)` 为 true | 对象在表里 |
+| **When** | `free(a)` | 调用者放弃唯一持有，ref_count → 0 |
+| **Then** | `exists(a)` 为 false | 槽位已归还，无环场景下**不需要**跑 GC |
+
+这个测试钉住的最小 API：`alloc` / `free` / `exists`。
+
+**`on_free_called_when_collected`** 钉住释放路径会跑 finalizer：
+
+```rust
+#[test]
+fn on_free_called_when_collected() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    assert!(!heap.freed.get());
+    heap.gc.free(a);
+    assert!(heap.freed.get());
+    assert!(!heap.gc.exists(a));
+}
+```
+
+**`malloc_state_tracks_allocations`** 钉住分配统计会被记账（第 8 章触发阈值要用）：
+
+```rust
+#[test]
+fn malloc_state_tracks_allocations() {
+    let mut heap = TestHeap::new();
+    let before = heap.gc.malloc_state().malloc_count;
+    let a = heap.alloc();
+    assert!(heap.gc.malloc_state().malloc_count > before);
+    heap.gc.free(a);
+}
+```
+
+### 2.3 实现
+
+句柄：
+
+```rust
+// gc/heap.rs
+pub struct GcRef(pub GcId);
+pub type GcId = usize;
+```
+
+对象表（简化）：
+
+```rust
+// gc/runtime.rs
+pub struct GcRuntime {
+    objects: Vec<Option<GcObjectEntry>>,
+    free_slots: Vec<GcId>,
+    // ...
+}
+
+struct GcObjectEntry {
+    header: GcObjectHeader,
+    object: Option<Box<dyn GcObject>>,
+}
+```
+
+header 此刻只需要 `ref_count`：
+
+```rust
+// gc/header.rs
+pub struct GcObjectHeader {
+    pub ref_count: i32,
+    // 后面会加 list_prev, mark, free_mark ...
+}
+```
+
+分配与释放：
+
+```rust
+pub fn add_gc_object(&mut self, object: Box<dyn GcObject>, gc_obj_type: GcObjectType) -> GcId {
+    let id = self.alloc_slot(GcObjectEntry {
+        header: GcObjectHeader::new(gc_obj_type, 1), // 调用者是第一个持有者
+        object: Some(object),
+    });
+    self.list_push_back(GcListKind::GcObj, id);
+    id
+}
+
+pub fn free_gc(&mut self, id: GcId) {
+    // ref_count -= 1；归零则进入级联释放（第 4 章）
+}
+```
+
+### 2.4 推演验证
+
+`refcount_frees_immediately_without_gc` 的 ref_count 轨迹：
+
+| 步骤 | 操作 | a.ref_count | exists(a) |
+|------|------|-------------|-----------|
+| 1 | `alloc()` | 1（测试代码持有） | true |
+| 2 | `free(a)` | 0 → 释放 | false |
+
+**本章测试**（`gc/gc_test.rs`）：`refcount_frees_immediately_without_gc`，`on_free_called_when_collected`，`malloc_state_tracks_allocations`
+
+---
+
+## 3. 第二个持有者：dup 与所有权纪律
+
+### 3.1 概念：每个 +1 都要能指名道姓
+
+`ref_count` 不是抽象数字——**每一个 +1 都必须对应一个真实持有者**，每一个 −1 都必须对应某个持有者放手。
+
+| 操作 | 谁多了/少了持有 |
+|------|-----------------|
+| `alloc()` | 返回句柄给调用者，计数从 1 开始 |
+| `dup(id)` | 调用者多持有一份，计数 +1 |
+| `free(id)` | 调用者少持有一份，计数 −1 |
+
+整个系统只有两条纪律（后文 VM 每条指令都逃不掉）：
+
+- **多一个持有者** → `dup`
+- **少一个持有者** → `free`
+
+没有写屏障，没有编译器帮忙，全靠每个调用点自觉。脆，但可测试。
+
+#### 持有者清单示例
+
+对象 `x`，`ref_count = 3` 时，合法的持有者清单长这样：
+
+| 持有者 | 来源 |
+|--------|------|
+| 1 | 测试变量 `let a = heap.alloc()` |
+| 1 | `let b = heap.dup(a)` |
+| 1 | 另一个对象 `holder` 的出边（`link(holder, x)` 时 dup 过） |
+
+若少 `dup` 或多 `free`，计数偏低，可能提前释放；若多 `dup` 或少 `free`，计数偏高，造成泄漏。
+
+### 3.2 测试即规格
+
+```rust
+#[test]
+fn dup_extends_lifetime() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    let _b = heap.gc.dup(a);   // 第二个持有者（_b 代表"某处多了一份持有"）
+    heap.gc.free(a);
+    assert!(heap.gc.exists(a));    // 还有人持有，不能死
+    heap.gc.free(a);
+    assert!(!heap.gc.exists(a));   // 两次 free = 两个持有者都放手了
+}
+```
+
+| 阶段 | 含义 |
+|------|------|
+| **Given** | `a` 独占对象，rc = 1 |
+| **When** | `dup(a)` | 某处多持有一份，rc = 2 |
+| **When** | 第一次 `free(a)` | 一个持有者放手，rc = 1 |
+| **Then** | 仍 `exists` | |
+| **When** | 第二次 `free(a)` | 最后一个持有者放手，rc = 0 |
+| **Then** | 不再 `exists` | |
+
+注意：`dup` 返回同一个 `GcId`，不是新对象。QuickJS 里叫 `js_dup` / `JS_FreeValueRT`，我们沿用 `dup` / `free`。
+
+### 3.3 实现
+
+```rust
+pub fn dup_gc(&mut self, id: GcId) -> GcId {
+    self.header_mut(id).ref_count += 1;
+    id
+}
+```
+
+### 3.4 推演验证
+
+| 步骤 | 操作 | a.ref_count | 持有者 |
+|------|------|-------------|--------|
+| 1 | `alloc()` | 1 | 测试代码 |
+| 2 | `dup(a)` | 2 | 测试代码 + dup 代表的那份 |
+| 3 | `free(a)` | 1 | dup 代表的那份 |
+| 4 | `free(a)` | 0 | 无 → 释放 |
+
+#### 持有者清单练手
+
+`holder` 通过 `link(holder, child)` 持 `child` 时：
+
+| 对象 | ref_count | 持有者清单 |
+|------|-----------|------------|
+| child | 2 | ① 测试变量 `child` ② `holder` 的出边 |
+| holder | 1 | ① 测试变量 `holder` |
+
+`free(child)` 后 child.rc = 1，只剩 holder 边——与第 4 章测试衔接。
+
+**本章测试**（`gc/gc_test.rs`）：`dup_extends_lifetime`
+
+---
+
+## 4. 对象引用对象：trace 与级联释放
+
+### 4.1 概念：堆不该知道对象内部长什么样
+
+数组的元素、哈希的值、闭包的捕获——每种对象内部布局不同。如果 `GcRuntime::free` 里写满 `match` 分支去翻字段，每加一种 Monkey 类型都要改运行时。
+
+**控制反转**：对象自己通过 `trace` 报告出边；堆只负责沿边 `dup`/`free` 和 GC 遍历。这是全文最重要的 trait 约定。
+
+#### 无环世界的承诺
+
+只要图无环，最后一个根或堆边放手后，整条子树会通过级联 `free` 在**一次 GC 都不跑**的情况下清空。第 5 章之前的世界完全靠引用计数。
+
+#### 深链与栈溢出
+
+若 `free` 归零时**同步递归**释放子节点，一万层链表会把 Rust 调用栈撑爆：
+
+```text
+free(链头) → free(子) → free(孙) → ... 深度 = 链长
+```
+
+解法：归零对象先挂到 `gc_zero_ref_count_list`，`free_zero_refcount` 用 `while` 循环平铺消化——深度从 O(链长) 变成 O(1) 调用栈。
+
+#### 侵入式链表
+
+GC 运行时不应再分配 `Vec` 或链表节点。`list_prev` / `list_next` 直接住在 header 里——QuickJS `list.h` 同款。
+
+```mermaid
+flowchart LR
+    subgraph gc_obj_list
+        N1["obj id=3"] --> N2["obj id=7"] --> N3["obj id=1"]
+    end
+    N1 --- H1["header: prev=None, next=7"]
+    N2 --- H2["header: prev=3, next=1"]
+```
+
+### 4.2 测试脚手架：TestHeap 与 TestNode
+
+正文测试不是直接操作裸 `GcRuntime`，而是包了一层 `TestHeap`。读 `gc/gc_test.rs` 时值得先看懂它：
+
+```rust
+struct TestNode {
+    id: Rc<Cell<Option<usize>>>,           // 自己的 GcId，trace 时查边表
+    edges: EdgeMap,                        // Rc<RefCell<HashMap<GcId, Vec<GcRef>>>>
+    freed: Rc<Cell<bool>>,                 // on_free 有没有被调用
+    freed_ref_counts: Rc<RefCell<HashMap<usize, i32>>>,
+}
+
+impl GcObject for TestNode {
+    fn trace(&self, visit: &mut dyn FnMut(GcId)) {
+        // 从 edges[id] 取出子节点，逐个 visit
+    }
+}
+```
+
+| 方法 | 行为 |
+|------|------|
+| `alloc()` | 分配 `TestNode`，在 `edges` 里建空邻接表 |
+| `link(from, to)` | `dup(to)` + 在 `edges[from]` 里加一条边 |
+| `make_cycle(n)` | n 个节点首尾相连（第 5 章） |
+| `drop_external_refs(&[ids])` | 对测试手里的每个句柄 `free` 一次 |
+
+**边在测试自己的 `EdgeMap` 里，不在 `GcRuntime` 里**——这样我们能随意搭图，不必等 Monkey `Value` 写好。
+
+### 4.3 测试即规格
+
+**`acyclic_holder_extends_child_lifetime`** — 父对象活着，子对象不能死：
+
+```rust
+#[test]
+fn acyclic_holder_extends_child_lifetime() {
+    let mut heap = TestHeap::new();
+    let child = heap.alloc();
+    let holder = heap.alloc();
+    heap.link(holder, child);      // holder 持有 child（内部 dup 了 child）
+
+    heap.gc.free(child);           // 测试代码放弃对 child 的直接引用
+    assert!(heap.gc.exists(child)); // holder 的边还在
+
+    heap.gc.free(holder);
+    assert!(!heap.gc.exists(child)); // 级联释放
+}
+```
+
+**`acyclic_graph_freed_without_gc`** — 整棵无环树外部引用全 drop 后，不用 `run_gc`：
+
+```rust
+#[test]
+fn acyclic_graph_freed_without_gc() {
+    let mut heap = TestHeap::new();
+    let c = heap.alloc();
+    let b = heap.alloc();
+    heap.link(b, c);
+    let a = heap.alloc();
+    heap.link(a, b);
+
+    heap.drop_external_refs(&[a, b, c]);
+    assert!(!heap.gc.exists(a));
+    assert!(!heap.gc.exists(b));
+    assert!(!heap.gc.exists(c));
+}
+```
+
+对象图：
+
+```mermaid
+flowchart LR
+    ext[外部 ref 已 drop] -.-> a
+    a --> b --> c
+```
+
+### 4.4 实现
+
+```rust
+pub trait GcObject: Any {
+    fn trace(&self, visit: &mut dyn FnMut(GcId));
+    fn on_free(&mut self, _rt: &mut GcRuntime) {}
+}
+```
+
+释放路径（简化）：
+
+```rust
+fn free_heap_object(&mut self, id: GcId) {
+    self.header_mut(id).free_mark = true;
+    let mut object = /* take from slot */;
+    object.trace(&mut |child| self.free_gc(child));
+    object.on_free(self);
+    drop(object);
+    // 归零则 free_slot；RemoveCycles 阶段可能延迟（第 6 章）
+}
+
+fn free_zero_refcount(&mut self) {
+    self.gc_phase = GcPhase::Decref;
+    while let Some(id) = self.gc_zero_ref_count_list.head {
+        self.free_gc_object(id);
+    }
+    self.gc_phase = GcPhase::None;
+}
+```
+
+`gc_phase` 此刻像多余牌子，第 6 章拆环时会救命。
+
+### 4.5 推演验证：`acyclic_holder_extends_child_lifetime`
+
+| 步骤 | 操作 | child.rc | holder.rc | 说明 |
+|------|------|----------|-----------|------|
+| 1 | `alloc` child | 1 | — | 测试持有 child |
+| 2 | `alloc` holder | — | 1 | 测试持有 holder |
+| 3 | `link(holder, child)` | 2 | 1 | holder 边 dup child |
+| 4 | `free(child)` | 1 | 1 | 测试放手，holder 还在 |
+| 5 | `free(holder)` | 0 | 0 | holder 死 → trace → free child → 子死 |
+
+**本章测试**（`gc/gc_test.rs`）：`acyclic_holder_extends_child_lifetime`，`acyclic_graph_freed_without_gc`
+
+---
+
+## 5. 红灯：循环引用
+
+### 5.1 概念：引用计数的天花板
+
+第 1 章说过：环上每个对象的计数都 ≥ 1（来自环内邻居），但外部根已经没了——**可达性说它们是垃圾，计数说它们还活着**。
+
+要判断"持有者是不是垃圾"，必须有人看**全局**对象图。这就是为什么要写 `run_gc`。
+
+### 5.2 测试即规格
+
+```rust
+fn make_cycle(&mut self, size: usize) -> Vec<GcRef> {
+    let nodes: Vec<GcRef> = (0..size).map(|_| self.alloc()).collect();
+    for i in 0..size {
+        self.link(nodes[i], nodes[(i + 1) % size]);
+    }
+    nodes
+}
+
+#[test]
+fn collects_simple_cycle() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+    heap.drop_external_refs(&nodes);
+
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+```
+
+| 阶段 | 含义 |
+|------|------|
+| **Given** | 两节点环，测试手里各有一份外部 ref |
+| **When** | `drop_external_refs` | 外部根全部放手 |
+| **When** | `run_gc()` | 此时还没有实现会失败——故意写的红灯 |
+| **Then** | 两个节点都不存在 | 环被识别为不可达垃圾 |
+
+两节点环对象图：
+
+```mermaid
+flowchart LR
+    N0[node0] --> N1[node1]
+    N1 --> N0
+```
+
+### 5.3 推演验证：没有 GC 时会发生什么
+
+| 步骤 | 操作 | node0.rc | node1.rc | 备注 |
+|------|------|----------|----------|------|
+| 1 | 各 `alloc` | 1 | 1 | 外部各 1 |
+| 2 | `link(0→1)`, `link(1→0)` | 2 | 2 | 各多环内 1 |
+| 3 | `drop_external_refs` | 1 | 1 | 只剩环内边 |
+| 4 | 尝试 `free` | 不变 | 不变 | rc > 0，无法释放 |
+
+**泄漏确认**：两个对象永远挂在 `gc_obj_list` 里。这就是 `Rc` 的洞，现在在我们自己的堆里重现了。
+
+**本章测试**（`gc/gc_test.rs`）：`collects_simple_cycle`（第 6 章实现后变绿）
+
+---
+
+## 6. 三阶段回收：先破坏，再修复，再收尸
+
+### 6.0 概念：核心等式
+
+对任意对象，在稳态下（没有正在进行的 dup/free/GC 中间态）：
+
+```text
+ref_count = 根引用数 + 堆内入边数
+```
+
+其中**堆内入边**= 其他堆对象通过 `trace` 报出来的、指向它的边数。根引用 = 栈槽、全局变量、测试代码手里的 `GcRef` 等堆外持有。
+
+**trial deletion（阶段 1）** 遍历每个堆对象，对它的每条出边执行"子对象 rc −= 1"。等价于把**所有堆内入边**从计数里摘掉。减完之后：
+
+```text
+剩余 ref_count = 根引用数
+```
+
+这是全文最重要的等式。下面用三个具体图各验证一遍。
+
+#### 验证 1：纯 2 环，无根
+
+```mermaid
+flowchart LR
+    A[node0 rc=1] --> B[node1 rc=1]
+    B --> A
+```
+
+堆内入边：node0 有 1 条（来自 node1），node1 有 1 条（来自 node0）。外部根 = 0。
+
+| 对象 | 初始 rc | 堆内入边 | 阶段 1 后 rc = 根引用数 |
+|------|---------|----------|---------------------------|
+| node0 | 1 | 1 | 0 |
+| node1 | 1 | 1 | 0 |
+
+两人都是嫌疑人 → 阶段 2 没人救 → 阶段 3 收尸。
+
+#### 验证 2：链式嵌套，只有根持头
+
+```mermaid
+flowchart LR
+    R[根 dup root] --> Root[root_array]
+    Root --> Mid[middle_array]
+    Mid --> Leaf[leaf_array]
+```
+
+| 对象 | 初始 rc | 堆内入边 | 阶段 1 后 rc |
+|------|---------|----------|--------------|
+| root | 1 | 0 | 1（根持有） |
+| middle | 1 | 1 | 0（误伤） |
+| leaf | 1 | 1 | 0（误伤） |
+
+middle、leaf 计数全来自堆内边，减完变 0——但它们从 root 可达，是活的。阶段 2 从 root 链式平反。
+
+#### 验证 3：环上一点有根
+
+```mermaid
+flowchart LR
+    Ext[外部根] --> N0[node0]
+    N0 --> N1[node1]
+    N1 --> N0
+```
+
+| 对象 | 初始 rc | 根引用 | 堆内入边 | 阶段 1 后 rc |
+|------|---------|--------|----------|--------------|
+| node0 | 2 | 1 | 1 | 1 |
+| node1 | 1 | 0 | 1 | 0 → tmp |
+
+node0 剩余 1 正是根那份；node1 进嫌疑人名单，阶段 2 从 node0 救回。
+
+#### 三阶段骨架
+
+```rust
+pub fn run_gc(&mut self) {
+    self.gc_decref();       // 阶段 1：试探性减掉堆内边
+    self.gc_scan();         // 阶段 2：活对象平反误伤者
+    self.gc_free_cycles();  // 阶段 3：名单上剩的才是真垃圾
+}
+```
+
+```mermaid
+flowchart TB
+    start[run_gc] --> p1[gc_decref]
+    p1 --> p2[gc_scan]
+    p2 --> p3[gc_free_cycles]
+    p1 --> L1["对象在 gc_obj_list / tmp_obj_list 间迁移"]
+    p2 --> L2["误伤者回到 gc_obj_list 尾部"]
+    p3 --> L3["tmp 剩余者被 free_heap_object"]
+```
+
+### 6.1 阶段 1：gc_decref
+
+#### 测试即规格
+
+```rust
+#[test]
+fn mark_func_decref_zeros_isolated_cycle() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+    heap.drop_external_refs(&nodes);
+
+    for &id in &nodes {
+        heap.gc.mark_children(id, MarkFunc::Decref);
+        heap.gc.header_mut(id).mark = 1;
+    }
+
+    assert_eq!(heap.gc.ref_count(nodes[0]), 0);
+    assert_eq!(heap.gc.ref_count(nodes[1]), 0);
+}
+```
+
+单独测阶段 1 的纯环：外部根已 drop，减完堆内边后两个节点都应归零。
+
+#### 实现要点
+
+```rust
+fn gc_decref(&mut self) {
+    let mut current = self.gc_obj_list.head;
+    while let Some(id) = current {
+        let next = self.header(id).list_next;
+        self.mark_children(id, MarkFunc::Decref);
+        self.header_mut(id).mark = 1;
+        if self.header(id).ref_count == 0 {
+            self.list_move(GcListKind::GcObj, GcListKind::Tmp, id);
+        }
+        current = next;
+    }
+}
+
+fn gc_decref_child(&mut self, id: GcId) {
+    self.header_mut(id).ref_count -= 1;
+    if self.header(id).ref_count == 0 && self.header(id).mark == 1 {
+        self.list_move(GcListKind::GcObj, GcListKind::Tmp, id);
+    }
+}
+```
+
+#### `mark` 字段：每条边恰好减一次
+
+`mark = 1` 表示"这个对象的出边已经处理过"。子对象归零时，**只有它自己的出边也减完了**（`mark == 1`）才立刻进 `tmp_obj_list`；否则等主循环轮到它。
+
+| 失败模式 | 原因 | 后果 |
+|----------|------|------|
+| 少减 | 某条堆内边没减掉 | 垃圾对象 rc 仍 > 0，漏回收 |
+| 多减 | 同一条边减了两次 | 活人 rc 变 0 进 tmp，可能被误杀 |
+
+**反例：若不做 mark 同步**
+
+两节点环，处理顺序若让 node1 先被邻居减量、自己出边尚未处理：
+
+```text
+node1 被 node0 的边减量 → rc 0，但 mark 仍为 0
+若此时立刻进 tmp 且不再处理 node1 的出边 → node0 少减一条 → 泄漏
+```
+
+**反例：若边减两次**
+
+同一子节点被两个父节点各减一次本没问题；但若**同一条边**因重复 `mark_children` 减两次，活人 rc 会偏低甚至变 0。
+
+进 `tmp_obj_list` **不是释放**，只是嫌疑人名单。
+
+#### 推演：两节点孤立环
+
+| 步骤 | node0.rc | node1.rc | 名单 |
+|------|----------|----------|------|
+| 初始 | 1 | 1 | 空 |
+| 处理 node0，边→node1 | 1 | 0 | node1 尚未处理出边，`mark=0`，仍在 `gc_obj_list` |
+| 处理 node1，边→node0 | 0 | 0 | node0 已 `mark=1`，先进入 tmp |
+| node1 标记完成 | 0 | 0 | node1 也进入 tmp |
+
+阶段 1 结束性质：**剩余 rc = 根引用数**（此例根为 0）。
+
+### 6.2 阶段 2：gc_scan
+
+#### 概念：为什么要平反
+
+```monkey
+let root = [[[1, 2], 3], 4];
+```
+
+```text
+globals[root] → root_array → middle_array → leaf_array
+```
+
+阶段 1 把 `middle`、`leaf` 都减到 0——它们的计数全来自堆内边。但它们从 `root` 可达，是活的。阶段 1 只看"减完堆内边后还有没有剩余"，不看"能不能从活人走过去"。
+
+阶段 2 从 **rc > 0 且仍在 `gc_obj_list` 的对象** 出发，沿边把计数加回去；从 0 变 1 的嫌疑人从 `tmp` 移回 `gc_obj_list` **尾部**。
+
+#### 动态遍历 ≠ 快照
+
+循环沿 `list_next` **动态**往后走。刚被平反的对象追加在尾部，同一轮稍后会被扫到——**链式营救**。
+
+**反例推演：快照成 Vec 会漏杀**
+
+对象图：`root → A → B → C`，阶段 1 后仅 root 存活，A/B/C 全在 tmp。
+
+| 时刻 | 正确做法（动态 list_next） | 错误做法（开头快照 ids = [root]） |
+|------|---------------------------|-----------------------------------|
+| 扫描开始 | current = root | 只遍历 [root] |
+| root 平反 A | A 移到 gc_obj_list 尾部 | A 回到活人堆，但 ids 里没有 A |
+| 继续 | current 走到 A，平反 B | 循环已结束 |
+| 再继续 | A 平反 B，B 平反 C | B、C 永远留在 tmp |
+| 阶段 3 | tmp 空 | **误杀 B、C** |
+
+QuickJS 用 `list_for_each` 达到动态效果；我们 `while let Some(id) = current { current = header(id).list_next }` 同理。别问我们怎么知道的。
+
+#### `ScanIncref2`：为啥给死人恢复计数？
+
+第二遍对 `tmp_obj_list` **剩下来的**对象做 `ScanIncref2`，只 +1，不迁链表。
+
+**反例：若跳过第二遍**
+
+2 环 A ↔ B，阶段 2 后 A、B 仍在 tmp，各自 rc 在阶段 1 末为 0，第二遍各 +1 → 都变 1。
+
+阶段 3 释放 A：沿边 `free(B)` → B: 1→0；A 本体 drop 后 A.rc 可能仍为 1（B 指着僵尸 A）。
+
+若阶段 2 没把环内 rc 恢复到"满边状态"，释放时沿边多次 `free_gc` 会把计数减成**负数**，`ref_count > 0` 的判断失效，拆环节奏全乱。
+
+**先恢复环内计数，再有序拆除，每一步的数才对。**
+
+#### 实现（简化）
+
+```rust
+fn gc_scan(&mut self) {
+    let mut current = self.gc_obj_list.head;
+    while let Some(id) = current {
+        self.header_mut(id).mark = 0;
+        self.mark_children(id, MarkFunc::ScanIncref);
+        current = self.header(id).list_next;
+    }
+    let mut current = self.tmp_obj_list.head;
+    while let Some(id) = current {
+        let next = self.header(id).list_next;
+        self.mark_children(id, MarkFunc::ScanIncref2);
+        current = next;
+    }
+}
+```
+
+#### 推演：嵌套数组误伤与营救
+
+假设只有 `globals[root]` 持 `root_array`，结构 `root → middle → leaf`。
+
+| 阶段 | root.rc | middle.rc | leaf.rc |
+|------|---------|-----------|---------|
+| GC 前 | 1 | 1 | 1 |
+| 阶段 1 后 | 1 | 0 | 0 |
+| 扫描 root，+middle | 1 | 1 | 0 |
+| 扫描 middle（从尾部捞回），+leaf | 1 | 1 | 1 |
+
+### 6.3 阶段 3：gc_free_cycles
+
+#### 概念：僵尸槽（free_mark）
+
+A、B 互指。先释放 A：沿边 `free(B)`，跑 `on_free`，drop A 本体——但 B 仍指着 A，A.rc 可能还是 1。若此时归还 A 的槽位，稍后 `free(B)` 沿边碰 A 会炸。
+
+**僵尸**：`free_mark = true`，逻辑已死，槽位推迟到 `gc_zero_ref_count_list` 统一归还。
+
+#### 实现（简化）
+
+```rust
+fn gc_free_cycles(&mut self) {
+    self.gc_phase = GcPhase::RemoveCycles;
+    while let Some(id) = self.tmp_obj_list.head {
+        self.free_gc_object(id);
+    }
+    self.gc_phase = GcPhase::None;
+    // 归还 zero_ref 里的僵尸槽
+}
+```
+
+`RemoveCycles` 期间 `free_gc` 只减计数，不触发普通级联节奏。
+
+#### 推演：A、B 互指环拆尸
+
+| 步骤 | 操作 | A.rc | B.rc | A 槽 | B 槽 |
+|------|------|------|------|------|------|
+| 0 | 阶段 3 入口 | 1 | 1 | 活 | 活 |
+| 1 | free A | 1 | 0 | 僵尸 | 活 |
+| 2 | free B | 0 | 0 | 僵尸 | 已归还 |
+| 3 | 收尾 | — | — | 归还 | — |
+
+#### 测试即规格（环的变体）
+
+```rust
+#[test]
+fn self_cycle_collected() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    heap.link(a, a);
+    heap.gc.free(a);
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(a));
+}
+
+#[test]
+fn three_node_cycle_collected() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(3);
+    heap.drop_external_refs(&nodes);
+    heap.gc.run_gc();
+    for &id in &nodes {
+        assert!(!heap.gc.exists(id));
+    }
+}
+
+#[test]
+fn four_node_cycle_collected() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(4);
+    heap.drop_external_refs(&nodes);
+    heap.gc.run_gc();
+    for &id in &nodes {
+        assert!(!heap.gc.exists(id));
+    }
+}
+
+#[test]
+fn repeated_gc_is_idempotent() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+    heap.drop_external_refs(&nodes);
+    heap.gc.run_gc();
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+
+#[test]
+fn self_cycle_finalizer_runs_after_edges_are_released() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    heap.link(a, a);
+    heap.gc.free(a);
+    heap.gc.run_gc();
+    assert_eq!(heap.freed_ref_counts.borrow().get(&a.0).copied(), Some(0));
+    assert!(!heap.gc.exists(a));
+}
+```
+
+`self_cycle_finalizer_runs_after_edges_are_released` 钉住 **finalizer 时序**：`on_free` 跑时环内边已释放，计数为 0。
+
+#### 三阶段全景：链表迁移
+
+```mermaid
+stateDiagram-v2
+    [*] --> GcObjList: 正常存活
+    GcObjList --> TmpList: gc_decref 后 rc==0
+    TmpList --> GcObjList: gc_scan 平反 rc 0→1
+    TmpList --> Freed: gc_free_cycles
+    GcObjList --> ZeroRef: 普通 free 归零
+    ZeroRef --> Freed: free_zero_refcount
+    TmpList --> ZeroRef: 拆环僵尸延迟
+```
+
+**本章测试**（`gc/gc_test.rs`）：`mark_func_decref_zeros_isolated_cycle`，`collects_simple_cycle`，`self_cycle_collected`，`three_node_cycle_collected`，`four_node_cycle_collected`，`repeated_gc_is_idempotent`，`self_cycle_finalizer_runs_after_edges_are_released`
+
+---
+
+## 7. 活着的环：循环 ≠ 垃圾
+
+### 7.1 概念
+
+回收判据是**不可达**，不是**成环**。只要外面还有人抓着环上任意节点，整个环都必须活。
+
+### 7.2 测试即规格
+
+**`cycle_with_external_root_survives`**：
+
+```rust
+#[test]
+fn cycle_with_external_root_survives() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+
+    let root = heap.gc.dup(nodes[0]);
+    heap.gc.run_gc();
+
+    assert!(heap.gc.exists(nodes[0]));
+    assert!(heap.gc.exists(nodes[1]));
+
+    heap.gc.free(root);
+    heap.drop_external_refs(&nodes);
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+```
+
+**`external_ref_to_cycle_entry_survives_gc`** — 救人者不必是"根"，只要是**活对象**：
+
+```rust
+#[test]
+fn external_ref_to_cycle_entry_survives_gc() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+    let holder = heap.alloc();
+    heap.link(holder, nodes[0]);
+
+    heap.gc.free(nodes[0]);
+    heap.gc.free(nodes[1]);
+
+    heap.gc.run_gc();
+    assert!(heap.gc.exists(nodes[0]));
+    assert!(heap.gc.exists(nodes[1]));
+    assert!(heap.gc.exists(holder));
+
+    heap.gc.free(holder);
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+```
+
+`holder` 在 `gc_obj_list` 里活着，阶段 2 从它出发能把环整条救回来。
+
+### 7.3 推演验证：带外部根的 2 环
+
+第一次 GC 前，测试里的 `nodes[0]` / `nodes[1]` 句柄还没释放，另外又 `dup` 了一份 `root`。所以不是"只有一个外部根"：
+
+- `node0.rc = 3`：`nodes[0]` + `root` + `node1 → node0`
+- `node1.rc = 2`：`nodes[1]` + `node0 → node1`
+
+| 阶段 | 操作 | node0.rc | node1.rc | gc_obj_list | tmp |
+|------|------|----------|----------|-------------|-----|
+| 0 | GC 前 | 3 | 2 | 0,1 | 空 |
+| 1a | 处理 node0，decref node1 | 3 | 1 | 0,1 | 空 |
+| 1b | 处理 node1，decref node0 | 2 | 1 | 0,1 | 空 |
+| 2a | scan node0，incref node1 | 2 | 2 | 0,1 | 空 |
+| 2b | scan node1，incref node0 | 3 | 2 | 0,1 | 空 |
+| 3 | tmp 空 | 3 | 2 | 0,1 | 空 |
+
+`root` 被 `free`，再 `drop_external_refs(&nodes)` 后，两节点各只剩一条环内边，变成第 5 章的纯环，下一次 GC 回收。
+
+### 7.4 推演验证：`external_ref_to_cycle_entry_survives_gc`
+
+对象图：`holder → node0 ↔ node1`，测试已 `free` 对 node0/node1 的直接引用。
+
+| 对象 | GC 前 rc | 外部根？ |
+|------|----------|----------|
+| holder | 1 | 是，测试代码仍持有着（未 free） |
+| node0 | 2 | 否，来自 `holder → node0` 和 `node1 → node0` |
+| node1 | 1 | 否，来自 `node0 → node1` |
+
+阶段 1 后 `holder.rc = 1`（测试代码持有），`node0` / `node1` 会进入 tmp；阶段 2 从 holder 出发先平反 node0，再动态扫到 node0 平反 node1，整环回到 `gc_obj_list`。`free(holder)` 后再 GC，环变不可达，收掉。
+
+**本章测试**（`gc/gc_test.rs`）：`cycle_with_external_root_survives`，`external_ref_to_cycle_entry_survives_gc`
+
+---
+
+## 8. 什么时候跑 GC
+
+### 8.1 概念：不能每次分配都全堆扫
+
+三阶段 GC 的成本与**当前堆对象数量**成正比：阶段 1 扫 `gc_obj_list` 每条边 trial decref；阶段 2 再扫一遍；阶段 3 处理 tmp。若每次 `alloc` 都 `run_gc()`，程序退化成 O(分配次数 × 堆大小)。
+
+无环垃圾已被引用计数**即时**收掉——临时数组、函数返回的中间值在最后一个 `free` 时就死了，根本进不了"需要环检测"的路径。因此：
+
+| 堆行为 | GC 频率 |
+|--------|---------|
+| 稳定，只有无环分配/释放 | 几乎不触发 |
+| 猛涨（大量新对象、可能出现环） | 超过阈值才扫 |
+
+**1.5 倍系数**：触发后 `threshold = malloc_size + malloc_size/2`。堆从 100KB 涨到触发点，下次要涨到 150KB 才再触发——避免抖动。堆缩小后阈值也会跟着降。
+
+`MallocState` 在 `alloc_slot` / `free_slot` 记账；`trigger_gc(alloc_size)` 在**即将分配**前判断 `malloc_size + alloc_size > threshold`。
+
+#### 纯 refcount 路径（预留）
+
+不参与环检测的值（未来大字符串等）可走 `RefCountHeader`：
+
+```rust
+#[test]
+fn ref_counted_freed_without_gc() {
+    let mut gc = GcHeap::new();
+    let freed = Rc::new(Cell::new(false));
+    let id = gc.runtime_mut().add_ref_counted(/* on_free */);
+    let dup = gc.runtime_mut().dup_ref_counted(id);
+    gc.runtime_mut().free_ref_counted(id);
+    assert!(!freed.get());
+    gc.runtime_mut().free_ref_counted(dup);
+    assert!(freed.get());
+}
+```
+
+API 已留好；当前 `Value::String` 仍内联在 `ValueCell`，见第 11 章。
+
+### 8.2 测试即规格
+
+```rust
+#[test]
+fn trigger_gc_on_threshold() {
+    let mut heap = TestHeap::new();
+    heap.gc.set_gc_threshold(0);
+
+    let nodes = heap.make_cycle(2);
+    heap.drop_external_refs(&nodes);
+
+    heap.gc.trigger_gc(1);
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+```
+
+阈值 0 → 下一次 `trigger_gc` 必跑 `run_gc`，环应被收掉。
+
+### 8.3 实现
+
+```rust
+pub fn trigger_gc(&mut self, alloc_size: usize) {
+    let force_gc =
+        self.malloc_state.malloc_size.saturating_add(alloc_size) > self.malloc_gc_threshold;
+    if force_gc {
+        self.run_gc();
+        self.malloc_gc_threshold =
+            self.malloc_state.malloc_size + (self.malloc_state.malloc_size >> 1);
+    }
+}
+```
+
+**本章测试**（`gc/gc_test.rs`）：`trigger_gc_on_threshold`，`ref_counted_freed_without_gc`，`malloc_state_tracks_allocations`（亦见第 2 章）
+
+---
+
+## 9. 把 Monkey 的值搬进堆
+
+### 9.1 概念：哪些 Monkey 值有出边？
+
+| Value 变体 | 堆内出边 |
+|------------|----------|
+| `Integer`, `Boolean`, `String`, `Null`, `Error` | 无 |
+| `Array` | 每个元素 |
+| `Hash` | 每个值 |
+| `Closure` | `func` + 每个 `free` 捕获 |
+| `CompiledFunction` | 无（字节码元数据） |
+| `Builtin` | 无 |
+
+`object::Object` 内部是 `Rc<Object>`，塞不进我们的堆。在 `gc/value.rs` 做镜像，边全换成 `GcRef`。
+
+### 9.2 测试即规格
+
+**所有权 — `alloc_value_increments_child_refcounts`**：
+
+```rust
+#[test]
+fn alloc_value_increments_child_refcounts() {
+    let mut heap = GcHeap::new();
+    let child = alloc_value(&mut heap, Value::Integer(1));
+    assert_eq!(heap.ref_count(child), 1);
+
+    let parent = alloc_value(&mut heap, Value::Array(vec![child]));
+    assert_eq!(heap.ref_count(child), 2);
+
+    heap.free(parent);
+    assert_eq!(heap.ref_count(child), 1);
+}
+```
+
+`alloc_value` **不**接管调用者手里的引用——传进去的 `child` 仍归调用者 `free`。
+
+**`import_object_releases_temporary_child_refs`** — import 深拷贝时，子节点会先作为临时 `GcRef` 握在调用栈上，父对象 `alloc` 完成后这些临时持有必须释放：
+
+```rust
+#[test]
+fn import_object_releases_temporary_child_refs() {
+    let mut heap = GcHeap::new();
+    let original = Object::Array(vec![Rc::new(Object::Array(vec![
+        Rc::new(Object::Integer(1)),
+        Rc::new(Object::Integer(2)),
+    ]))]);
+
+    let root = import_object(&mut heap, &original);
+    let nested = match get_value(&heap, root) {
+        Value::Array(items) => items[0],
+        other => panic!("expected root array, got {:?}", other),
+    };
+    let leaves = match get_value(&heap, nested) {
+        Value::Array(items) => items.clone(),
+        other => panic!("expected nested array, got {:?}", other),
+    };
+
+    assert_eq!(heap.ref_count(root), 1);
+    assert_eq!(heap.ref_count(nested), 1);
+    for leaf in &leaves {
+        assert_eq!(heap.ref_count(*leaf), 1);
+    }
+
+    heap.free(root);
+    assert!(!heap.exists(root));
+    assert!(!heap.exists(nested));
+    for leaf in leaves {
+        assert!(!heap.exists(leaf));
+    }
+}
+```
+
+| 断言 | 若 import 泄漏临时 dup |
+|------|------------------------|
+| `ref_count(nested) == 1` | 可能是 2（import 栈 + 父数组边各一份未 free） |
+| `free(root)` 后 nested 不存在 | 临时引用把子树钉住，级联失败 |
+
+钉住：深拷贝路径上的**临时**子 `GcRef` 在父分配完成后必须 `free`。
+
+**环 — `value_cycle_collected_by_gc`**：
+
+```rust
+#[test]
+fn value_cycle_collected_by_gc() {
+    let mut heap = GcHeap::new();
+    let node_a = alloc_value(&mut heap, Value::Array(vec![]));
+    let node_b = alloc_value(&mut heap, Value::Array(vec![node_a]));
+
+    let node_b_edge = heap.dup(node_b);
+    match &mut heap
+        .runtime_mut()
+        .object_downcast_mut::<ValueCell>(node_a.0)
+        .expect("node_a should be a ValueCell")
+        .value
+    {
+        Value::Array(items) => items.push(node_b_edge),
+        other => panic!("expected node_a array, got {:?}", other),
+    }
+
+    heap.free(node_a);
+    heap.free(node_b);
+    heap.run_gc();
+    assert!(!heap.exists(node_a));
+    assert!(!heap.exists(node_b));
+}
+```
+
+roundtrip 类测试验证 `import_object` / `export_object` 深拷贝语义一致：
+
+| 测试 | 钉住 |
+|------|------|
+| `import_export_integer_roundtrip` | 标量 |
+| `import_export_string_roundtrip` | 字符串 |
+| `import_export_array_roundtrip` | 一层数组 |
+| `import_export_hash_roundtrip` | 哈希 |
+| `import_export_nested_array_roundtrip` | 嵌套结构 |
+| `hash_key_from_value_matches_object` | 哈希键一致性 |
+
+不逐行展开；失败时优先查 `import_object` 是否漏 `free` 临时子引用。
+
+### 9.3 实现摘要
+
+```rust
+// gc/value.rs
+pub enum Value {
+    Integer(i64),
+    Boolean(bool),
+    String(String),
+    Array(Vec<GcRef>),
+    Hash(HashMap<HashKey, GcRef>),
+    Null,
+    Error(String),
+    CompiledFunction(CompiledFunction),
+    Closure(GcClosure),
+    Builtin(BuiltinFunc),
+}
+
+pub struct GcClosure {
+    pub func: GcRef,
+    pub free: Vec<GcRef>,
+}
+
+impl Value {
+    pub fn trace(&self, visit: &mut dyn FnMut(GcRef)) {
+        match self {
+            Value::Array(items) => items.iter().for_each(|i| visit(*i)),
+            Value::Hash(map) => map.values().for_each(|v| visit(*v)),
+            Value::Closure(c) => {
+                visit(c.func);
+                c.free.iter().for_each(|f| visit(*f));
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn alloc_value(heap: &mut GcHeap, value: Value) -> GcRef {
+    let value = value.with_owned_edges(heap);
+    heap.alloc(ValueCell { value }, GcObjectType::MonkeyObject)
+}
+```
+
+#### import / export 数据流
+
+```mermaid
+flowchart LR
+    Obj["object::Object Rc"] -->|import_object| Heap["GcRef / Value"]
+    Heap -->|export_object| Obj
+    Builtin["BuiltinFunc"] -->|export 参数| Obj
+    Obj -->|调用| Builtin
+    Builtin -->|import 结果| Heap
+```
+
+**本章测试**（`gc/value_test.rs`）：`alloc_value_increments_child_refcounts`，`import_object_releases_temporary_child_refs`，`value_cycle_collected_by_gc`，以及 `import_export_*`、`hash_key_from_value_matches_object`
+
+---
+
+## 10. VM：每条指令说清楚谁持有谁
+
+### 10.1 概念：VM 里的根集合
+
+第 1 章的"根"在 `GcVM` 里具体是：
+
+```mermaid
+flowchart TB
+    subgraph GcVM
+        constants[constants]
+        main_fn[main_fn 初始引用]
+        stack[stack 0..sp]
+        globals[globals]
+        last_popped[last_popped]
+        null_ref[null 单例]
+    end
+    constants --> HeapObj
+    main_fn --> HeapObj
+    stack --> HeapObj
+    globals --> HeapObj
+    last_popped --> HeapObj
+```
+
+| 区域 | 角色 |
+|------|------|
+| `constants` | 编译期字面量，全程存活 |
+| 主函数初始引用 | `GcVM::new` 为顶层字节码分配的 `CompiledFunction`；`Frame` 只借用 |
+| `stack[0..sp)` | 操作数栈，活跃槽 |
+| `globals` | 全局变量 |
+| `last_popped` | 最近一次 `OpPop` 结果 |
+| `null` | 空槽占位；每个清空栈槽持有一份 dup |
+
+**帧 `Frame` 不 dup 闭包**——被调对象在调用者栈槽活着，靠注释和测试兜底。
+
+### 10.2 测试：功能 + 计数
+
+功能测试沿用《Writing A Compiler In Go》的 `VmTestCase` 数组——解析、编译、跑、比 `export_last_result` 与期望 `Object`：
+
+```rust
+run_gc_vm_tests(vec![
+    VmTestCase { input: "1 + 2", expected: Object::Integer(3) },
+    VmTestCase { input: "[1, 2, 3][1]", expected: Object::Integer(2) },
+    VmTestCase {
+        input: "let newAdder = fn(a, b) { fn(c) { a + b + c } };
+                let adder = newAdder(1, 2); adder(8);",
+        expected: Object::Integer(11),
+    },
+    // ... 共 15 组 VmTestCase + 1 组计数测试
+]);
+```
+
+| 测试函数 | 覆盖 |
+|----------|------|
+| `test_integer_arithmetic` | 整数、四则、一元负号 |
+| `test_boolean_expressions` | 比较、逻辑非 |
+| `test_conditionals` | if/else |
+| `test_global_let_statements` | 全局 let |
+| `test_strings` | 字符串拼接 |
+| `test_arrays` / `test_hash` / `test_index` | 复合类型 |
+| `test_functions_*` / `test_closures` | 调用、闭包 |
+| `test_builtins` | len、push 等 |
+| `test_eval_source_helper` | 顶层 `eval_source` API |
+
+16 组里 15 组验语义，1 组验计数。
+
+**`builtin_call_releases_callee_args_and_stack_temporaries`** 保证**计数对**：
+
+```rust
+#[test]
+fn builtin_call_releases_callee_args_and_stack_temporaries() {
+    let program = parse("len([1, 2, 3]);").unwrap();
+    let mut compiler = Compiler::new();
+    let bytecode = compiler.compile(&program).unwrap();
+    let mut vm = GcVM::new(bytecode);
+    vm.run();
+    assert_eq!(vm.export_last_result(), Some(Object::Integer(3)));
+
+    vm.heap_mut().run_gc();
+    assert_eq!(vm.heap().runtime().gc_object_count(), 6);
+}
+```
+
+执行 `len([1, 2, 3])` 期间栈上曾短暂存在数组、builtin、临时整数等；`run()` 结束后须全部 `free` 干净。
+
+#### "数到 6" 对照表
+
+跑完 `len([1, 2, 3]);` 再 `run_gc()` 后，堆里应**恰好**剩 6 个 GC 对象：
+
+| # | 对象 | 为何还在 |
+|---|------|----------|
+| 1 | `null` 单例 | 空栈槽占位 |
+| 2 | 常量 `1` | `constants` |
+| 3 | 常量 `2` | `constants` |
+| 4 | 常量 `3` | `constants` |
+| 5 | 主函数 `CompiledFunction` | `GcVM::new` 单独分配的 `main_fn` 初始引用；帧只借用它 |
+| 6 | 结果 `Integer(3)` | `last_popped` |
+
+**不应存在**：临时数组、`len` builtin 包装、调用期栈上垃圾。多 `dup` 一次 → 计数变 7，测试立刻红。
+
+### 10.3 三种指令模式与栈快照
+
+#### 模式一：移动（`OpSetGlobal`）
+
+全局接手栈顶，持有者总数不变，**不** `dup`。
+
+```text
+OpSetGlobal g 前:  stack[sp-1] 持 value (rc 含栈这份)
+                 globals[g] 持 old (若有)
+
+后:               stack 槽变 null
+                 globals[g] 持 value
+                 old 被 free
+```
+
+#### 模式二：复制（`OpGetGlobal`）
+
+```rust
+self.dup_and_push(self.globals[global_index]);
+```
+
+```text
+前: globals[g] 持 value, rc = N
+后: globals[g] 仍持 value, rc = N
+    stack[sp] 新增一份, rc = N+1
+```
+
+#### 模式三：接管（`OpArray`）
+
+```rust
+let elements = self.build_array(start, self.sp);
+let array = alloc_value(&mut self.heap, Value::Array(elements)); // 对每个元素 dup
+self.clear_stack_range(start, self.sp);  // 栈槽 free
+self.push_raw(array);
+```
+
+```text
+前: 栈上各元素 rc 各含栈槽一份
+后: 数组对象持有各元素 (dup +1)
+    栈槽 free (-1)
+    净计数不变，持有者从栈换成数组
+```
+
+`OpHash`、`OpClosure` 同模式三。
+
+#### 闭包捕获：栈 → 闭包对象的净转移
+
+`newAdder(1, 2)` 返回内层闭包时，外层帧弹出，但内层仍要读 `a`、`b`。`OpClosure` 走模式三：`with_owned_edges` 对 `func` 和每个自由变量 `dup`，再清空栈上捕获槽。
+
+```text
+OpClosure 前:  stack[base..] 持 func、a、b
+后:            闭包对象持 func、a、b（各 dup 一次）
+               栈槽 free，计数净不变
+```
+
+#### 帧不持引用
+
+`Frame` 里的 `GcClosure` 是借来的——被调闭包在**调用者栈槽**活着，帧只记 IP 和 base pointer，不 `dup`。省一次调用/返回的计数操作，代价是 `gc/frame.rs` 里必须写清的隐式约定。
+
+### 10.4 实现摘要
+
+```rust
+pub struct GcVM {
+    heap: GcHeap,
+    constants: Vec<GcRef>,
+    stack: Vec<GcRef>,
+    sp: usize,
+    globals: Vec<GcRef>,
+    frames: Vec<Frame>,
+    frame_index: usize,
+    null: GcRef,
+    last_popped: GcRef,
+}
+```
+
+**本章测试**（`gc/vm_test.rs`）：`test_integer_arithmetic`，`test_boolean_expressions`，`test_conditionals`，`test_global_let_statements`，`test_strings`，`test_arrays`，`test_hash`，`test_index`，`test_functions_without_arguments`，`test_functions_without_return_value`，`test_calling_functions_with_bindings`，`test_calling_functions_with_arguments_and_bindings`，`test_closures`，`test_builtins`，`builtin_call_releases_callee_args_and_stack_temporaries`，`test_eval_source_helper`
+
+---
+
+## 11. 我们没做什么
+
+照例坦白。这套实现是最小可用系统：
+
+| 没做 | 说明 |
+|------|------|
+| **写屏障** | 全靠手写 `dup`/`free`；安全网是第 10 章那种精确计数测试 |
+| **字符串拆堆** | `Value::String` 内联；`RefCountHeader` API 已预留 |
+| **builtin 深拷贝** | 每次 export/import 一轮，慢但 `object` crate 零改动 |
+| **替换默认 VM** | `wasm` / playground 仍用 `compiler::VM` |
+| **单线程** | 无 `Send`/`Sync` |
+
+验证：
+
+```bash
+cargo test -p monkey-gc
+```
+
+**42 个测试**：`gc_test.rs` 17 + `value_test.rs` 9 + `vm_test.rs` 16。
+
+---
+
+## 12. 回顾
+
+### 12.1 五小步
+
+1. 下标句柄堆，`alloc` / `free`
+2. `dup` 与所有权纪律
+3. `trace` 与无环级联释放
+4. 三阶段环回收：trial deletion → 平反 → 拆环收尸
+5. 阈值触发，`Value` 与 `GcVM` 接线
+
+### 12.2 核心直觉
+
+```text
+引用计数负责"立刻能知道没人要"的对象。
+三阶段 GC 负责"看起来有人要，其实只是在环里互相撑着"的对象。
+判据只有一条：把堆内的边都减掉之后，计数还大于 0 的，一定被根持有。
+```
+
+### 12.3 概念 → 章节 → 测试 索引
+
+| 概念 | 章节 | 代表测试 |
+|------|------|----------|
+| 句柄 / 槽位表 | 2 | `refcount_frees_immediately_without_gc` |
+| finalizer | 2 | `on_free_called_when_collected` |
+| dup / free 纪律 | 3 | `dup_extends_lifetime` |
+| trace / 级联 | 4 | `acyclic_holder_extends_child_lifetime` |
+| 无环整图释放 | 4 | `acyclic_graph_freed_without_gc` |
+| 循环泄漏 | 5 | `collects_simple_cycle` |
+| gc_decref | 6.1 | `mark_func_decref_zeros_isolated_cycle` |
+| 多节点环 | 6.3 | `three_node_cycle_collected`, `four_node_cycle_collected`, `self_cycle_collected` |
+| finalizer 时序 | 6.3 | `self_cycle_finalizer_runs_after_edges_are_released` |
+| 有根环存活 | 7 | `cycle_with_external_root_survives` |
+| 活对象救环 | 7 | `external_ref_to_cycle_entry_survives_gc` |
+| 阈值触发 | 8 | `trigger_gc_on_threshold` |
+| 纯 refcount 预留 | 8 | `ref_counted_freed_without_gc` |
+| Value 所有权 | 9 | `alloc_value_increments_child_refcounts` |
+| import 不泄漏 | 9 | `import_object_releases_temporary_child_refs` |
+| Value 层环 | 9 | `value_cycle_collected_by_gc` |
+| VM 计数 | 10 | `builtin_call_releases_callee_args_and_stack_temporaries` |
+| 端到端语义 | 10 | `test_closures` 等 15 组 |
+
+### 12.4 延伸阅读
+
+- 模块设计：[`docs/gc.md`](../docs/gc.md)
+- crate 用法：[`gc/README.md`](README.md)

--- a/gc/gc-report.md
+++ b/gc/gc-report.md
@@ -81,11 +81,7 @@ cargo test -p monkey-gc -- value_test
 cargo test -p monkey-gc -- vm_test
 ```
 
-3. 每章末尾有 **本章测试** 列表，可以按名过滤，例如：
-
-```bash
-cargo test -p monkey-gc collects_simple_cycle
-```
+3. 读到某个测试时，可以按名单独跑，例如 `cargo test -p monkey-gc collects_simple_cycle`。
 
 ### 0.5 每章固定四拍
 
@@ -415,8 +411,6 @@ pub fn free_gc(&mut self, id: GcId) {
 | 1 | `alloc()` | 1（测试代码持有） | true |
 | 2 | `free(a)` | 0 → 释放 | false |
 
-**本章测试**（`gc/gc_test.rs`）：`refcount_frees_immediately_without_gc`，`on_free_called_when_collected`，`malloc_state_tracks_allocations`
-
 ---
 
 ## 3. 第二个持有者：dup 与所有权纪律
@@ -504,8 +498,6 @@ pub fn dup_gc(&mut self, id: GcId) -> GcId {
 | holder | 1 | ① 测试变量 `holder` |
 
 `free(child)` 后 child.rc = 1，只剩 holder 边——与第 4 章测试衔接。
-
-**本章测试**（`gc/gc_test.rs`）：`dup_extends_lifetime`
 
 ---
 
@@ -661,8 +653,6 @@ fn free_zero_refcount(&mut self) {
 | 4 | `free(child)` | 1 | 1 | 测试放手，holder 还在 |
 | 5 | `free(holder)` | 0 | 0 | holder 死 → trace → free child → 子死 |
 
-**本章测试**（`gc/gc_test.rs`）：`acyclic_holder_extends_child_lifetime`，`acyclic_graph_freed_without_gc`
-
 ---
 
 ## 5. 红灯：循环引用
@@ -721,8 +711,6 @@ flowchart LR
 | 4 | 尝试 `free` | 不变 | 不变 | rc > 0，无法释放 |
 
 **泄漏确认**：两个对象永远挂在 `gc_obj_list` 里。这就是 `Rc` 的洞，现在在我们自己的堆里重现了。
-
-**本章测试**（`gc/gc_test.rs`）：`collects_simple_cycle`（第 6 章实现后变绿）
 
 ---
 
@@ -1081,8 +1069,6 @@ stateDiagram-v2
     TmpList --> ZeroRef: 拆环僵尸延迟
 ```
 
-**本章测试**（`gc/gc_test.rs`）：`mark_func_decref_zeros_isolated_cycle`，`collects_simple_cycle`，`self_cycle_collected`，`three_node_cycle_collected`，`four_node_cycle_collected`，`repeated_gc_is_idempotent`，`self_cycle_finalizer_runs_after_edges_are_released`
-
 ---
 
 ## 7. 活着的环：循环 ≠ 垃圾
@@ -1172,8 +1158,6 @@ fn external_ref_to_cycle_entry_survives_gc() {
 
 阶段 1 后 `holder.rc = 1`（测试代码持有），`node0` / `node1` 会进入 tmp；阶段 2 从 holder 出发先平反 node0，再动态扫到 node0 平反 node1，整环回到 `gc_obj_list`。`free(holder)` 后再 GC，环变不可达，收掉。
 
-**本章测试**（`gc/gc_test.rs`）：`cycle_with_external_root_survives`，`external_ref_to_cycle_entry_survives_gc`
-
 ---
 
 ## 8. 什么时候跑 GC
@@ -1245,8 +1229,6 @@ pub fn trigger_gc(&mut self, alloc_size: usize) {
     }
 }
 ```
-
-**本章测试**（`gc/gc_test.rs`）：`trigger_gc_on_threshold`，`ref_counted_freed_without_gc`，`malloc_state_tracks_allocations`（亦见第 2 章）
 
 ---
 
@@ -1423,8 +1405,6 @@ flowchart LR
     Builtin -->|import 结果| Heap
 ```
 
-**本章测试**（`gc/value_test.rs`）：`alloc_value_increments_child_refcounts`，`import_object_releases_temporary_child_refs`，`value_cycle_collected_by_gc`，以及 `import_export_*`、`hash_key_from_value_matches_object`
-
 ---
 
 ## 10. VM：每条指令说清楚谁持有谁
@@ -1600,8 +1580,6 @@ pub struct GcVM {
     last_popped: GcRef,
 }
 ```
-
-**本章测试**（`gc/vm_test.rs`）：`test_integer_arithmetic`，`test_boolean_expressions`，`test_conditionals`，`test_global_let_statements`，`test_strings`，`test_arrays`，`test_hash`，`test_index`，`test_functions_without_arguments`，`test_functions_without_return_value`，`test_calling_functions_with_bindings`，`test_calling_functions_with_arguments_and_bindings`，`test_closures`，`test_builtins`，`builtin_call_releases_callee_args_and_stack_temporaries`，`test_eval_source_helper`
 
 ---
 

--- a/gc/gc_test.rs
+++ b/gc/gc_test.rs
@@ -76,7 +76,7 @@ impl TestHeap {
                 self.freed.clone(),
                 self.freed_ref_counts.clone(),
             ),
-            GcObjectType::JsObject,
+            GcObjectType::MonkeyObject,
         );
         assert_eq!(reference.0, id);
         self.edges.borrow_mut().insert(id, Vec::new());

--- a/gc/gc_test.rs
+++ b/gc/gc_test.rs
@@ -1,10 +1,4 @@
-use crate::{
-    GcHeap,
-    GcObject,
-    GcObjectType,
-    GcRef,
-    MarkFunc,
-};
+use crate::{GcHeap, GcObject, GcObjectType, GcRef, MarkFunc};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -15,14 +9,21 @@ struct TestNode {
     id: usize,
     edges: EdgeMap,
     freed: Rc<Cell<bool>>,
+    freed_ref_counts: Rc<RefCell<HashMap<usize, i32>>>,
 }
 
 impl TestNode {
-    fn new(id: usize, edges: EdgeMap, freed: Rc<Cell<bool>>) -> Self {
+    fn new(
+        id: usize,
+        edges: EdgeMap,
+        freed: Rc<Cell<bool>>,
+        freed_ref_counts: Rc<RefCell<HashMap<usize, i32>>>,
+    ) -> Self {
         TestNode {
             id,
             edges,
             freed,
+            freed_ref_counts,
         }
     }
 }
@@ -37,7 +38,10 @@ impl GcObject for TestNode {
         }
     }
 
-    fn on_free(&mut self, _rt: &mut crate::GcRuntime) {
+    fn on_free(&mut self, rt: &mut crate::GcRuntime) {
+        self.freed_ref_counts
+            .borrow_mut()
+            .insert(self.id, rt.ref_count(self.id));
         self.freed.set(true);
     }
 }
@@ -46,6 +50,7 @@ struct TestHeap {
     gc: GcHeap,
     edges: EdgeMap,
     freed: Rc<Cell<bool>>,
+    freed_ref_counts: Rc<RefCell<HashMap<usize, i32>>>,
 }
 
 impl TestHeap {
@@ -54,6 +59,7 @@ impl TestHeap {
             gc: GcHeap::new(),
             edges: Rc::new(RefCell::new(HashMap::new())),
             freed: Rc::new(Cell::new(false)),
+            freed_ref_counts: Rc::new(RefCell::new(HashMap::new())),
         }
     }
 
@@ -64,7 +70,12 @@ impl TestHeap {
             self.gc.runtime().object_len_for_test()
         };
         let reference = self.gc.alloc(
-            TestNode::new(id, self.edges.clone(), self.freed.clone()),
+            TestNode::new(
+                id,
+                self.edges.clone(),
+                self.freed.clone(),
+                self.freed_ref_counts.clone(),
+            ),
             GcObjectType::JsObject,
         );
         assert_eq!(reference.0, id);
@@ -258,11 +269,26 @@ fn external_ref_to_cycle_entry_survives_gc() {
 
     // Holder keeps the cycle entry alive through GC.
     assert!(heap.gc.exists(nodes[0]));
+    assert!(heap.gc.exists(nodes[1]));
     assert!(heap.gc.exists(holder));
 
     heap.gc.free(holder);
     heap.gc.run_gc();
     assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+
+#[test]
+fn self_cycle_finalizer_runs_after_edges_are_released() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    heap.link(a, a);
+    heap.gc.free(a);
+
+    heap.gc.run_gc();
+
+    assert_eq!(heap.freed_ref_counts.borrow().get(&a.0).copied(), Some(0));
+    assert!(!heap.gc.exists(a));
 }
 
 #[test]

--- a/gc/gc_test.rs
+++ b/gc/gc_test.rs
@@ -1,0 +1,301 @@
+use crate::{
+    GcHeap,
+    GcObject,
+    GcObjectType,
+    GcRef,
+    MarkFunc,
+};
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+type EdgeMap = Rc<RefCell<HashMap<usize, Vec<GcRef>>>>;
+
+struct TestNode {
+    id: usize,
+    edges: EdgeMap,
+    freed: Rc<Cell<bool>>,
+}
+
+impl TestNode {
+    fn new(id: usize, edges: EdgeMap, freed: Rc<Cell<bool>>) -> Self {
+        TestNode {
+            id,
+            edges,
+            freed,
+        }
+    }
+}
+
+impl GcObject for TestNode {
+    fn trace(&self, visit: &mut dyn FnMut(crate::GcId)) {
+        let edges = self.edges.borrow();
+        if let Some(children) = edges.get(&self.id) {
+            for child in children {
+                visit(child.0);
+            }
+        }
+    }
+
+    fn on_free(&mut self, _rt: &mut crate::GcRuntime) {
+        self.freed.set(true);
+    }
+}
+
+struct TestHeap {
+    gc: GcHeap,
+    edges: EdgeMap,
+    freed: Rc<Cell<bool>>,
+}
+
+impl TestHeap {
+    fn new() -> Self {
+        TestHeap {
+            gc: GcHeap::new(),
+            edges: Rc::new(RefCell::new(HashMap::new())),
+            freed: Rc::new(Cell::new(false)),
+        }
+    }
+
+    fn alloc(&mut self) -> GcRef {
+        let id = if let Some(&id) = self.gc.runtime().free_slots_for_test().first() {
+            id
+        } else {
+            self.gc.runtime().object_len_for_test()
+        };
+        let reference = self.gc.alloc(
+            TestNode::new(id, self.edges.clone(), self.freed.clone()),
+            GcObjectType::JsObject,
+        );
+        assert_eq!(reference.0, id);
+        self.edges.borrow_mut().insert(id, Vec::new());
+        reference
+    }
+
+    fn link(&mut self, from: GcRef, to: GcRef) {
+        self.gc.dup(to);
+        self.edges.borrow_mut().entry(from.0).or_default().push(to);
+    }
+
+    fn make_cycle(&mut self, size: usize) -> Vec<GcRef> {
+        let nodes: Vec<GcRef> = (0..size).map(|_| self.alloc()).collect();
+        for i in 0..size {
+            let next = nodes[(i + 1) % size];
+            self.link(nodes[i], next);
+        }
+        nodes
+    }
+
+    fn drop_external_refs(&mut self, ids: &[GcRef]) {
+        for &id in ids {
+            self.gc.free(id);
+        }
+    }
+}
+
+#[test]
+fn refcount_frees_immediately_without_gc() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    assert!(heap.gc.exists(a));
+    heap.gc.free(a);
+    assert!(!heap.gc.exists(a));
+}
+
+#[test]
+fn dup_extends_lifetime() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    let _b = heap.gc.dup(a);
+    heap.gc.free(a);
+    assert!(heap.gc.exists(a));
+    heap.gc.free(a);
+    assert!(!heap.gc.exists(a));
+}
+
+#[test]
+fn collects_simple_cycle() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+    heap.drop_external_refs(&nodes);
+
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+
+#[test]
+fn cycle_with_external_root_survives() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+
+    let root = heap.gc.dup(nodes[0]);
+    heap.gc.run_gc();
+
+    assert!(heap.gc.exists(nodes[0]));
+    assert!(heap.gc.exists(nodes[1]));
+
+    heap.gc.free(root);
+    heap.drop_external_refs(&nodes);
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+
+#[test]
+fn self_cycle_collected() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    heap.link(a, a);
+    heap.gc.free(a);
+
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(a));
+}
+
+#[test]
+fn three_node_cycle_collected() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(3);
+    heap.drop_external_refs(&nodes);
+
+    heap.gc.run_gc();
+    for &id in &nodes {
+        assert!(!heap.gc.exists(id));
+    }
+}
+
+#[test]
+fn ref_counted_freed_without_gc() {
+    let mut gc = GcHeap::new();
+    let freed = Rc::new(Cell::new(false));
+    let flag = freed.clone();
+    let id = gc.runtime_mut().add_ref_counted(move |_| {
+        flag.set(true);
+    });
+    let dup = gc.runtime_mut().dup_ref_counted(id);
+    gc.runtime_mut().free_ref_counted(id);
+    assert!(!freed.get());
+    gc.runtime_mut().free_ref_counted(dup);
+    assert!(freed.get());
+}
+
+#[test]
+fn trigger_gc_on_threshold() {
+    let mut heap = TestHeap::new();
+    heap.gc.set_gc_threshold(0);
+
+    let nodes = heap.make_cycle(2);
+    heap.drop_external_refs(&nodes);
+
+    heap.gc.trigger_gc(1);
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+
+#[test]
+fn mark_func_decref_zeros_isolated_cycle() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+    heap.drop_external_refs(&nodes);
+
+    for &id in &nodes {
+        heap.gc.mark_children(id, MarkFunc::Decref);
+        heap.gc.header_mut(id).mark = 1;
+    }
+
+    assert_eq!(heap.gc.ref_count(nodes[0]), 0);
+    assert_eq!(heap.gc.ref_count(nodes[1]), 0);
+}
+
+#[test]
+fn four_node_cycle_collected() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(4);
+    heap.drop_external_refs(&nodes);
+    heap.gc.run_gc();
+    for &id in &nodes {
+        assert!(!heap.gc.exists(id));
+    }
+}
+
+#[test]
+fn acyclic_graph_freed_without_gc() {
+    let mut heap = TestHeap::new();
+    let c = heap.alloc();
+    let b = heap.alloc();
+    heap.link(b, c);
+    let a = heap.alloc();
+    heap.link(a, b);
+
+    heap.drop_external_refs(&[a, b, c]);
+    assert!(!heap.gc.exists(a));
+    assert!(!heap.gc.exists(b));
+    assert!(!heap.gc.exists(c));
+}
+
+#[test]
+fn on_free_called_when_collected() {
+    let mut heap = TestHeap::new();
+    let a = heap.alloc();
+    assert!(!heap.freed.get());
+    heap.gc.free(a);
+    assert!(heap.freed.get());
+    assert!(!heap.gc.exists(a));
+}
+
+#[test]
+fn external_ref_to_cycle_entry_survives_gc() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+    let holder = heap.alloc();
+    heap.link(holder, nodes[0]);
+
+    heap.gc.free(nodes[0]);
+    heap.gc.free(nodes[1]);
+
+    heap.gc.run_gc();
+
+    // Holder keeps the cycle entry alive through GC.
+    assert!(heap.gc.exists(nodes[0]));
+    assert!(heap.gc.exists(holder));
+
+    heap.gc.free(holder);
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(nodes[0]));
+}
+
+#[test]
+fn acyclic_holder_extends_child_lifetime() {
+    let mut heap = TestHeap::new();
+    let child = heap.alloc();
+    let holder = heap.alloc();
+    heap.link(holder, child);
+
+    heap.gc.free(child);
+    assert!(heap.gc.exists(child));
+
+    heap.gc.free(holder);
+    assert!(!heap.gc.exists(child));
+}
+
+#[test]
+fn repeated_gc_is_idempotent() {
+    let mut heap = TestHeap::new();
+    let nodes = heap.make_cycle(2);
+    heap.drop_external_refs(&nodes);
+
+    heap.gc.run_gc();
+    heap.gc.run_gc();
+    assert!(!heap.gc.exists(nodes[0]));
+    assert!(!heap.gc.exists(nodes[1]));
+}
+
+#[test]
+fn malloc_state_tracks_allocations() {
+    let mut heap = TestHeap::new();
+    let before = heap.gc.malloc_state().malloc_count;
+    let a = heap.alloc();
+    assert!(heap.gc.malloc_state().malloc_count > before);
+    heap.gc.free(a);
+}

--- a/gc/gc_test.rs
+++ b/gc/gc_test.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 type EdgeMap = Rc<RefCell<HashMap<usize, Vec<GcRef>>>>;
 
 struct TestNode {
-    id: usize,
+    id: Rc<Cell<Option<usize>>>,
     edges: EdgeMap,
     freed: Rc<Cell<bool>>,
     freed_ref_counts: Rc<RefCell<HashMap<usize, i32>>>,
@@ -14,7 +14,7 @@ struct TestNode {
 
 impl TestNode {
     fn new(
-        id: usize,
+        id: Rc<Cell<Option<usize>>>,
         edges: EdgeMap,
         freed: Rc<Cell<bool>>,
         freed_ref_counts: Rc<RefCell<HashMap<usize, i32>>>,
@@ -30,8 +30,11 @@ impl TestNode {
 
 impl GcObject for TestNode {
     fn trace(&self, visit: &mut dyn FnMut(crate::GcId)) {
+        let Some(id) = self.id.get() else {
+            return;
+        };
         let edges = self.edges.borrow();
-        if let Some(children) = edges.get(&self.id) {
+        if let Some(children) = edges.get(&id) {
             for child in children {
                 visit(child.0);
             }
@@ -39,9 +42,12 @@ impl GcObject for TestNode {
     }
 
     fn on_free(&mut self, rt: &mut crate::GcRuntime) {
+        let Some(id) = self.id.get() else {
+            return;
+        };
         self.freed_ref_counts
             .borrow_mut()
-            .insert(self.id, rt.ref_count(self.id));
+            .insert(id, rt.ref_count(id));
         self.freed.set(true);
     }
 }
@@ -64,22 +70,18 @@ impl TestHeap {
     }
 
     fn alloc(&mut self) -> GcRef {
-        let id = if let Some(&id) = self.gc.runtime().free_slots_for_test().first() {
-            id
-        } else {
-            self.gc.runtime().object_len_for_test()
-        };
+        let id = Rc::new(Cell::new(None));
         let reference = self.gc.alloc(
             TestNode::new(
-                id,
+                id.clone(),
                 self.edges.clone(),
                 self.freed.clone(),
                 self.freed_ref_counts.clone(),
             ),
             GcObjectType::MonkeyObject,
         );
-        assert_eq!(reference.0, id);
-        self.edges.borrow_mut().insert(id, Vec::new());
+        id.set(Some(reference.0));
+        self.edges.borrow_mut().insert(reference.0, Vec::new());
         reference
     }
 

--- a/gc/header.rs
+++ b/gc/header.rs
@@ -6,7 +6,7 @@ pub enum GcObjectType {
     Shape,
     VarRef,
     AsyncFunction,
-    JsContext,
+    MonkeyContext,
 }
 
 /// Reentrancy guard during cascade free and cycle removal.

--- a/gc/header.rs
+++ b/gc/header.rs
@@ -18,6 +18,14 @@ pub enum GcPhase {
     RemoveCycles,
 }
 
+/// Which intrusive GC list currently owns an object. Each object is on at most one list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GcListKind {
+    GcObj,
+    Tmp,
+    ZeroRef,
+}
+
 /// Header shared by all cycle-GC'd objects.
 /// Matches QuickJS `JSGCObjectHeader`.
 #[derive(Debug, Clone)]
@@ -28,6 +36,7 @@ pub struct GcObjectHeader {
     pub mark: u8,
     /// Zombie detection during cycle free, inspired by QuickJS `free_mark`.
     pub free_mark: bool,
+    pub list_kind: Option<GcListKind>,
     pub list_prev: Option<GcId>,
     pub list_next: Option<GcId>,
 }
@@ -49,6 +58,7 @@ impl GcObjectHeader {
             gc_obj_type,
             mark: 0,
             free_mark: false,
+            list_kind: None,
             list_prev: None,
             list_next: None,
         }

--- a/gc/header.rs
+++ b/gc/header.rs
@@ -1,7 +1,7 @@
-/// GC object type tags, matching QuickJS `JSGCObjectTypeEnum`.
+/// GC object type tags, adapted from QuickJS `JSGCObjectTypeEnum`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GcObjectType {
-    JsObject,
+    MonkeyObject,
     FunctionBytecode,
     Shape,
     VarRef,
@@ -26,7 +26,7 @@ pub struct GcObjectHeader {
     pub gc_obj_type: GcObjectType,
     /// GC-phase flag (not a permanent mark bit). Set to 1 after `gc_decref` processes the object.
     pub mark: u8,
-    /// Zombie detection during cycle free, like QuickJS `JSObject.free_mark`.
+    /// Zombie detection during cycle free, inspired by QuickJS `free_mark`.
     pub free_mark: bool,
     pub list_prev: Option<GcId>,
     pub list_next: Option<GcId>,

--- a/gc/header.rs
+++ b/gc/header.rs
@@ -1,0 +1,62 @@
+/// GC object type tags, matching QuickJS `JSGCObjectTypeEnum`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GcObjectType {
+    JsObject,
+    FunctionBytecode,
+    Shape,
+    VarRef,
+    AsyncFunction,
+    JsContext,
+}
+
+/// Reentrancy guard during cascade free and cycle removal.
+/// Matches QuickJS `JSGCPhaseEnum`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GcPhase {
+    None,
+    Decref,
+    RemoveCycles,
+}
+
+/// Header shared by all cycle-GC'd objects.
+/// Matches QuickJS `JSGCObjectHeader`.
+#[derive(Debug, Clone)]
+pub struct GcObjectHeader {
+    pub ref_count: i32,
+    pub gc_obj_type: GcObjectType,
+    /// GC-phase flag (not a permanent mark bit). Set to 1 after `gc_decref` processes the object.
+    pub mark: u8,
+    /// Zombie detection during cycle free, like QuickJS `JSObject.free_mark`.
+    pub free_mark: bool,
+    pub list_prev: Option<GcId>,
+    pub list_next: Option<GcId>,
+}
+
+/// Header for simple refcounted values (strings, bigints, etc.) that are not cycle-collected.
+/// Matches QuickJS `JSRefCountHeader`.
+#[derive(Debug, Clone)]
+pub struct RefCountHeader {
+    pub ref_count: i32,
+}
+
+pub type GcId = usize;
+pub type RefCountId = usize;
+
+impl GcObjectHeader {
+    pub fn new(gc_obj_type: GcObjectType, ref_count: i32) -> Self {
+        GcObjectHeader {
+            ref_count,
+            gc_obj_type,
+            mark: 0,
+            free_mark: false,
+            list_prev: None,
+            list_next: None,
+        }
+    }
+}
+
+impl RefCountHeader {
+    pub fn new(ref_count: i32) -> Self {
+        RefCountHeader { ref_count }
+    }
+}

--- a/gc/header.rs
+++ b/gc/header.rs
@@ -57,6 +57,8 @@ impl GcObjectHeader {
 
 impl RefCountHeader {
     pub fn new(ref_count: i32) -> Self {
-        RefCountHeader { ref_count }
+        RefCountHeader {
+            ref_count,
+        }
     }
 }

--- a/gc/heap.rs
+++ b/gc/heap.rs
@@ -1,0 +1,95 @@
+use crate::header::{GcId, GcObjectType, GcPhase};
+use crate::malloc::MallocState;
+use crate::runtime::{GcObject, GcRuntime, MarkFunc};
+
+/// Opaque handle to a GC-managed object.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct GcRef(pub GcId);
+
+/// High-level heap API wrapping QuickJS-style `GcRuntime`.
+pub struct GcHeap {
+    rt: GcRuntime,
+}
+
+impl GcHeap {
+    pub fn new() -> Self {
+        GcHeap {
+            rt: GcRuntime::new(),
+        }
+    }
+
+    pub fn malloc_state(&self) -> &MallocState {
+        self.rt.malloc_state()
+    }
+
+    pub fn malloc_state_mut(&mut self) -> &mut MallocState {
+        self.rt.malloc_state_mut()
+    }
+
+    pub fn gc_threshold(&self) -> usize {
+        self.rt.gc_threshold()
+    }
+
+    pub fn set_gc_threshold(&mut self, threshold: usize) {
+        self.rt.set_gc_threshold(threshold);
+    }
+
+    pub fn gc_phase(&self) -> GcPhase {
+        self.rt.gc_phase()
+    }
+
+    pub fn alloc<O: GcObject>(&mut self, object: O, ty: GcObjectType) -> GcRef {
+        self.trigger_gc(std::mem::size_of::<O>());
+        GcRef(self.rt.add_gc_object(Box::new(object), ty))
+    }
+
+    pub fn dup(&mut self, reference: GcRef) -> GcRef {
+        GcRef(self.rt.dup_gc(reference.0))
+    }
+
+    pub fn free(&mut self, reference: GcRef) {
+        self.rt.free_gc(reference.0);
+    }
+
+    pub fn run_gc(&mut self) {
+        self.rt.run_gc();
+    }
+
+    pub fn trigger_gc(&mut self, alloc_size: usize) {
+        self.rt.trigger_gc(alloc_size);
+    }
+
+    pub fn is_live(&self, reference: GcRef) -> bool {
+        self.rt.is_live_object(reference.0)
+    }
+
+    pub fn exists(&self, reference: GcRef) -> bool {
+        self.rt.object_exists(reference.0)
+    }
+
+    pub fn ref_count(&self, reference: GcRef) -> i32 {
+        self.rt.ref_count(reference.0)
+    }
+
+    pub fn mark_children(&mut self, reference: GcRef, mark_func: MarkFunc) {
+        self.rt.mark_children(reference.0, mark_func);
+    }
+
+    pub(crate) fn header_mut(&mut self, reference: GcRef) -> &mut crate::header::GcObjectHeader {
+        self.rt.header_mut(reference.0)
+    }
+
+    pub fn runtime(&self) -> &GcRuntime {
+        &self.rt
+    }
+
+    pub fn runtime_mut(&mut self) -> &mut GcRuntime {
+        &mut self.rt
+    }
+}
+
+impl Default for GcHeap {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/gc/lib.rs
+++ b/gc/lib.rs
@@ -15,16 +15,9 @@ pub mod value;
 pub mod vm;
 
 pub use frame::Frame;
+pub use header::{GcId, GcObjectHeader, GcObjectType, GcPhase, RefCountHeader, RefCountId};
 pub use heap::{GcHeap, GcRef};
-pub use header::{
-    GcId,
-    GcObjectHeader,
-    GcObjectType,
-    GcPhase,
-    RefCountHeader,
-    RefCountId,
-};
-pub use malloc::{DEFAULT_GC_THRESHOLD, MALLOC_OVERHEAD, MallocState};
+pub use malloc::{MallocState, DEFAULT_GC_THRESHOLD, MALLOC_OVERHEAD};
 pub use runtime::{GcObject, GcRuntime, MarkFunc};
 pub use value::{export_object, import_object, GcClosure, Value};
 pub use vm::GcVM;
@@ -44,7 +37,8 @@ pub fn eval(program: &Node) -> Result<Object, String> {
     let bytecode = compile(program)?;
     let mut vm = GcVM::new(bytecode);
     vm.run();
-    vm.export_last_result().ok_or_else(|| "no result on stack".to_string())
+    vm.export_last_result()
+        .ok_or_else(|| "no result on stack".to_string())
 }
 
 /// Parse, compile, and execute Monkey source.

--- a/gc/lib.rs
+++ b/gc/lib.rs
@@ -1,0 +1,54 @@
+#[cfg(test)]
+mod gc_test;
+#[cfg(test)]
+mod value_test;
+#[cfg(test)]
+mod vm_test;
+
+pub mod frame;
+pub mod header;
+pub mod heap;
+pub mod list;
+pub mod malloc;
+pub mod runtime;
+pub mod value;
+pub mod vm;
+
+pub use frame::Frame;
+pub use heap::{GcHeap, GcRef};
+pub use header::{
+    GcId,
+    GcObjectHeader,
+    GcObjectType,
+    GcPhase,
+    RefCountHeader,
+    RefCountId,
+};
+pub use malloc::{DEFAULT_GC_THRESHOLD, MALLOC_OVERHEAD, MallocState};
+pub use runtime::{GcObject, GcRuntime, MarkFunc};
+pub use value::{export_object, import_object, GcClosure, Value};
+pub use vm::GcVM;
+
+use compiler::compiler::{Bytecode, Compiler};
+use object::Object;
+use parser::ast::Node;
+
+/// Compile Monkey source using the existing bytecode compiler.
+pub fn compile(program: &Node) -> Result<Bytecode, String> {
+    let mut compiler = Compiler::new();
+    compiler.compile(program)
+}
+
+/// Compile and execute on the GC-backed VM.
+pub fn eval(program: &Node) -> Result<Object, String> {
+    let bytecode = compile(program)?;
+    let mut vm = GcVM::new(bytecode);
+    vm.run();
+    vm.export_last_result().ok_or_else(|| "no result on stack".to_string())
+}
+
+/// Parse, compile, and execute Monkey source.
+pub fn eval_source(source: &str) -> Result<Object, String> {
+    let program = parser::parse(source).map_err(|errors| errors[0].clone())?;
+    eval(&program)
+}

--- a/gc/list.rs
+++ b/gc/list.rs
@@ -1,0 +1,47 @@
+use crate::header::GcId;
+use crate::runtime::GcRuntime;
+
+/// Intrusive doubly-linked list head/tail, indexed by `GcId`.
+/// Rust equivalent of QuickJS `list.h` + embedded `list_head`.
+#[derive(Debug, Default, Clone)]
+pub struct GcList {
+    pub(crate) head: Option<GcId>,
+    pub(crate) tail: Option<GcId>,
+}
+
+impl GcList {
+    pub fn new() -> Self {
+        GcList {
+            head: None,
+            tail: None,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.head.is_none()
+    }
+
+    pub fn head(&self) -> Option<GcId> {
+        self.head
+    }
+
+    pub fn clear(&mut self) {
+        self.head = None;
+        self.tail = None;
+    }
+}
+
+pub struct GcListIter<'a> {
+    pub(crate) rt: &'a GcRuntime,
+    pub(crate) current: Option<GcId>,
+}
+
+impl<'a> Iterator for GcListIter<'a> {
+    type Item = GcId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let id = self.current?;
+        self.current = self.rt.header(id).list_next;
+        Some(id)
+    }
+}

--- a/gc/malloc.rs
+++ b/gc/malloc.rs
@@ -1,0 +1,50 @@
+/// Default GC trigger threshold, matching QuickJS `JS_NewRuntime2`.
+pub const DEFAULT_GC_THRESHOLD: usize = 256 * 1024;
+
+/// Per-allocation accounting overhead, matching QuickJS `MALLOC_OVERHEAD` on non-Apple platforms.
+pub const MALLOC_OVERHEAD: usize = 8;
+
+/// Tracked heap usage, matching QuickJS `JSMallocState`.
+#[derive(Debug, Clone)]
+pub struct MallocState {
+    pub malloc_count: usize,
+    pub malloc_size: usize,
+    pub malloc_limit: usize,
+}
+
+impl Default for MallocState {
+    fn default() -> Self {
+        MallocState {
+            malloc_count: 0,
+            malloc_size: 0,
+            malloc_limit: 0,
+        }
+    }
+}
+
+impl MallocState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_limit(&mut self, limit: usize) {
+        self.malloc_limit = limit;
+    }
+
+    pub fn would_exceed(&self, size: usize) -> bool {
+        if self.malloc_limit == 0 {
+            return false;
+        }
+        self.malloc_size.saturating_add(size) > self.malloc_limit.saturating_sub(1)
+    }
+
+    pub fn record_alloc(&mut self, usable_size: usize) {
+        self.malloc_count += 1;
+        self.malloc_size += usable_size + MALLOC_OVERHEAD;
+    }
+
+    pub fn record_free(&mut self, usable_size: usize) {
+        self.malloc_count = self.malloc_count.saturating_sub(1);
+        self.malloc_size = self.malloc_size.saturating_sub(usable_size + MALLOC_OVERHEAD);
+    }
+}

--- a/gc/malloc.rs
+++ b/gc/malloc.rs
@@ -45,6 +45,8 @@ impl MallocState {
 
     pub fn record_free(&mut self, usable_size: usize) {
         self.malloc_count = self.malloc_count.saturating_sub(1);
-        self.malloc_size = self.malloc_size.saturating_sub(usable_size + MALLOC_OVERHEAD);
+        self.malloc_size = self
+            .malloc_size
+            .saturating_sub(usable_size + MALLOC_OVERHEAD);
     }
 }

--- a/gc/runtime.rs
+++ b/gc/runtime.rs
@@ -371,16 +371,6 @@ impl GcRuntime {
         (entry.object.as_mut()?.as_mut() as &mut dyn Any).downcast_mut()
     }
 
-    #[cfg(test)]
-    pub(crate) fn object_len_for_test(&self) -> GcId {
-        self.objects.len()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn free_slots_for_test(&self) -> &[GcId] {
-        &self.free_slots
-    }
-
     // --- Phase 1: trial deletion ---
 
     fn gc_decref_child(&mut self, id: GcId) {

--- a/gc/runtime.rs
+++ b/gc/runtime.rs
@@ -1,4 +1,6 @@
-use crate::header::{GcId, GcObjectHeader, GcObjectType, GcPhase, RefCountHeader, RefCountId};
+use crate::header::{
+    GcId, GcListKind, GcObjectHeader, GcObjectType, GcPhase, RefCountHeader, RefCountId,
+};
 use crate::list::{GcList, GcListIter};
 use crate::malloc::{MallocState, DEFAULT_GC_THRESHOLD};
 use std::any::Any;
@@ -10,14 +12,6 @@ pub enum MarkFunc {
     Decref,
     ScanIncref,
     ScanIncref2,
-}
-
-/// Which intrusive list a GC object belongs to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GcListKind {
-    GcObj,
-    Tmp,
-    ZeroRef,
 }
 
 /// Trait for objects stored in the GC heap. Implementors expose graph edges via `trace`.
@@ -118,6 +112,12 @@ impl GcRuntime {
 
         {
             let header = self.header_mut(id);
+            assert!(
+                header.list_kind.is_none(),
+                "object already belongs to a GC list: {:?}",
+                header.list_kind
+            );
+            header.list_kind = Some(kind);
             header.list_prev = tail;
             header.list_next = None;
         }
@@ -135,11 +135,9 @@ impl GcRuntime {
     }
 
     fn list_remove(&mut self, kind: GcListKind, id: GcId) {
-        let list_ptr = self.list_ptr(kind);
-        if !self.list_contains(kind, id) {
-            return;
-        }
+        assert_eq!(self.header(id).list_kind, Some(kind), "object is not on the expected GC list");
 
+        let list_ptr = self.list_ptr(kind);
         let (prev, next) = {
             let header = self.header(id);
             (header.list_prev, header.list_next)
@@ -160,34 +158,30 @@ impl GcRuntime {
         }
 
         let header = self.header_mut(id);
+        header.list_kind = None;
         header.list_prev = None;
         header.list_next = None;
     }
 
-    fn list_contains(&self, kind: GcListKind, id: GcId) -> bool {
-        let head = match kind {
-            GcListKind::GcObj => self.gc_obj_list.head,
-            GcListKind::Tmp => self.tmp_obj_list.head,
-            GcListKind::ZeroRef => self.gc_zero_ref_count_list.head,
-        };
-        GcListIter {
-            rt: self,
-            current: head,
-        }
-        .any(|x| x == id)
+    fn list_remove_current(&mut self, id: GcId) {
+        let kind = self
+            .header(id)
+            .list_kind
+            .expect("object is not on a GC list");
+        self.list_remove(kind, id);
     }
 
-    fn list_to_vec(&self, kind: GcListKind) -> Vec<GcId> {
-        let head = match kind {
-            GcListKind::GcObj => self.gc_obj_list.head,
-            GcListKind::Tmp => self.tmp_obj_list.head,
-            GcListKind::ZeroRef => self.gc_zero_ref_count_list.head,
-        };
-        GcListIter {
-            rt: self,
-            current: head,
-        }
-        .collect()
+    fn list_move(&mut self, from: GcListKind, to: GcListKind, id: GcId) {
+        self.list_remove(from, id);
+        self.list_push_back(to, id);
+    }
+
+    fn list_move_current_to(&mut self, to: GcListKind, id: GcId) {
+        let from = self
+            .header(id)
+            .list_kind
+            .expect("object is not on a GC list");
+        self.list_move(from, to, id);
     }
 
     fn alloc_slot(&mut self, entry: GcObjectEntry) -> GcId {
@@ -245,8 +239,7 @@ impl GcRuntime {
         }
 
         if self.gc_phase != GcPhase::RemoveCycles {
-            self.list_remove(GcListKind::GcObj, id);
-            self.list_push_back(GcListKind::ZeroRef, id);
+            self.list_move(GcListKind::GcObj, GcListKind::ZeroRef, id);
             if self.gc_phase == GcPhase::None {
                 self.free_zero_refcount();
             }
@@ -311,19 +304,21 @@ impl GcRuntime {
 
     /// Traverse children of a GC object. Matches QuickJS `mark_children`.
     pub fn mark_children(&mut self, id: GcId, mark_func: MarkFunc) {
-        let mut child_ids = Vec::new();
-        {
-            let object = self.objects[id]
-                .as_ref()
-                .expect("invalid GcId")
-                .object
-                .as_ref()
-                .expect("object already finalized");
-            object.trace(&mut |child| child_ids.push(child));
-        }
-        for child in child_ids {
+        // Move the box out temporarily so `trace` can call back into the runtime without
+        // materializing a child-id buffer.
+        let object = self.objects[id]
+            .as_mut()
+            .expect("invalid GcId")
+            .object
+            .take()
+            .expect("object already finalized");
+        object.trace(&mut |child| {
             self.mark_gc_header(child, mark_func);
-        }
+        });
+        self.objects[id]
+            .as_mut()
+            .expect("object freed while tracing")
+            .object = Some(object);
     }
 
     /// Maybe run GC when tracked malloc exceeds threshold. Matches `js_trigger_gc`.
@@ -377,22 +372,25 @@ impl GcRuntime {
         assert!(self.header(id).ref_count > 0);
         self.header_mut(id).ref_count -= 1;
         if self.header(id).ref_count == 0 && self.header(id).mark == 1 {
-            self.list_remove(GcListKind::GcObj, id);
-            self.list_push_back(GcListKind::Tmp, id);
+            self.list_move(GcListKind::GcObj, GcListKind::Tmp, id);
         }
     }
 
     fn gc_decref(&mut self) {
-        self.tmp_obj_list.clear();
-        let ids = self.list_to_vec(GcListKind::GcObj);
-        for id in ids {
+        assert!(
+            self.tmp_obj_list.is_empty(),
+            "temporary GC list must be empty before trial deletion"
+        );
+        let mut current = self.gc_obj_list.head;
+        while let Some(id) = current {
+            let next = self.header(id).list_next;
             assert_eq!(self.header(id).mark, 0);
             self.mark_children(id, MarkFunc::Decref);
             self.header_mut(id).mark = 1;
             if self.header(id).ref_count == 0 {
-                self.list_remove(GcListKind::GcObj, id);
-                self.list_push_back(GcListKind::Tmp, id);
+                self.list_move(GcListKind::GcObj, GcListKind::Tmp, id);
             }
+            current = next;
         }
     }
 
@@ -401,8 +399,7 @@ impl GcRuntime {
     fn gc_scan_incref_child(&mut self, id: GcId) {
         self.header_mut(id).ref_count += 1;
         if self.header(id).ref_count == 1 {
-            self.list_remove(GcListKind::Tmp, id);
-            self.list_push_back(GcListKind::GcObj, id);
+            self.list_move(GcListKind::Tmp, GcListKind::GcObj, id);
             self.header_mut(id).mark = 0;
         }
     }
@@ -420,9 +417,11 @@ impl GcRuntime {
             current = self.header(id).list_next;
         }
 
-        let tmp_ids = self.list_to_vec(GcListKind::Tmp);
-        for id in tmp_ids {
+        let mut current = self.tmp_obj_list.head;
+        while let Some(id) = current {
+            let next = self.header(id).list_next;
             self.mark_children(id, MarkFunc::ScanIncref2);
+            current = next;
         }
     }
 
@@ -443,28 +442,23 @@ impl GcRuntime {
                     self.free_gc_object(id);
                 }
                 _ => {
-                    self.list_remove(GcListKind::Tmp, id);
-                    self.list_push_back(GcListKind::ZeroRef, id);
+                    self.list_move(GcListKind::Tmp, GcListKind::ZeroRef, id);
                 }
             }
         }
 
         self.gc_phase = GcPhase::None;
 
-        let deferred = self.list_to_vec(GcListKind::ZeroRef);
-        for id in deferred {
+        while let Some(id) = self.gc_zero_ref_count_list.head {
             let ty = self.header(id).gc_obj_type;
             assert!(
                 ty == GcObjectType::MonkeyObject || ty == GcObjectType::FunctionBytecode,
                 "unexpected deferred type: {:?}",
                 ty
             );
-            self.list_remove(GcListKind::GcObj, id);
-            self.list_remove(GcListKind::Tmp, id);
-            self.list_remove(GcListKind::ZeroRef, id);
+            self.list_remove_current(id);
             self.free_slot(id);
         }
-        self.gc_zero_ref_count_list.clear();
     }
 
     fn free_zero_refcount(&mut self) {
@@ -490,47 +484,29 @@ impl GcRuntime {
         }
     }
 
-    fn list_remove_from_any(&mut self, id: GcId) {
-        self.list_remove(GcListKind::GcObj, id);
-        self.list_remove(GcListKind::Tmp, id);
-        self.list_remove(GcListKind::ZeroRef, id);
-    }
-
     fn free_heap_object(&mut self, id: GcId) {
         self.header_mut(id).free_mark = true;
 
-        let child_ids = {
-            let object = self.objects[id]
-                .as_ref()
-                .expect("invalid GcId")
-                .object
-                .as_ref()
-                .expect("object already finalized");
-            let mut child_ids = Vec::new();
-            object.trace(&mut |child| child_ids.push(child));
-            child_ids
-        };
-
-        for child in child_ids {
-            self.free_gc(child);
-        }
-
+        // Process outgoing edges as `trace` reports them; GC freeing should not allocate
+        // a child snapshot.
         let mut object = self.objects[id]
             .as_mut()
-            .expect("object already freed")
+            .expect("invalid GcId")
             .object
             .take()
             .expect("object already finalized");
+        object.trace(&mut |child| {
+            self.free_gc(child);
+        });
         object.on_free(self);
         drop(object);
 
-        self.list_remove_from_any(id);
-
         let defer_free = self.gc_phase == GcPhase::RemoveCycles && self.header(id).ref_count != 0;
         if !defer_free {
+            self.list_remove_current(id);
             self.free_slot(id);
         } else {
-            self.list_push_back(GcListKind::ZeroRef, id);
+            self.list_move_current_to(GcListKind::ZeroRef, id);
         }
     }
 }

--- a/gc/runtime.rs
+++ b/gc/runtime.rs
@@ -1,0 +1,544 @@
+use crate::header::{
+    GcId,
+    GcObjectHeader,
+    GcObjectType,
+    GcPhase,
+    RefCountHeader,
+    RefCountId,
+};
+use crate::list::{GcList, GcListIter};
+use crate::malloc::{DEFAULT_GC_THRESHOLD, MallocState};
+use std::any::Any;
+
+/// Child-mark callback mode used during the three GC phases.
+/// Matches QuickJS `gc_decref_child`, `gc_scan_incref_child`, `gc_scan_incref_child2`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkFunc {
+    Decref,
+    ScanIncref,
+    ScanIncref2,
+}
+
+/// Which intrusive list a GC object belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GcListKind {
+    GcObj,
+    Tmp,
+    ZeroRef,
+}
+
+/// Trait for objects stored in the GC heap. Implementors expose graph edges via `trace`.
+pub trait GcObject: Any {
+    fn trace(&self, visit: &mut dyn FnMut(GcId));
+    fn on_free(&mut self, _rt: &mut GcRuntime) {}
+}
+
+struct GcObjectEntry {
+    header: GcObjectHeader,
+    object: Box<dyn GcObject>,
+}
+
+struct RefCountEntry {
+    header: RefCountHeader,
+    payload: Box<dyn FnOnce(&mut GcRuntime)>,
+}
+
+/// QuickJS-style runtime heap: reference counting + three-phase cycle removal.
+pub struct GcRuntime {
+    objects: Vec<Option<GcObjectEntry>>,
+    free_slots: Vec<GcId>,
+    ref_counts: Vec<Option<RefCountEntry>>,
+    ref_count_free_slots: Vec<RefCountId>,
+
+    gc_obj_list: GcList,
+    gc_zero_ref_count_list: GcList,
+    tmp_obj_list: GcList,
+    gc_phase: GcPhase,
+    malloc_state: MallocState,
+    malloc_gc_threshold: usize,
+}
+
+impl GcRuntime {
+    pub fn new() -> Self {
+        GcRuntime {
+            objects: Vec::new(),
+            free_slots: Vec::new(),
+            ref_counts: Vec::new(),
+            ref_count_free_slots: Vec::new(),
+            gc_obj_list: GcList::new(),
+            gc_zero_ref_count_list: GcList::new(),
+            tmp_obj_list: GcList::new(),
+            gc_phase: GcPhase::None,
+            malloc_state: MallocState::new(),
+            malloc_gc_threshold: DEFAULT_GC_THRESHOLD,
+        }
+    }
+
+    pub fn malloc_state(&self) -> &MallocState {
+        &self.malloc_state
+    }
+
+    pub fn malloc_state_mut(&mut self) -> &mut MallocState {
+        &mut self.malloc_state
+    }
+
+    pub fn gc_threshold(&self) -> usize {
+        self.malloc_gc_threshold
+    }
+
+    /// `threshold == usize::MAX` disables automatic GC, matching `JS_SetGCThreshold(rt, -1)`.
+    pub fn set_gc_threshold(&mut self, threshold: usize) {
+        self.malloc_gc_threshold = threshold;
+    }
+
+    pub fn gc_phase(&self) -> GcPhase {
+        self.gc_phase
+    }
+
+    pub fn gc_object_count(&self) -> usize {
+        GcListIter {
+            rt: self,
+            current: self.gc_obj_list.head,
+        }
+        .count()
+    }
+
+    pub(crate) fn header(&self, id: GcId) -> &GcObjectHeader {
+        &self.objects[id].as_ref().expect("invalid GcId").header
+    }
+
+    pub(crate) fn header_mut(&mut self, id: GcId) -> &mut GcObjectHeader {
+        &mut self.objects[id].as_mut().expect("invalid GcId").header
+    }
+
+    fn list_ptr(&mut self, kind: GcListKind) -> *mut GcList {
+        (match kind {
+            GcListKind::GcObj => &mut self.gc_obj_list,
+            GcListKind::Tmp => &mut self.tmp_obj_list,
+            GcListKind::ZeroRef => &mut self.gc_zero_ref_count_list,
+        }) as *mut GcList
+    }
+
+    fn list_push_back(&mut self, kind: GcListKind, id: GcId) {
+        let list_ptr = self.list_ptr(kind);
+        let tail = unsafe { (*list_ptr).tail };
+
+        {
+            let header = self.header_mut(id);
+            header.list_prev = tail;
+            header.list_next = None;
+        }
+
+        if let Some(tail_id) = tail {
+            self.header_mut(tail_id).list_next = Some(id);
+        } else {
+            unsafe {
+                (*list_ptr).head = Some(id);
+            }
+        }
+        unsafe {
+            (*list_ptr).tail = Some(id);
+        }
+    }
+
+    fn list_remove(&mut self, kind: GcListKind, id: GcId) {
+        let list_ptr = self.list_ptr(kind);
+        if !self.list_contains(kind, id) {
+            return;
+        }
+
+        let (prev, next) = {
+            let header = self.header(id);
+            (header.list_prev, header.list_next)
+        };
+
+        match prev {
+            Some(p) => self.header_mut(p).list_next = next,
+            None => unsafe {
+                (*list_ptr).head = next;
+            },
+        }
+
+        match next {
+            Some(n) => self.header_mut(n).list_prev = prev,
+            None => unsafe {
+                (*list_ptr).tail = prev;
+            },
+        }
+
+        let header = self.header_mut(id);
+        header.list_prev = None;
+        header.list_next = None;
+    }
+
+    fn list_contains(&self, kind: GcListKind, id: GcId) -> bool {
+        let head = match kind {
+            GcListKind::GcObj => self.gc_obj_list.head,
+            GcListKind::Tmp => self.tmp_obj_list.head,
+            GcListKind::ZeroRef => self.gc_zero_ref_count_list.head,
+        };
+        GcListIter {
+            rt: self,
+            current: head,
+        }
+        .any(|x| x == id)
+    }
+
+    fn list_to_vec(&self, kind: GcListKind) -> Vec<GcId> {
+        let head = match kind {
+            GcListKind::GcObj => self.gc_obj_list.head,
+            GcListKind::Tmp => self.tmp_obj_list.head,
+            GcListKind::ZeroRef => self.gc_zero_ref_count_list.head,
+        };
+        GcListIter {
+            rt: self,
+            current: head,
+        }
+        .collect()
+    }
+
+    fn alloc_slot(&mut self, entry: GcObjectEntry) -> GcId {
+        let id = if let Some(id) = self.free_slots.pop() {
+            self.objects[id] = Some(entry);
+            id
+        } else {
+            let id = self.objects.len();
+            self.objects.push(Some(entry));
+            id
+        };
+        self.malloc_state
+            .record_alloc(std::mem::size_of::<GcObjectEntry>());
+        id
+    }
+
+    fn free_slot(&mut self, id: GcId) {
+        self.malloc_state
+            .record_free(std::mem::size_of::<GcObjectEntry>());
+        self.objects[id] = None;
+        self.free_slots.push(id);
+    }
+
+    /// Register a new GC object with `ref_count = 1` on `gc_obj_list`.
+    /// Matches QuickJS `add_gc_object`.
+    pub fn add_gc_object(
+        &mut self,
+        object: Box<dyn GcObject>,
+        gc_obj_type: GcObjectType,
+    ) -> GcId {
+        let id = self.alloc_slot(GcObjectEntry {
+            header: GcObjectHeader::new(gc_obj_type, 1),
+            object,
+        });
+        self.list_push_back(GcListKind::GcObj, id);
+        id
+    }
+
+    /// Increment refcount. Matches QuickJS `js_dup` for GC objects.
+    pub fn dup_gc(&mut self, id: GcId) -> GcId {
+        self.header_mut(id).ref_count += 1;
+        id
+    }
+
+    /// Decrement refcount and free when it reaches zero.
+    /// Matches QuickJS `JS_FreeValueRT` for GC objects.
+    pub fn free_gc(&mut self, id: GcId) {
+        if !self.object_exists(id) {
+            return;
+        }
+        let ref_count = {
+            let header = self.header_mut(id);
+            header.ref_count -= 1;
+            header.ref_count
+        };
+
+        if ref_count > 0 {
+            return;
+        }
+
+        if self.gc_phase != GcPhase::RemoveCycles {
+            self.list_remove(GcListKind::GcObj, id);
+            self.list_push_back(GcListKind::ZeroRef, id);
+            if self.gc_phase == GcPhase::None {
+                self.free_zero_refcount();
+            }
+        }
+    }
+
+    /// Allocate a simple refcounted payload (strings, etc.). Not cycle-collected.
+    pub fn add_ref_counted<F>(&mut self, on_free: F) -> RefCountId
+    where
+        F: FnOnce(&mut GcRuntime) + 'static,
+    {
+        let entry = RefCountEntry {
+            header: RefCountHeader::new(1),
+            payload: Box::new(on_free),
+        };
+        let id = if let Some(id) = self.ref_count_free_slots.pop() {
+            self.ref_counts[id] = Some(entry);
+            id
+        } else {
+            let id = self.ref_counts.len();
+            self.ref_counts.push(Some(entry));
+            id
+        };
+        self.malloc_state
+            .record_alloc(std::mem::size_of::<RefCountEntry>());
+        id
+    }
+
+    pub fn dup_ref_counted(&mut self, id: RefCountId) -> RefCountId {
+        self.ref_counts[id].as_mut().expect("invalid RefCountId").header.ref_count += 1;
+        id
+    }
+
+    pub fn free_ref_counted(&mut self, id: RefCountId) {
+        let ref_count = {
+            let entry = self.ref_counts[id].as_mut().expect("invalid RefCountId");
+            entry.header.ref_count -= 1;
+            entry.header.ref_count
+        };
+
+        if ref_count <= 0 {
+            let entry = self.ref_counts[id].take().expect("double free");
+            self.malloc_state
+                .record_free(std::mem::size_of::<RefCountEntry>());
+            (entry.payload)(self);
+            self.ref_count_free_slots.push(id);
+        }
+    }
+
+    /// Mark a GC object header during traversal. Matches `JS_MarkValue` for object tags.
+    pub fn mark_gc_header(&mut self, id: GcId, mark_func: MarkFunc) {
+        match mark_func {
+            MarkFunc::Decref => self.gc_decref_child(id),
+            MarkFunc::ScanIncref => self.gc_scan_incref_child(id),
+            MarkFunc::ScanIncref2 => self.gc_scan_incref_child2(id),
+        }
+    }
+
+    /// Traverse children of a GC object. Matches QuickJS `mark_children`.
+    pub fn mark_children(&mut self, id: GcId, mark_func: MarkFunc) {
+        let mut child_ids = Vec::new();
+        {
+            let object = &self.objects[id].as_ref().expect("invalid GcId").object;
+            object.trace(&mut |child| child_ids.push(child));
+        }
+        for child in child_ids {
+            self.mark_gc_header(child, mark_func);
+        }
+    }
+
+    /// Maybe run GC when tracked malloc exceeds threshold. Matches `js_trigger_gc`.
+    pub fn trigger_gc(&mut self, alloc_size: usize) {
+        let force_gc =
+            self.malloc_state.malloc_size.saturating_add(alloc_size) > self.malloc_gc_threshold;
+        if force_gc {
+            self.run_gc();
+            self.malloc_gc_threshold = self.malloc_state.malloc_size
+                + (self.malloc_state.malloc_size >> 1);
+        }
+    }
+
+    /// Run the three-phase cycle collector. Matches `JS_RunGC`.
+    pub fn run_gc(&mut self) {
+        self.gc_decref();
+        self.gc_scan();
+        self.gc_free_cycles();
+    }
+
+    /// Return false if the object has been freed during cycle collection.
+    /// Matches `JS_IsLiveObject`.
+    pub fn is_live_object(&self, id: GcId) -> bool {
+        self.objects
+            .get(id)
+            .and_then(|o| o.as_ref())
+            .map_or(false, |e| !e.header.free_mark)
+    }
+
+    pub fn ref_count(&self, id: GcId) -> i32 {
+        self.header(id).ref_count
+    }
+
+    pub fn object_exists(&self, id: GcId) -> bool {
+        self.objects.get(id).and_then(|o| o.as_ref()).is_some()
+    }
+
+    pub fn object_downcast<T: GcObject>(&self, id: GcId) -> Option<&T> {
+        let entry = self.objects.get(id)?.as_ref()?;
+        (entry.object.as_ref() as &dyn Any).downcast_ref()
+    }
+
+    pub fn object_downcast_mut<T: GcObject>(&mut self, id: GcId) -> Option<&mut T> {
+        let entry = self.objects.get_mut(id)?.as_mut()?;
+        (entry.object.as_mut() as &mut dyn Any).downcast_mut()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn object_len_for_test(&self) -> GcId {
+        self.objects.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn free_slots_for_test(&self) -> &[GcId] {
+        &self.free_slots
+    }
+
+    // --- Phase 1: trial deletion ---
+
+    fn gc_decref_child(&mut self, id: GcId) {
+        assert!(self.header(id).ref_count > 0);
+        self.header_mut(id).ref_count -= 1;
+        if self.header(id).ref_count == 0 && self.header(id).mark == 1 {
+            self.list_remove(GcListKind::GcObj, id);
+            self.list_push_back(GcListKind::Tmp, id);
+        }
+    }
+
+    fn gc_decref(&mut self) {
+        self.tmp_obj_list.clear();
+        let ids = self.list_to_vec(GcListKind::GcObj);
+        for id in ids {
+            assert_eq!(self.header(id).mark, 0);
+            self.mark_children(id, MarkFunc::Decref);
+            self.header_mut(id).mark = 1;
+            if self.header(id).ref_count == 0 {
+                self.list_remove(GcListKind::GcObj, id);
+                self.list_push_back(GcListKind::Tmp, id);
+            }
+        }
+    }
+
+    // --- Phase 2: restore live refs ---
+
+    fn gc_scan_incref_child(&mut self, id: GcId) {
+        self.header_mut(id).ref_count += 1;
+        if self.header(id).ref_count == 1 {
+            self.list_remove(GcListKind::Tmp, id);
+            self.list_push_back(GcListKind::GcObj, id);
+            self.header_mut(id).mark = 0;
+        }
+    }
+
+    fn gc_scan_incref_child2(&mut self, id: GcId) {
+        self.header_mut(id).ref_count += 1;
+    }
+
+    fn gc_scan(&mut self) {
+        let live_ids = self.list_to_vec(GcListKind::GcObj);
+        for id in live_ids {
+            assert!(self.header(id).ref_count > 0);
+            self.header_mut(id).mark = 0;
+            self.mark_children(id, MarkFunc::ScanIncref);
+        }
+
+        let tmp_ids = self.list_to_vec(GcListKind::Tmp);
+        for id in tmp_ids {
+            self.mark_children(id, MarkFunc::ScanIncref2);
+        }
+    }
+
+    // --- Phase 3: free cyclic garbage ---
+
+    fn gc_free_cycles(&mut self) {
+        self.gc_phase = GcPhase::RemoveCycles;
+
+        loop {
+            let id = self.tmp_obj_list.head;
+            if id.is_none() {
+                break;
+            }
+            let id = id.unwrap();
+            let gc_obj_type = self.header(id).gc_obj_type;
+            match gc_obj_type {
+                GcObjectType::JsObject | GcObjectType::FunctionBytecode => {
+                    self.free_gc_object(id);
+                }
+                _ => {
+                    self.list_remove(GcListKind::Tmp, id);
+                    self.list_push_back(GcListKind::ZeroRef, id);
+                }
+            }
+        }
+
+        self.gc_phase = GcPhase::None;
+
+        let deferred = self.list_to_vec(GcListKind::ZeroRef);
+        for id in deferred {
+            let ty = self.header(id).gc_obj_type;
+            assert!(
+                ty == GcObjectType::JsObject || ty == GcObjectType::FunctionBytecode,
+                "unexpected deferred type: {:?}",
+                ty
+            );
+            self.list_remove(GcListKind::GcObj, id);
+            self.list_remove(GcListKind::Tmp, id);
+            self.list_remove(GcListKind::ZeroRef, id);
+            let mut entry = self.objects[id].take().expect("deferred object missing");
+            entry.object.on_free(self);
+            drop(entry.object);
+            self.free_slot(id);
+        }
+        self.gc_zero_ref_count_list.clear();
+    }
+
+    fn free_zero_refcount(&mut self) {
+        self.gc_phase = GcPhase::Decref;
+        loop {
+            let id = self.gc_zero_ref_count_list.head;
+            if id.is_none() {
+                break;
+            }
+            let id = id.unwrap();
+            assert_eq!(self.header(id).ref_count, 0);
+            self.free_gc_object(id);
+        }
+        self.gc_phase = GcPhase::None;
+    }
+
+    fn free_gc_object(&mut self, id: GcId) {
+        match self.header(id).gc_obj_type {
+            GcObjectType::JsObject | GcObjectType::FunctionBytecode => self.free_js_object(id),
+            other => panic!("free_gc_object: unsupported type {:?}", other),
+        }
+    }
+
+    fn list_remove_from_any(&mut self, id: GcId) {
+        self.list_remove(GcListKind::GcObj, id);
+        self.list_remove(GcListKind::Tmp, id);
+        self.list_remove(GcListKind::ZeroRef, id);
+    }
+
+    fn free_js_object(&mut self, id: GcId) {
+        self.header_mut(id).free_mark = true;
+
+        let child_ids = {
+            let object = &self.objects[id].as_ref().expect("invalid GcId").object;
+            let mut child_ids = Vec::new();
+            object.trace(&mut |child| child_ids.push(child));
+            child_ids
+        };
+
+        self.list_remove_from_any(id);
+
+        let defer_free =
+            self.gc_phase == GcPhase::RemoveCycles && self.header(id).ref_count != 0;
+        if !defer_free {
+            let mut entry = self.objects[id].take().expect("object already freed");
+            entry.object.on_free(self);
+            drop(entry.object);
+            self.free_slot(id);
+        } else {
+            self.list_push_back(GcListKind::ZeroRef, id);
+        }
+
+        for child in child_ids {
+            self.free_gc(child);
+        }
+    }
+}
+
+impl Default for GcRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/gc/runtime.rs
+++ b/gc/runtime.rs
@@ -449,7 +449,7 @@ impl GcRuntime {
             let id = id.unwrap();
             let gc_obj_type = self.header(id).gc_obj_type;
             match gc_obj_type {
-                GcObjectType::JsObject | GcObjectType::FunctionBytecode => {
+                GcObjectType::MonkeyObject | GcObjectType::FunctionBytecode => {
                     self.free_gc_object(id);
                 }
                 _ => {
@@ -465,7 +465,7 @@ impl GcRuntime {
         for id in deferred {
             let ty = self.header(id).gc_obj_type;
             assert!(
-                ty == GcObjectType::JsObject || ty == GcObjectType::FunctionBytecode,
+                ty == GcObjectType::MonkeyObject || ty == GcObjectType::FunctionBytecode,
                 "unexpected deferred type: {:?}",
                 ty
             );
@@ -493,7 +493,9 @@ impl GcRuntime {
 
     fn free_gc_object(&mut self, id: GcId) {
         match self.header(id).gc_obj_type {
-            GcObjectType::JsObject | GcObjectType::FunctionBytecode => self.free_js_object(id),
+            GcObjectType::MonkeyObject | GcObjectType::FunctionBytecode => {
+                self.free_heap_object(id)
+            }
             other => panic!("free_gc_object: unsupported type {:?}", other),
         }
     }
@@ -504,7 +506,7 @@ impl GcRuntime {
         self.list_remove(GcListKind::ZeroRef, id);
     }
 
-    fn free_js_object(&mut self, id: GcId) {
+    fn free_heap_object(&mut self, id: GcId) {
         self.header_mut(id).free_mark = true;
 
         let child_ids = {

--- a/gc/runtime.rs
+++ b/gc/runtime.rs
@@ -1,13 +1,6 @@
-use crate::header::{
-    GcId,
-    GcObjectHeader,
-    GcObjectType,
-    GcPhase,
-    RefCountHeader,
-    RefCountId,
-};
+use crate::header::{GcId, GcObjectHeader, GcObjectType, GcPhase, RefCountHeader, RefCountId};
 use crate::list::{GcList, GcListIter};
-use crate::malloc::{DEFAULT_GC_THRESHOLD, MallocState};
+use crate::malloc::{MallocState, DEFAULT_GC_THRESHOLD};
 use std::any::Any;
 
 /// Child-mark callback mode used during the three GC phases.
@@ -35,7 +28,7 @@ pub trait GcObject: Any {
 
 struct GcObjectEntry {
     header: GcObjectHeader,
-    object: Box<dyn GcObject>,
+    object: Option<Box<dyn GcObject>>,
 }
 
 struct RefCountEntry {
@@ -220,14 +213,10 @@ impl GcRuntime {
 
     /// Register a new GC object with `ref_count = 1` on `gc_obj_list`.
     /// Matches QuickJS `add_gc_object`.
-    pub fn add_gc_object(
-        &mut self,
-        object: Box<dyn GcObject>,
-        gc_obj_type: GcObjectType,
-    ) -> GcId {
+    pub fn add_gc_object(&mut self, object: Box<dyn GcObject>, gc_obj_type: GcObjectType) -> GcId {
         let id = self.alloc_slot(GcObjectEntry {
             header: GcObjectHeader::new(gc_obj_type, 1),
-            object,
+            object: Some(object),
         });
         self.list_push_back(GcListKind::GcObj, id);
         id
@@ -287,7 +276,11 @@ impl GcRuntime {
     }
 
     pub fn dup_ref_counted(&mut self, id: RefCountId) -> RefCountId {
-        self.ref_counts[id].as_mut().expect("invalid RefCountId").header.ref_count += 1;
+        self.ref_counts[id]
+            .as_mut()
+            .expect("invalid RefCountId")
+            .header
+            .ref_count += 1;
         id
     }
 
@@ -320,7 +313,12 @@ impl GcRuntime {
     pub fn mark_children(&mut self, id: GcId, mark_func: MarkFunc) {
         let mut child_ids = Vec::new();
         {
-            let object = &self.objects[id].as_ref().expect("invalid GcId").object;
+            let object = self.objects[id]
+                .as_ref()
+                .expect("invalid GcId")
+                .object
+                .as_ref()
+                .expect("object already finalized");
             object.trace(&mut |child| child_ids.push(child));
         }
         for child in child_ids {
@@ -334,8 +332,8 @@ impl GcRuntime {
             self.malloc_state.malloc_size.saturating_add(alloc_size) > self.malloc_gc_threshold;
         if force_gc {
             self.run_gc();
-            self.malloc_gc_threshold = self.malloc_state.malloc_size
-                + (self.malloc_state.malloc_size >> 1);
+            self.malloc_gc_threshold =
+                self.malloc_state.malloc_size + (self.malloc_state.malloc_size >> 1);
         }
     }
 
@@ -365,12 +363,12 @@ impl GcRuntime {
 
     pub fn object_downcast<T: GcObject>(&self, id: GcId) -> Option<&T> {
         let entry = self.objects.get(id)?.as_ref()?;
-        (entry.object.as_ref() as &dyn Any).downcast_ref()
+        (entry.object.as_ref()?.as_ref() as &dyn Any).downcast_ref()
     }
 
     pub fn object_downcast_mut<T: GcObject>(&mut self, id: GcId) -> Option<&mut T> {
         let entry = self.objects.get_mut(id)?.as_mut()?;
-        (entry.object.as_mut() as &mut dyn Any).downcast_mut()
+        (entry.object.as_mut()?.as_mut() as &mut dyn Any).downcast_mut()
     }
 
     #[cfg(test)]
@@ -424,11 +422,12 @@ impl GcRuntime {
     }
 
     fn gc_scan(&mut self) {
-        let live_ids = self.list_to_vec(GcListKind::GcObj);
-        for id in live_ids {
+        let mut current = self.gc_obj_list.head;
+        while let Some(id) = current {
             assert!(self.header(id).ref_count > 0);
             self.header_mut(id).mark = 0;
             self.mark_children(id, MarkFunc::ScanIncref);
+            current = self.header(id).list_next;
         }
 
         let tmp_ids = self.list_to_vec(GcListKind::Tmp);
@@ -473,9 +472,6 @@ impl GcRuntime {
             self.list_remove(GcListKind::GcObj, id);
             self.list_remove(GcListKind::Tmp, id);
             self.list_remove(GcListKind::ZeroRef, id);
-            let mut entry = self.objects[id].take().expect("deferred object missing");
-            entry.object.on_free(self);
-            drop(entry.object);
             self.free_slot(id);
         }
         self.gc_zero_ref_count_list.clear();
@@ -512,27 +508,37 @@ impl GcRuntime {
         self.header_mut(id).free_mark = true;
 
         let child_ids = {
-            let object = &self.objects[id].as_ref().expect("invalid GcId").object;
+            let object = self.objects[id]
+                .as_ref()
+                .expect("invalid GcId")
+                .object
+                .as_ref()
+                .expect("object already finalized");
             let mut child_ids = Vec::new();
             object.trace(&mut |child| child_ids.push(child));
             child_ids
         };
 
+        for child in child_ids {
+            self.free_gc(child);
+        }
+
+        let mut object = self.objects[id]
+            .as_mut()
+            .expect("object already freed")
+            .object
+            .take()
+            .expect("object already finalized");
+        object.on_free(self);
+        drop(object);
+
         self.list_remove_from_any(id);
 
-        let defer_free =
-            self.gc_phase == GcPhase::RemoveCycles && self.header(id).ref_count != 0;
+        let defer_free = self.gc_phase == GcPhase::RemoveCycles && self.header(id).ref_count != 0;
         if !defer_free {
-            let mut entry = self.objects[id].take().expect("object already freed");
-            entry.object.on_free(self);
-            drop(entry.object);
             self.free_slot(id);
         } else {
             self.list_push_back(GcListKind::ZeroRef, id);
-        }
-
-        for child in child_ids {
-            self.free_gc(child);
         }
     }
 }

--- a/gc/value.rs
+++ b/gc/value.rs
@@ -69,12 +69,10 @@ impl Value {
 
     pub fn with_owned_edges(self, heap: &mut GcHeap) -> Self {
         match self {
-            Value::Array(items) => {
-                Value::Array(items.into_iter().map(|r| heap.dup(r)).collect())
+            Value::Array(items) => Value::Array(items.into_iter().map(|r| heap.dup(r)).collect()),
+            Value::Hash(map) => {
+                Value::Hash(map.into_iter().map(|(k, v)| (k, heap.dup(v))).collect())
             }
-            Value::Hash(map) => Value::Hash(
-                map.into_iter().map(|(k, v)| (k, heap.dup(v))).collect(),
-            ),
             Value::Closure(mut closure) => {
                 closure.func = heap.dup(closure.func);
                 closure.free = closure.free.into_iter().map(|r| heap.dup(r)).collect();
@@ -82,6 +80,12 @@ impl Value {
             }
             other => other,
         }
+    }
+
+    pub fn edge_refs(&self) -> Vec<GcRef> {
+        let mut refs = Vec::new();
+        self.trace(&mut |reference| refs.push(reference));
+        refs
     }
 }
 
@@ -115,7 +119,12 @@ impl HashKey {
 
 pub fn alloc_value(heap: &mut GcHeap, value: Value) -> GcRef {
     let value = value.with_owned_edges(heap);
-    heap.alloc(ValueCell { value }, GcObjectType::JsObject)
+    heap.alloc(
+        ValueCell {
+            value,
+        },
+        GcObjectType::JsObject,
+    )
 }
 
 pub fn get_value<'a>(heap: &'a GcHeap, reference: GcRef) -> &'a Value {
@@ -206,7 +215,12 @@ pub fn import_object(heap: &mut GcHeap, object: &Object) -> GcRef {
             panic!("interpreter functions cannot be imported into the GC VM")
         }
     };
-    alloc_value(heap, value)
+    let edge_refs = value.edge_refs();
+    let reference = alloc_value(heap, value);
+    for edge in edge_refs {
+        heap.free(edge);
+    }
+    reference
 }
 
 pub fn export_object(heap: &GcHeap, reference: GcRef) -> Object {
@@ -224,12 +238,7 @@ pub fn export_object(heap: &GcHeap, reference: GcRef) -> Object {
         ),
         Value::Hash(map) => Object::Hash(
             map.iter()
-                .map(|(k, v)| {
-                    (
-                        Rc::new(k.to_object()),
-                        Rc::new(export_object(heap, *v)),
-                    )
-                })
+                .map(|(k, v)| (Rc::new(k.to_object()), Rc::new(export_object(heap, *v))))
                 .collect(),
         ),
         Value::CompiledFunction(f) => Object::CompiledFunction(Rc::new(f.clone())),

--- a/gc/value.rs
+++ b/gc/value.rs
@@ -1,0 +1,267 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::rc::Rc;
+
+use crate::header::GcObjectType;
+use crate::{GcHeap, GcObject, GcRef};
+use object::{BuiltinFunc, Closure, CompiledFunction, Object};
+
+/// Runtime value stored in the GC heap. Mirrors `object::Object` but uses `GcRef` edges.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Integer(i64),
+    Boolean(bool),
+    String(String),
+    Array(Vec<GcRef>),
+    Hash(HashMap<HashKey, GcRef>),
+    Null,
+    Error(String),
+    CompiledFunction(CompiledFunction),
+    Closure(GcClosure),
+    Builtin(BuiltinFunc),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcClosure {
+    pub func: GcRef,
+    pub free: Vec<GcRef>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum HashKey {
+    Integer(i64),
+    Boolean(bool),
+    String(String),
+}
+
+pub struct ValueCell {
+    pub value: Value,
+}
+
+impl GcObject for ValueCell {
+    fn trace(&self, visit: &mut dyn FnMut(crate::GcId)) {
+        self.value.trace(&mut |reference| visit(reference.0));
+    }
+}
+
+impl Value {
+    pub fn trace(&self, visit: &mut dyn FnMut(GcRef)) {
+        match self {
+            Value::Array(items) => {
+                for item in items {
+                    visit(*item);
+                }
+            }
+            Value::Hash(map) => {
+                for value in map.values() {
+                    visit(*value);
+                }
+            }
+            Value::Closure(closure) => {
+                visit(closure.func);
+                for free in &closure.free {
+                    visit(*free);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn with_owned_edges(self, heap: &mut GcHeap) -> Self {
+        match self {
+            Value::Array(items) => {
+                Value::Array(items.into_iter().map(|r| heap.dup(r)).collect())
+            }
+            Value::Hash(map) => Value::Hash(
+                map.into_iter().map(|(k, v)| (k, heap.dup(v))).collect(),
+            ),
+            Value::Closure(mut closure) => {
+                closure.func = heap.dup(closure.func);
+                closure.free = closure.free.into_iter().map(|r| heap.dup(r)).collect();
+                Value::Closure(closure)
+            }
+            other => other,
+        }
+    }
+}
+
+impl HashKey {
+    pub fn from_object(object: &Object) -> Option<HashKey> {
+        match object {
+            Object::Integer(i) => Some(HashKey::Integer(*i)),
+            Object::Boolean(b) => Some(HashKey::Boolean(*b)),
+            Object::String(s) => Some(HashKey::String(s.clone())),
+            _ => None,
+        }
+    }
+
+    pub fn from_value(value: &Value) -> Option<HashKey> {
+        match value {
+            Value::Integer(i) => Some(HashKey::Integer(*i)),
+            Value::Boolean(b) => Some(HashKey::Boolean(*b)),
+            Value::String(s) => Some(HashKey::String(s.clone())),
+            _ => None,
+        }
+    }
+
+    pub fn to_object(&self) -> Object {
+        match self {
+            HashKey::Integer(i) => Object::Integer(*i),
+            HashKey::Boolean(b) => Object::Boolean(*b),
+            HashKey::String(s) => Object::String(s.clone()),
+        }
+    }
+}
+
+pub fn alloc_value(heap: &mut GcHeap, value: Value) -> GcRef {
+    let value = value.with_owned_edges(heap);
+    heap.alloc(ValueCell { value }, GcObjectType::JsObject)
+}
+
+pub fn get_value<'a>(heap: &'a GcHeap, reference: GcRef) -> &'a Value {
+    &heap
+        .runtime()
+        .object_downcast::<ValueCell>(reference.0)
+        .expect("invalid value reference")
+        .value
+}
+
+pub fn value_to_string(heap: &GcHeap, reference: GcRef) -> String {
+    format_value(heap, get_value(heap, reference))
+}
+
+fn format_value(heap: &GcHeap, value: &Value) -> String {
+    match value {
+        Value::Integer(i) => i.to_string(),
+        Value::Boolean(b) => b.to_string(),
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        Value::Error(e) => e.clone(),
+        Value::Array(items) => {
+            let parts = items
+                .iter()
+                .map(|item| value_to_string(heap, *item))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("[{}]", parts)
+        }
+        Value::Hash(map) => {
+            let parts = map
+                .iter()
+                .map(|(k, v)| format!("{}: {}", format_hash_key(k), value_to_string(heap, *v)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{{}}}", parts)
+        }
+        Value::CompiledFunction(_) => "[compiled function]".to_string(),
+        Value::Closure(_) => "[closure function]".to_string(),
+        Value::Builtin(_) => "[builtin function]".to_string(),
+    }
+}
+
+fn format_hash_key(key: &HashKey) -> String {
+    match key {
+        HashKey::Integer(i) => i.to_string(),
+        HashKey::Boolean(b) => b.to_string(),
+        HashKey::String(s) => s.clone(),
+    }
+}
+
+pub fn import_object(heap: &mut GcHeap, object: &Object) -> GcRef {
+    let value = match object {
+        Object::Integer(i) => Value::Integer(*i),
+        Object::Boolean(b) => Value::Boolean(*b),
+        Object::String(s) => Value::String(s.clone()),
+        Object::Null => Value::Null,
+        Object::Error(e) => Value::Error(e.clone()),
+        Object::Array(items) => {
+            Value::Array(items.iter().map(|item| import_object(heap, item)).collect())
+        }
+        Object::Hash(map) => Value::Hash(
+            map.iter()
+                .map(|(k, v)| {
+                    (
+                        HashKey::from_object(k).expect("hash key must be hashable"),
+                        import_object(heap, v),
+                    )
+                })
+                .collect(),
+        ),
+        Object::CompiledFunction(f) => Value::CompiledFunction(CompiledFunction {
+            instructions: f.instructions.clone(),
+            num_locals: f.num_locals,
+            num_parameters: f.num_parameters,
+        }),
+        Object::ClosureObj(closure) => Value::Closure(GcClosure {
+            func: import_object(heap, &Object::CompiledFunction(Rc::clone(&closure.func))),
+            free: closure
+                .free
+                .iter()
+                .map(|item| import_object(heap, item))
+                .collect(),
+        }),
+        Object::Builtin(b) => Value::Builtin(*b),
+        Object::ReturnValue(inner) => return import_object(heap, inner),
+        Object::Function(_, _, _) => {
+            panic!("interpreter functions cannot be imported into the GC VM")
+        }
+    };
+    alloc_value(heap, value)
+}
+
+pub fn export_object(heap: &GcHeap, reference: GcRef) -> Object {
+    match get_value(heap, reference) {
+        Value::Integer(i) => Object::Integer(*i),
+        Value::Boolean(b) => Object::Boolean(*b),
+        Value::String(s) => Object::String(s.clone()),
+        Value::Null => Object::Null,
+        Value::Error(e) => Object::Error(e.clone()),
+        Value::Array(items) => Object::Array(
+            items
+                .iter()
+                .map(|item| Rc::new(export_object(heap, *item)))
+                .collect(),
+        ),
+        Value::Hash(map) => Object::Hash(
+            map.iter()
+                .map(|(k, v)| {
+                    (
+                        Rc::new(k.to_object()),
+                        Rc::new(export_object(heap, *v)),
+                    )
+                })
+                .collect(),
+        ),
+        Value::CompiledFunction(f) => Object::CompiledFunction(Rc::new(f.clone())),
+        Value::Closure(closure) => {
+            let func = match get_value(heap, closure.func) {
+                Value::CompiledFunction(f) => Rc::new(f.clone()),
+                _ => panic!("closure func must be compiled function"),
+            };
+            Object::ClosureObj(Closure {
+                func,
+                free: closure
+                    .free
+                    .iter()
+                    .map(|item| Rc::new(export_object(heap, *item)))
+                    .collect(),
+            })
+        }
+        Value::Builtin(b) => Object::Builtin(*b),
+    }
+}
+
+pub fn call_builtin(heap: &mut GcHeap, builtin: BuiltinFunc, args: Vec<GcRef>) -> GcRef {
+    let rc_args = args
+        .iter()
+        .map(|reference| Rc::new(export_object(heap, *reference)))
+        .collect();
+    let result = builtin(rc_args);
+    import_object(heap, &result)
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/gc/value.rs
+++ b/gc/value.rs
@@ -123,7 +123,7 @@ pub fn alloc_value(heap: &mut GcHeap, value: Value) -> GcRef {
         ValueCell {
             value,
         },
-        GcObjectType::JsObject,
+        GcObjectType::MonkeyObject,
     )
 }
 

--- a/gc/value_test.rs
+++ b/gc/value_test.rs
@@ -95,6 +95,38 @@ mod tests {
     }
 
     #[test]
+    fn import_object_releases_temporary_child_refs() {
+        let mut heap = GcHeap::new();
+        let original = Object::Array(vec![Rc::new(Object::Array(vec![
+            Rc::new(Object::Integer(1)),
+            Rc::new(Object::Integer(2)),
+        ]))]);
+
+        let root = import_object(&mut heap, &original);
+        let nested = match get_value(&heap, root) {
+            Value::Array(items) => items[0],
+            other => panic!("expected root array, got {:?}", other),
+        };
+        let leaves = match get_value(&heap, nested) {
+            Value::Array(items) => items.clone(),
+            other => panic!("expected nested array, got {:?}", other),
+        };
+
+        assert_eq!(heap.ref_count(root), 1);
+        assert_eq!(heap.ref_count(nested), 1);
+        for leaf in &leaves {
+            assert_eq!(heap.ref_count(*leaf), 1);
+        }
+
+        heap.free(root);
+        assert!(!heap.exists(root));
+        assert!(!heap.exists(nested));
+        for leaf in leaves {
+            assert!(!heap.exists(leaf));
+        }
+    }
+
+    #[test]
     fn value_cycle_collected_by_gc() {
         let mut heap = GcHeap::new();
         let node_b = alloc_value(&mut heap, Value::Null);

--- a/gc/value_test.rs
+++ b/gc/value_test.rs
@@ -5,7 +5,9 @@ mod tests {
 
     use object::Object;
 
-    use crate::value::{alloc_value, export_object, get_value, import_object, HashKey, Value};
+    use crate::value::{
+        alloc_value, export_object, get_value, import_object, HashKey, Value, ValueCell,
+    };
     use crate::GcHeap;
 
     #[test]
@@ -129,10 +131,19 @@ mod tests {
     #[test]
     fn value_cycle_collected_by_gc() {
         let mut heap = GcHeap::new();
-        let node_b = alloc_value(&mut heap, Value::Null);
-        let node_a = alloc_value(&mut heap, Value::Array(vec![node_b]));
-        heap.free(node_b);
+        let node_a = alloc_value(&mut heap, Value::Array(vec![]));
         let node_b = alloc_value(&mut heap, Value::Array(vec![node_a]));
+
+        let node_b_edge = heap.dup(node_b);
+        match &mut heap
+            .runtime_mut()
+            .object_downcast_mut::<ValueCell>(node_a.0)
+            .expect("node_a should be a ValueCell")
+            .value
+        {
+            Value::Array(items) => items.push(node_b_edge),
+            other => panic!("expected node_a array, got {:?}", other),
+        }
 
         heap.free(node_a);
         heap.free(node_b);

--- a/gc/value_test.rs
+++ b/gc/value_test.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    use object::Object;
+
+    use crate::value::{alloc_value, export_object, get_value, import_object, HashKey, Value};
+    use crate::GcHeap;
+
+    #[test]
+    fn import_export_integer_roundtrip() {
+        let mut heap = GcHeap::new();
+        let original = Object::Integer(42);
+        let reference = import_object(&mut heap, &original);
+        assert_eq!(export_object(&heap, reference), original);
+    }
+
+    #[test]
+    fn import_export_string_roundtrip() {
+        let mut heap = GcHeap::new();
+        let original = Object::String("monkey".to_string());
+        let reference = import_object(&mut heap, &original);
+        assert_eq!(export_object(&heap, reference), original);
+    }
+
+    #[test]
+    fn import_export_array_roundtrip() {
+        let mut heap = GcHeap::new();
+        let original = Object::Array(vec![
+            Rc::new(Object::Integer(1)),
+            Rc::new(Object::String("two".to_string())),
+            Rc::new(Object::Boolean(true)),
+        ]);
+        let reference = import_object(&mut heap, &original);
+        assert_eq!(export_object(&heap, reference), original);
+    }
+
+    #[test]
+    fn import_export_hash_roundtrip() {
+        let mut heap = GcHeap::new();
+        let original = Object::Hash(
+            vec![
+                (Rc::new(Object::Integer(1)), Rc::new(Object::Integer(10))),
+                (
+                    Rc::new(Object::String("k".to_string())),
+                    Rc::new(Object::String("v".to_string())),
+                ),
+            ]
+            .into_iter()
+            .collect::<HashMap<_, _>>(),
+        );
+        let reference = import_object(&mut heap, &original);
+        assert_eq!(export_object(&heap, reference), original);
+    }
+
+    #[test]
+    fn import_export_nested_array_roundtrip() {
+        let mut heap = GcHeap::new();
+        let original = Object::Array(vec![Rc::new(Object::Array(vec![
+            Rc::new(Object::Integer(1)),
+            Rc::new(Object::Integer(2)),
+        ]))]);
+        let reference = import_object(&mut heap, &original);
+        assert_eq!(export_object(&heap, reference), original);
+    }
+
+    #[test]
+    fn hash_key_from_value_matches_object() {
+        let mut heap = GcHeap::new();
+        for object in [
+            Object::Integer(7),
+            Object::Boolean(false),
+            Object::String("x".to_string()),
+        ] {
+            let reference = import_object(&mut heap, &object);
+            assert_eq!(
+                HashKey::from_value(get_value(&heap, reference)),
+                HashKey::from_object(&object)
+            );
+        }
+    }
+
+    #[test]
+    fn alloc_value_increments_child_refcounts() {
+        let mut heap = GcHeap::new();
+        let child = alloc_value(&mut heap, Value::Integer(1));
+        assert_eq!(heap.ref_count(child), 1);
+
+        let parent = alloc_value(&mut heap, Value::Array(vec![child]));
+        assert_eq!(heap.ref_count(child), 2);
+
+        heap.free(parent);
+        assert_eq!(heap.ref_count(child), 1);
+    }
+
+    #[test]
+    fn value_cycle_collected_by_gc() {
+        let mut heap = GcHeap::new();
+        let node_b = alloc_value(&mut heap, Value::Null);
+        let node_a = alloc_value(&mut heap, Value::Array(vec![node_b]));
+        heap.free(node_b);
+        let node_b = alloc_value(&mut heap, Value::Array(vec![node_a]));
+
+        heap.free(node_a);
+        heap.free(node_b);
+        heap.run_gc();
+        assert!(!heap.exists(node_a));
+        assert!(!heap.exists(node_b));
+    }
+}

--- a/gc/vm.rs
+++ b/gc/vm.rs
@@ -1,0 +1,488 @@
+use std::collections::HashMap;
+
+use byteorder::{BigEndian, ByteOrder};
+use compiler::compiler::Bytecode;
+use compiler::op_code::{cast_u8_to_opcode, Opcode};
+use object::builtins::BuiltIns;
+use object::Object;
+
+use crate::frame::Frame;
+use crate::value::{
+    alloc_value,
+    call_builtin,
+    export_object,
+    get_value,
+    import_object,
+    GcClosure,
+    HashKey,
+    Value,
+};
+use crate::{GcHeap, GcRef};
+
+const STACK_SIZE: usize = 2048;
+pub const GLOBAL_SIZE: usize = 65536;
+const MAX_FRAMES: usize = 1024;
+
+enum CalleeKind {
+    Closure(GcClosure),
+    Builtin(object::BuiltinFunc),
+}
+
+pub struct GcVM {
+    heap: GcHeap,
+    constants: Vec<GcRef>,
+    stack: Vec<GcRef>,
+    sp: usize,
+    globals: Vec<GcRef>,
+    frames: Vec<Frame>,
+    frame_index: usize,
+    null: GcRef,
+}
+
+impl GcVM {
+    pub fn new(bytecode: Bytecode) -> Self {
+        let mut heap = GcHeap::new();
+        let null = alloc_value(&mut heap, Value::Null);
+        let constants = bytecode
+            .constants
+            .iter()
+            .map(|constant| import_object(&mut heap, constant))
+            .collect();
+
+        let main_fn = alloc_value(
+            &mut heap,
+            Value::CompiledFunction(object::CompiledFunction {
+                instructions: bytecode.instructions.data,
+                num_locals: 0,
+                num_parameters: 0,
+            }),
+        );
+        let main_instructions = compiled_instructions(&heap, main_fn);
+        let main_frame = Frame::new(
+            GcClosure {
+                func: main_fn,
+                free: vec![],
+            },
+            main_instructions,
+            0,
+        );
+
+        let empty_frame = Frame::new(
+            GcClosure {
+                func: main_fn,
+                free: vec![],
+            },
+            vec![],
+            0,
+        );
+
+        let mut frames = vec![empty_frame; MAX_FRAMES];
+        frames[0] = main_frame;
+
+        let stack = (0..STACK_SIZE).map(|_| heap.dup(null)).collect();
+        let globals = (0..GLOBAL_SIZE).map(|_| heap.dup(null)).collect();
+
+        GcVM {
+            heap,
+            constants,
+            stack,
+            sp: 0,
+            globals,
+            frames,
+            frame_index: 1,
+            null,
+        }
+    }
+
+    pub fn heap(&self) -> &GcHeap {
+        &self.heap
+    }
+
+    pub fn heap_mut(&mut self) -> &mut GcHeap {
+        &mut self.heap
+    }
+
+    pub fn run(&mut self) {
+        while self.current_frame().ip
+            < self.current_frame().instructions.len() as i32 - 1
+        {
+            self.current_frame().ip += 1;
+            let ip = self.current_frame().ip as usize;
+            let ins = self.current_frame().instructions.clone();
+            let op = *ins.get(ip).unwrap();
+            let opcode = cast_u8_to_opcode(op);
+
+            match opcode {
+                Opcode::OpConst => {
+                    let const_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
+                    self.current_frame().ip += 2;
+                    self.dup_and_push(self.constants[const_index]);
+                }
+                Opcode::OpAdd | Opcode::OpSub | Opcode::OpMul | Opcode::OpDiv => {
+                    self.execute_binary_operation(opcode);
+                }
+                Opcode::OpPop => {
+                    self.pop_discard();
+                }
+                Opcode::OpTrue => {
+                    self.alloc_and_push(Value::Boolean(true));
+                }
+                Opcode::OpFalse => {
+                    self.alloc_and_push(Value::Boolean(false));
+                }
+                Opcode::OpEqual | Opcode::OpNotEqual | Opcode::OpGreaterThan => {
+                    self.execute_comparison(opcode);
+                }
+                Opcode::OpMinus => {
+                    self.execute_minus_operation();
+                }
+                Opcode::OpBang => {
+                    self.execute_bang_operation();
+                }
+                Opcode::OpJump => {
+                    let pos = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
+                    self.current_frame().ip = pos as i32 - 1;
+                }
+                Opcode::OpJumpNotTruthy => {
+                    let pos = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
+                    self.current_frame().ip += 2;
+                    let condition = self.pop();
+                    if !is_truthy(&self.heap, condition) {
+                        self.current_frame().ip = pos as i32 - 1;
+                    }
+                    self.heap.free(condition);
+                }
+                Opcode::OpNull => {
+                    self.dup_and_push(self.null);
+                }
+                Opcode::OpGetGlobal => {
+                    let global_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
+                    self.current_frame().ip += 2;
+                    self.dup_and_push(self.globals[global_index]);
+                }
+                Opcode::OpSetGlobal => {
+                    let global_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
+                    self.current_frame().ip += 2;
+                    let value = self.pop();
+                    self.heap.free(self.globals[global_index]);
+                    self.globals[global_index] = value;
+                }
+                Opcode::OpArray => {
+                    let count = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
+                    self.current_frame().ip += 2;
+                    let elements = self.build_array(self.sp - count, self.sp);
+                    self.sp -= count;
+                    self.alloc_and_push(Value::Array(elements));
+                }
+                Opcode::OpHash => {
+                    let count = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
+                    self.current_frame().ip += 2;
+                    let elements = self.build_hash(self.sp - count, self.sp);
+                    self.sp -= count;
+                    self.alloc_and_push(Value::Hash(elements));
+                }
+                Opcode::OpIndex => {
+                    let index = self.pop();
+                    let left = self.pop();
+                    self.execute_index_operation(left, index);
+                    self.heap.free(index);
+                    self.heap.free(left);
+                }
+                Opcode::OpReturnValue => {
+                    let return_value = self.pop();
+                    let frame = self.pop_frame();
+                    self.sp = frame.base_pointer - 1;
+                    self.push_raw(return_value);
+                }
+                Opcode::OpReturn => {
+                    let frame = self.pop_frame();
+                    self.sp = frame.base_pointer - 1;
+                    self.dup_and_push(self.null);
+                }
+                Opcode::OpCall => {
+                    let num_args = ins[ip + 1] as usize;
+                    self.current_frame().ip += 1;
+                    self.execute_call(num_args);
+                }
+                Opcode::OpSetLocal => {
+                    let local_index = ins[ip + 1] as usize;
+                    self.current_frame().ip += 1;
+                    let base = self.current_frame().base_pointer;
+                    let value = self.pop();
+                    self.heap.free(self.stack[base + local_index]);
+                    self.stack[base + local_index] = value;
+                }
+                Opcode::OpGetLocal => {
+                    let local_index = ins[ip + 1] as usize;
+                    self.current_frame().ip += 1;
+                    let base = self.current_frame().base_pointer;
+                    self.dup_and_push(self.stack[base + local_index]);
+                }
+                Opcode::OpGetBuiltin => {
+                    let built_index = ins[ip + 1] as usize;
+                    self.current_frame().ip += 1;
+                    let definition = BuiltIns.get(built_index).unwrap().1;
+                    self.alloc_and_push(Value::Builtin(definition));
+                }
+                Opcode::OpClosure => {
+                    let const_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
+                    let num_free = ins[ip + 3] as usize;
+                    self.current_frame().ip += 3;
+                    self.push_closure(const_index, num_free);
+                }
+                Opcode::OpGetFree => {
+                    let free_index = ins[ip + 1] as usize;
+                    self.current_frame().ip += 1;
+                    let free_var = self.current_frame().cl.free[free_index];
+                    self.dup_and_push(free_var);
+                }
+                Opcode::OpCurrentClosure => {
+                    let current = self.current_frame().cl.clone();
+                    self.alloc_and_push(Value::Closure(current));
+                }
+            }
+        }
+    }
+
+    pub fn last_popped_stack_elm(&self) -> Option<GcRef> {
+        self.stack.get(self.sp).copied()
+    }
+
+    pub fn export_last_result(&self) -> Option<Object> {
+        self.last_popped_stack_elm()
+            .map(|reference| export_object(&self.heap, reference))
+    }
+
+    fn alloc_and_push(&mut self, value: Value) {
+        let reference = alloc_value(&mut self.heap, value);
+        self.push_raw(reference);
+    }
+
+    fn dup_and_push(&mut self, reference: GcRef) {
+        let duplicated = self.heap.dup(reference);
+        self.push_raw(duplicated);
+    }
+
+    fn push_raw(&mut self, value: GcRef) {
+        if self.sp >= STACK_SIZE {
+            panic!("Stack overflow");
+        }
+        self.stack[self.sp] = value;
+        self.sp += 1;
+    }
+
+    fn pop(&mut self) -> GcRef {
+        let value = self.heap.dup(self.stack[self.sp - 1]);
+        self.sp -= 1;
+        value
+    }
+
+    fn pop_discard(&mut self) {
+        self.sp -= 1;
+    }
+
+    fn execute_binary_operation(&mut self, opcode: Opcode) {
+        let right = self.pop();
+        let left = self.pop();
+        match (get_value(&self.heap, left), get_value(&self.heap, right)) {
+            (Value::Integer(l), Value::Integer(r)) => {
+                let result = match opcode {
+                    Opcode::OpAdd => l + r,
+                    Opcode::OpSub => l - r,
+                    Opcode::OpMul => l * r,
+                    Opcode::OpDiv => l / r,
+                    _ => panic!("Unknown opcode for int"),
+                };
+                self.alloc_and_push(Value::Integer(result));
+            }
+            (Value::String(l), Value::String(r)) => {
+                let result = match opcode {
+                    Opcode::OpAdd => l.to_string() + r,
+                    _ => panic!("Unknown opcode for string"),
+                };
+                self.alloc_and_push(Value::String(result));
+            }
+            _ => panic!("unsupported binary operation for those types"),
+        }
+        self.heap.free(left);
+        self.heap.free(right);
+    }
+
+    fn execute_comparison(&mut self, opcode: Opcode) {
+        let right = self.pop();
+        let left = self.pop();
+        let result = match (get_value(&self.heap, left), get_value(&self.heap, right)) {
+            (Value::Integer(l), Value::Integer(r)) => match opcode {
+                Opcode::OpEqual => l == r,
+                Opcode::OpNotEqual => l != r,
+                Opcode::OpGreaterThan => l > r,
+                _ => panic!("Unknown opcode for comparing int"),
+            },
+            (Value::Boolean(l), Value::Boolean(r)) => match opcode {
+                Opcode::OpEqual => l == r,
+                Opcode::OpNotEqual => l != r,
+                _ => panic!("Unknown opcode for comparing boolean"),
+            },
+            _ => panic!("unsupported comparison for those types"),
+        };
+        self.alloc_and_push(Value::Boolean(result));
+        self.heap.free(left);
+        self.heap.free(right);
+    }
+
+    fn execute_minus_operation(&mut self) {
+        let operand = self.pop();
+        let negated = match get_value(&self.heap, operand) {
+            Value::Integer(l) => -l,
+            _ => panic!("unsupported types for negation"),
+        };
+        self.alloc_and_push(Value::Integer(negated));
+        self.heap.free(operand);
+    }
+
+    fn execute_bang_operation(&mut self) {
+        let operand = self.pop();
+        let result = match get_value(&self.heap, operand) {
+            Value::Boolean(l) => !l,
+            _ => false,
+        };
+        self.alloc_and_push(Value::Boolean(result));
+        self.heap.free(operand);
+    }
+
+    fn build_array(&mut self, start: usize, end: usize) -> Vec<GcRef> {
+        let mut elements = Vec::with_capacity(end - start);
+        for i in start..end {
+            elements.push(self.heap.dup(self.stack[i]));
+        }
+        elements
+    }
+
+    fn build_hash(&mut self, start: usize, end: usize) -> HashMap<HashKey, GcRef> {
+        let mut elements = HashMap::new();
+        for i in (start..end).step_by(2) {
+            let key_ref = self.stack[i];
+            let key = HashKey::from_value(get_value(&self.heap, key_ref))
+                .expect("hash key must be hashable");
+            elements.insert(key, self.heap.dup(self.stack[i + 1]));
+        }
+        elements
+    }
+
+    fn execute_index_operation(&mut self, left: GcRef, index: GcRef) {
+        let left_value = get_value(&self.heap, left).clone();
+        let index_value = get_value(&self.heap, index).clone();
+        match (&left_value, &index_value) {
+            (Value::Array(array), Value::Integer(i)) => {
+                self.execute_array_index(array, *i);
+            }
+            (Value::Hash(hash), _) => {
+                self.execute_hash_index(hash, &index_value);
+            }
+            _ => panic!("unsupported index operation for those types"),
+        }
+    }
+
+    fn execute_array_index(&mut self, array: &[GcRef], index: i64) {
+        if index < array.len() as i64 && index >= 0 {
+            self.dup_and_push(array[index as usize]);
+        } else {
+            self.dup_and_push(self.null);
+        }
+    }
+
+    fn execute_hash_index(&mut self, hash: &HashMap<HashKey, GcRef>, index: &Value) {
+        let key = HashKey::from_value(index).expect("unsupported hash index key");
+        match hash.get(&key) {
+            Some(value) => self.dup_and_push(*value),
+            None => self.dup_and_push(self.null),
+        }
+    }
+
+    fn current_frame(&mut self) -> &mut Frame {
+        &mut self.frames[self.frame_index - 1]
+    }
+
+    fn push_frame(&mut self, frame: Frame) {
+        self.frames[self.frame_index] = frame;
+        self.frame_index += 1;
+    }
+
+    fn pop_frame(&mut self) -> Frame {
+        self.frame_index -= 1;
+        self.frames[self.frame_index].clone()
+    }
+
+    fn execute_call(&mut self, num_args: usize) {
+        let callee = self.stack[self.sp - 1 - num_args];
+        match callee_kind(&self.heap, callee) {
+            CalleeKind::Closure(closure) => self.call_closure(closure, num_args),
+            CalleeKind::Builtin(builtin) => self.call_builtin(builtin, num_args),
+        }
+    }
+
+    fn call_closure(&mut self, closure: GcClosure, num_args: usize) {
+        let compiled = match get_value(&self.heap, closure.func) {
+            Value::CompiledFunction(f) => f.clone(),
+            _ => panic!("closure without compiled function"),
+        };
+        if compiled.num_parameters != num_args {
+            panic!(
+                "wrong number of arguments: want={}, got={}",
+                compiled.num_parameters, num_args
+            );
+        }
+
+        let frame = Frame::new(closure, compiled.instructions, self.sp - num_args);
+        self.sp = frame.base_pointer + compiled.num_locals;
+        self.push_frame(frame);
+    }
+
+    fn call_builtin(&mut self, builtin: object::BuiltinFunc, num_args: usize) {
+        let mut args = Vec::with_capacity(num_args);
+        for reference in &self.stack[self.sp - num_args..self.sp] {
+            args.push(self.heap.dup(*reference));
+        }
+        let result = call_builtin(&mut self.heap, builtin, args);
+        self.sp = self.sp - num_args - 1;
+        self.push_raw(result);
+    }
+
+    fn push_closure(&mut self, const_index: usize, num_free: usize) {
+        match get_value(&self.heap, self.constants[const_index]).clone() {
+            Value::CompiledFunction(_) => {
+                let mut free = Vec::with_capacity(num_free);
+                for i in 0..num_free {
+                    free.push(self.heap.dup(self.stack[self.sp - num_free + i]));
+                }
+                self.sp -= num_free;
+                let func = self.heap.dup(self.constants[const_index]);
+                self.alloc_and_push(Value::Closure(GcClosure { func, free }));
+            }
+            other => panic!("not a function {:?}", other),
+        }
+    }
+}
+
+fn is_truthy(heap: &GcHeap, condition: GcRef) -> bool {
+    match get_value(heap, condition) {
+        Value::Boolean(b) => *b,
+        Value::Null => false,
+        _ => true,
+    }
+}
+
+fn callee_kind(heap: &GcHeap, reference: GcRef) -> CalleeKind {
+    match get_value(heap, reference) {
+        Value::Closure(closure) => CalleeKind::Closure(closure.clone()),
+        Value::Builtin(builtin) => CalleeKind::Builtin(*builtin),
+        _ => panic!("calling non-closure"),
+    }
+}
+
+fn compiled_instructions(heap: &GcHeap, func: GcRef) -> Vec<u8> {
+    match get_value(heap, func) {
+        Value::CompiledFunction(f) => f.instructions.clone(),
+        _ => panic!("expected compiled function"),
+    }
+}

--- a/gc/vm.rs
+++ b/gc/vm.rs
@@ -8,14 +8,7 @@ use object::Object;
 
 use crate::frame::Frame;
 use crate::value::{
-    alloc_value,
-    call_builtin,
-    export_object,
-    get_value,
-    import_object,
-    GcClosure,
-    HashKey,
-    Value,
+    alloc_value, call_builtin, export_object, get_value, import_object, GcClosure, HashKey, Value,
 };
 use crate::{GcHeap, GcRef};
 
@@ -37,6 +30,7 @@ pub struct GcVM {
     frames: Vec<Frame>,
     frame_index: usize,
     null: GcRef,
+    last_popped: GcRef,
 }
 
 impl GcVM {
@@ -81,6 +75,7 @@ impl GcVM {
 
         let stack = (0..STACK_SIZE).map(|_| heap.dup(null)).collect();
         let globals = (0..GLOBAL_SIZE).map(|_| heap.dup(null)).collect();
+        let last_popped = heap.dup(null);
 
         GcVM {
             heap,
@@ -91,6 +86,7 @@ impl GcVM {
             frames,
             frame_index: 1,
             null,
+            last_popped,
         }
     }
 
@@ -103,9 +99,7 @@ impl GcVM {
     }
 
     pub fn run(&mut self) {
-        while self.current_frame().ip
-            < self.current_frame().instructions.len() as i32 - 1
-        {
+        while self.current_frame().ip < self.current_frame().instructions.len() as i32 - 1 {
             self.current_frame().ip += 1;
             let ip = self.current_frame().ip as usize;
             let ins = self.current_frame().instructions.clone();
@@ -170,16 +164,22 @@ impl GcVM {
                 Opcode::OpArray => {
                     let count = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
                     self.current_frame().ip += 2;
-                    let elements = self.build_array(self.sp - count, self.sp);
-                    self.sp -= count;
-                    self.alloc_and_push(Value::Array(elements));
+                    let start = self.sp - count;
+                    let elements = self.build_array(start, self.sp);
+                    let array = alloc_value(&mut self.heap, Value::Array(elements));
+                    self.clear_stack_range(start, self.sp);
+                    self.sp = start;
+                    self.push_raw(array);
                 }
                 Opcode::OpHash => {
                     let count = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
                     self.current_frame().ip += 2;
-                    let elements = self.build_hash(self.sp - count, self.sp);
-                    self.sp -= count;
-                    self.alloc_and_push(Value::Hash(elements));
+                    let start = self.sp - count;
+                    let elements = self.build_hash(start, self.sp);
+                    let hash = alloc_value(&mut self.heap, Value::Hash(elements));
+                    self.clear_stack_range(start, self.sp);
+                    self.sp = start;
+                    self.push_raw(hash);
                 }
                 Opcode::OpIndex => {
                     let index = self.pop();
@@ -191,12 +191,16 @@ impl GcVM {
                 Opcode::OpReturnValue => {
                     let return_value = self.pop();
                     let frame = self.pop_frame();
-                    self.sp = frame.base_pointer - 1;
+                    let new_sp = frame.base_pointer - 1;
+                    self.clear_stack_range(new_sp, self.sp);
+                    self.sp = new_sp;
                     self.push_raw(return_value);
                 }
                 Opcode::OpReturn => {
                     let frame = self.pop_frame();
-                    self.sp = frame.base_pointer - 1;
+                    let new_sp = frame.base_pointer - 1;
+                    self.clear_stack_range(new_sp, self.sp);
+                    self.sp = new_sp;
                     self.dup_and_push(self.null);
                 }
                 Opcode::OpCall => {
@@ -245,7 +249,7 @@ impl GcVM {
     }
 
     pub fn last_popped_stack_elm(&self) -> Option<GcRef> {
-        self.stack.get(self.sp).copied()
+        Some(self.last_popped)
     }
 
     pub fn export_last_result(&self) -> Option<Object> {
@@ -267,18 +271,31 @@ impl GcVM {
         if self.sp >= STACK_SIZE {
             panic!("Stack overflow");
         }
+        let old = self.stack[self.sp];
         self.stack[self.sp] = value;
+        self.heap.free(old);
         self.sp += 1;
     }
 
     fn pop(&mut self) -> GcRef {
-        let value = self.heap.dup(self.stack[self.sp - 1]);
         self.sp -= 1;
+        let value = self.stack[self.sp];
+        self.stack[self.sp] = self.heap.dup(self.null);
         value
     }
 
     fn pop_discard(&mut self) {
-        self.sp -= 1;
+        let value = self.pop();
+        self.heap.free(self.last_popped);
+        self.last_popped = value;
+    }
+
+    fn clear_stack_range(&mut self, start: usize, end: usize) {
+        for index in start..end {
+            let old = self.stack[index];
+            self.stack[index] = self.heap.dup(self.null);
+            self.heap.free(old);
+        }
     }
 
     fn execute_binary_operation(&mut self, opcode: Opcode) {
@@ -353,7 +370,7 @@ impl GcVM {
     fn build_array(&mut self, start: usize, end: usize) -> Vec<GcRef> {
         let mut elements = Vec::with_capacity(end - start);
         for i in start..end {
-            elements.push(self.heap.dup(self.stack[i]));
+            elements.push(self.stack[i]);
         }
         elements
     }
@@ -364,7 +381,7 @@ impl GcVM {
             let key_ref = self.stack[i];
             let key = HashKey::from_value(get_value(&self.heap, key_ref))
                 .expect("hash key must be hashable");
-            elements.insert(key, self.heap.dup(self.stack[i + 1]));
+            elements.insert(key, self.stack[i + 1]);
         }
         elements
     }
@@ -427,10 +444,7 @@ impl GcVM {
             _ => panic!("closure without compiled function"),
         };
         if compiled.num_parameters != num_args {
-            panic!(
-                "wrong number of arguments: want={}, got={}",
-                compiled.num_parameters, num_args
-            );
+            panic!("wrong number of arguments: want={}, got={}", compiled.num_parameters, num_args);
         }
 
         let frame = Frame::new(closure, compiled.instructions, self.sp - num_args);
@@ -439,25 +453,33 @@ impl GcVM {
     }
 
     fn call_builtin(&mut self, builtin: object::BuiltinFunc, num_args: usize) {
-        let mut args = Vec::with_capacity(num_args);
-        for reference in &self.stack[self.sp - num_args..self.sp] {
-            args.push(self.heap.dup(*reference));
-        }
+        let base = self.sp - num_args - 1;
+        let args = self.stack[self.sp - num_args..self.sp].to_vec();
         let result = call_builtin(&mut self.heap, builtin, args);
-        self.sp = self.sp - num_args - 1;
+        self.clear_stack_range(base, self.sp);
+        self.sp = base;
         self.push_raw(result);
     }
 
     fn push_closure(&mut self, const_index: usize, num_free: usize) {
         match get_value(&self.heap, self.constants[const_index]).clone() {
             Value::CompiledFunction(_) => {
+                let start = self.sp - num_free;
                 let mut free = Vec::with_capacity(num_free);
                 for i in 0..num_free {
-                    free.push(self.heap.dup(self.stack[self.sp - num_free + i]));
+                    free.push(self.stack[start + i]);
                 }
-                self.sp -= num_free;
-                let func = self.heap.dup(self.constants[const_index]);
-                self.alloc_and_push(Value::Closure(GcClosure { func, free }));
+                let func = self.constants[const_index];
+                let closure = alloc_value(
+                    &mut self.heap,
+                    Value::Closure(GcClosure {
+                        func,
+                        free,
+                    }),
+                );
+                self.clear_stack_range(start, self.sp);
+                self.sp = start;
+                self.push_raw(closure);
             }
             other => panic!("not a function {:?}", other),
         }

--- a/gc/vm.rs
+++ b/gc/vm.rs
@@ -52,6 +52,8 @@ impl GcVM {
             }),
         );
         let main_instructions = compiled_instructions(&heap, main_fn);
+        // Frames keep borrowed GcRefs. The initial main_fn allocation is the VM
+        // root for these handles; placeholder frames do not take extra refs.
         let main_frame = Frame::new(
             GcClosure {
                 func: main_fn,
@@ -140,7 +142,7 @@ impl GcVM {
                 Opcode::OpJumpNotTruthy => {
                     let pos = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
                     self.current_frame().ip += 2;
-                    let condition = self.pop();
+                    let condition = self.pop_owned();
                     if !is_truthy(&self.heap, condition) {
                         self.current_frame().ip = pos as i32 - 1;
                     }
@@ -157,7 +159,7 @@ impl GcVM {
                 Opcode::OpSetGlobal => {
                     let global_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
                     self.current_frame().ip += 2;
-                    let value = self.pop();
+                    let value = self.pop_owned();
                     self.heap.free(self.globals[global_index]);
                     self.globals[global_index] = value;
                 }
@@ -182,14 +184,14 @@ impl GcVM {
                     self.push_raw(hash);
                 }
                 Opcode::OpIndex => {
-                    let index = self.pop();
-                    let left = self.pop();
+                    let index = self.pop_owned();
+                    let left = self.pop_owned();
                     self.execute_index_operation(left, index);
                     self.heap.free(index);
                     self.heap.free(left);
                 }
                 Opcode::OpReturnValue => {
-                    let return_value = self.pop();
+                    let return_value = self.pop_owned();
                     let frame = self.pop_frame();
                     let new_sp = frame.base_pointer - 1;
                     self.clear_stack_range(new_sp, self.sp);
@@ -212,7 +214,7 @@ impl GcVM {
                     let local_index = ins[ip + 1] as usize;
                     self.current_frame().ip += 1;
                     let base = self.current_frame().base_pointer;
-                    let value = self.pop();
+                    let value = self.pop_owned();
                     self.heap.free(self.stack[base + local_index]);
                     self.stack[base + local_index] = value;
                 }
@@ -277,7 +279,11 @@ impl GcVM {
         self.sp += 1;
     }
 
-    fn pop(&mut self) -> GcRef {
+    /// Move the top stack slot's owned reference to the caller.
+    ///
+    /// The caller must either free the returned ref or store it in another
+    /// owning location. The vacated stack slot is reset to a null ref.
+    fn pop_owned(&mut self) -> GcRef {
         self.sp -= 1;
         let value = self.stack[self.sp];
         self.stack[self.sp] = self.heap.dup(self.null);
@@ -285,7 +291,7 @@ impl GcVM {
     }
 
     fn pop_discard(&mut self) {
-        let value = self.pop();
+        let value = self.pop_owned();
         self.heap.free(self.last_popped);
         self.last_popped = value;
     }
@@ -299,8 +305,8 @@ impl GcVM {
     }
 
     fn execute_binary_operation(&mut self, opcode: Opcode) {
-        let right = self.pop();
-        let left = self.pop();
+        let right = self.pop_owned();
+        let left = self.pop_owned();
         match (get_value(&self.heap, left), get_value(&self.heap, right)) {
             (Value::Integer(l), Value::Integer(r)) => {
                 let result = match opcode {
@@ -326,8 +332,8 @@ impl GcVM {
     }
 
     fn execute_comparison(&mut self, opcode: Opcode) {
-        let right = self.pop();
-        let left = self.pop();
+        let right = self.pop_owned();
+        let left = self.pop_owned();
         let result = match (get_value(&self.heap, left), get_value(&self.heap, right)) {
             (Value::Integer(l), Value::Integer(r)) => match opcode {
                 Opcode::OpEqual => l == r,
@@ -348,7 +354,7 @@ impl GcVM {
     }
 
     fn execute_minus_operation(&mut self) {
-        let operand = self.pop();
+        let operand = self.pop_owned();
         let negated = match get_value(&self.heap, operand) {
             Value::Integer(l) => -l,
             _ => panic!("unsupported types for negation"),
@@ -358,7 +364,7 @@ impl GcVM {
     }
 
     fn execute_bang_operation(&mut self) {
-        let operand = self.pop();
+        let operand = self.pop_owned();
         let result = match get_value(&self.heap, operand) {
             Value::Boolean(l) => !l,
             _ => false,

--- a/gc/vm_test.rs
+++ b/gc/vm_test.rs
@@ -13,9 +13,8 @@ pub struct VmTestCase<'a> {
 
 pub fn run_gc_vm_tests(tests: Vec<VmTestCase>) {
     for test in tests {
-        let program = parse(test.input).unwrap_or_else(|errors| {
-            panic!("parse error for {:?}: {}", test.input, errors[0])
-        });
+        let program = parse(test.input)
+            .unwrap_or_else(|errors| panic!("parse error for {:?}: {}", test.input, errors[0]));
         let mut compiler = Compiler::new();
         let bytecode = compiler
             .compile(&program)
@@ -323,7 +322,8 @@ mod tests {
                 expected: Object::Integer(3),
             },
             VmTestCase {
-                input: "let a = fn() { 1 }; let b = fn() { a() + 1 }; let c = fn() { b() + 1 }; c();",
+                input:
+                    "let a = fn() { 1 }; let b = fn() { a() + 1 }; let c = fn() { b() + 1 }; c();",
                 expected: Object::Integer(3),
             },
         ]);
@@ -388,6 +388,20 @@ mod tests {
     }
 
     #[test]
+    fn test_closures() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "let newAdder = fn(a, b) { fn(c) { a + b + c } }; let adder = newAdder(1, 2); adder(8);",
+                expected: Object::Integer(11),
+            },
+            VmTestCase {
+                input: "let global = 10; let outer = fn(a) { let inner = fn(b) { a + b + global }; inner }; let adder = outer(2); adder(3);",
+                expected: Object::Integer(15),
+            },
+        ]);
+    }
+
+    #[test]
     fn test_builtins() {
         run_gc_vm_tests(vec![
             VmTestCase {
@@ -443,6 +457,20 @@ mod tests {
                 expected: int_array(&[1]),
             },
         ]);
+    }
+
+    #[test]
+    fn builtin_call_releases_callee_args_and_stack_temporaries() {
+        let program = parse("len([1, 2, 3]);").unwrap();
+        let mut compiler = Compiler::new();
+        let bytecode = compiler.compile(&program).unwrap();
+        let mut vm = GcVM::new(bytecode);
+
+        vm.run();
+        assert_eq!(vm.export_last_result(), Some(Object::Integer(3)));
+
+        vm.heap_mut().run_gc();
+        assert_eq!(vm.heap().runtime().gc_object_count(), 6);
     }
 
     #[test]

--- a/gc/vm_test.rs
+++ b/gc/vm_test.rs
@@ -1,0 +1,453 @@
+use compiler::compiler::Compiler;
+use object::Object;
+use parser::parse;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::GcVM;
+
+pub struct VmTestCase<'a> {
+    pub input: &'a str,
+    pub expected: Object,
+}
+
+pub fn run_gc_vm_tests(tests: Vec<VmTestCase>) {
+    for test in tests {
+        let program = parse(test.input).unwrap_or_else(|errors| {
+            panic!("parse error for {:?}: {}", test.input, errors[0])
+        });
+        let mut compiler = Compiler::new();
+        let bytecode = compiler
+            .compile(&program)
+            .unwrap_or_else(|error| panic!("compile error for {:?}: {}", test.input, error));
+        let mut vm = GcVM::new(bytecode);
+        vm.run();
+        let got = vm
+            .export_last_result()
+            .unwrap_or_else(|| panic!("no result on stack for {:?}", test.input));
+        assert_eq!(got, test.expected, "input: {:?}", test.input);
+    }
+}
+
+fn int_array(values: &[i64]) -> Object {
+    Object::Array(
+        values
+            .iter()
+            .map(|value| Rc::new(Object::Integer(*value)))
+            .collect(),
+    )
+}
+
+fn int_hash(pairs: &[(i64, i64)]) -> Object {
+    Object::Hash(
+        pairs
+            .iter()
+            .map(|(k, v)| (Rc::new(Object::Integer(*k)), Rc::new(Object::Integer(*v))))
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_integer_arithmetic() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "1",
+                expected: Object::Integer(1),
+            },
+            VmTestCase {
+                input: "2",
+                expected: Object::Integer(2),
+            },
+            VmTestCase {
+                input: "1 + 2",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "4 / 2",
+                expected: Object::Integer(2),
+            },
+            VmTestCase {
+                input: "50 / 2 * 2 + 10 - 5",
+                expected: Object::Integer(55),
+            },
+            VmTestCase {
+                input: "5 * (2 + 10)",
+                expected: Object::Integer(60),
+            },
+            VmTestCase {
+                input: "5 + 5 + 5 + 5 - 10",
+                expected: Object::Integer(10),
+            },
+            VmTestCase {
+                input: "2 * 2 * 2 * 2 * 2",
+                expected: Object::Integer(32),
+            },
+            VmTestCase {
+                input: "5 * 2 + 10",
+                expected: Object::Integer(20),
+            },
+            VmTestCase {
+                input: "5 + 2 * 10",
+                expected: Object::Integer(25),
+            },
+            VmTestCase {
+                input: "-5",
+                expected: Object::Integer(-5),
+            },
+            VmTestCase {
+                input: "-10",
+                expected: Object::Integer(-10),
+            },
+            VmTestCase {
+                input: "-50 + 100 + -50",
+                expected: Object::Integer(0),
+            },
+            VmTestCase {
+                input: "(5 + 10 * 2 + 15 / 3) * 2 + -10",
+                expected: Object::Integer(50),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_boolean_expressions() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "true",
+                expected: Object::Boolean(true),
+            },
+            VmTestCase {
+                input: "false",
+                expected: Object::Boolean(false),
+            },
+            VmTestCase {
+                input: "1 < 2",
+                expected: Object::Boolean(true),
+            },
+            VmTestCase {
+                input: "1 > 2",
+                expected: Object::Boolean(false),
+            },
+            VmTestCase {
+                input: "1 == 1",
+                expected: Object::Boolean(true),
+            },
+            VmTestCase {
+                input: "1 != 2",
+                expected: Object::Boolean(true),
+            },
+            VmTestCase {
+                input: "true == false",
+                expected: Object::Boolean(false),
+            },
+            VmTestCase {
+                input: "(1 < 2) == true",
+                expected: Object::Boolean(true),
+            },
+            VmTestCase {
+                input: "!true",
+                expected: Object::Boolean(false),
+            },
+            VmTestCase {
+                input: "!false",
+                expected: Object::Boolean(true),
+            },
+            VmTestCase {
+                input: "!5",
+                expected: Object::Boolean(false),
+            },
+            VmTestCase {
+                input: "!!5",
+                expected: Object::Boolean(true),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_conditionals() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "if (true) { 10 }",
+                expected: Object::Integer(10),
+            },
+            VmTestCase {
+                input: "if (false) { 10 } else { 20 }",
+                expected: Object::Integer(20),
+            },
+            VmTestCase {
+                input: "if (1) { 10 }",
+                expected: Object::Integer(10),
+            },
+            VmTestCase {
+                input: "if (1 > 2) { 10 }",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "if (false) { 10 }",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "if ((if (false) { 10 })) { 10 } else { 20 }",
+                expected: Object::Integer(20),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_global_let_statements() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "let one = 1; one",
+                expected: Object::Integer(1),
+            },
+            VmTestCase {
+                input: "let one = 1; let two = 2; one + two",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "let one = 1; let two = one + one; one + two",
+                expected: Object::Integer(3),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_strings() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "\"monkey\"",
+                expected: Object::String("monkey".to_string()),
+            },
+            VmTestCase {
+                input: "\"mon\" + \"key\"",
+                expected: Object::String("monkey".to_string()),
+            },
+            VmTestCase {
+                input: "\"mon\" + \"key\" + \"banana\"",
+                expected: Object::String("monkeybanana".to_string()),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_arrays() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "[]",
+                expected: int_array(&[]),
+            },
+            VmTestCase {
+                input: "[1, 2, 3]",
+                expected: int_array(&[1, 2, 3]),
+            },
+            VmTestCase {
+                input: "[1 + 2, 3 * 4, 5 + 6]",
+                expected: int_array(&[3, 12, 11]),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_hash() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "{}",
+                expected: Object::Hash(HashMap::new()),
+            },
+            VmTestCase {
+                input: "{1: 2, 2: 3}",
+                expected: int_hash(&[(1, 2), (2, 3)]),
+            },
+            VmTestCase {
+                input: "{1 + 1: 2 * 2, 3 + 3: 4 * 4}",
+                expected: int_hash(&[(2, 4), (6, 16)]),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_index() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "[1, 2, 3][1]",
+                expected: Object::Integer(2),
+            },
+            VmTestCase {
+                input: "[1, 2, 3][0 + 2]",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "[[1, 1, 1]][0][0]",
+                expected: Object::Integer(1),
+            },
+            VmTestCase {
+                input: "[][0]",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "[1, 2, 3][99]",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "[1][-1]",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "{1: 1, 2: 2}[1]",
+                expected: Object::Integer(1),
+            },
+            VmTestCase {
+                input: "{1: 1}[0]",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "{}[0]",
+                expected: Object::Null,
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_functions_without_arguments() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "let fivePlusTen = fn() { 5 + 10; }; fivePlusTen();",
+                expected: Object::Integer(15),
+            },
+            VmTestCase {
+                input: "let one = fn() { 1; }; let two = fn() { 2; }; one() + two();",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "let a = fn() { 1 }; let b = fn() { a() + 1 }; let c = fn() { b() + 1 }; c();",
+                expected: Object::Integer(3),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_functions_without_return_value() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "let noReturn = fn() {}; noReturn();",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "let noReturn = fn() {}; let noReturnTwo = fn() { noReturn() }; noReturn(); noReturnTwo();",
+                expected: Object::Null,
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_calling_functions_with_bindings() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "let one = fn() { let one = 1; one }; one();",
+                expected: Object::Integer(1),
+            },
+            VmTestCase {
+                input: "let oneAndTwo = fn() { let one = 1; let two = 2; one + two }; oneAndTwo();",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "let globalSeed = 50; let minusOne = fn() { let num = 1; globalSeed - num }; let minusTwo = fn() { let num = 2; globalSeed - num }; minusOne() + minusTwo();",
+                expected: Object::Integer(97),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_calling_functions_with_arguments_and_bindings() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "let identity = fn(a) { a }; identity(4);",
+                expected: Object::Integer(4),
+            },
+            VmTestCase {
+                input: "let sum = fn(a, b) { a + b }; sum(1, 2);",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "let sum = fn(a, b) { let c = a + b; c }; sum(1, 2);",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "let sum = fn(a, b) { let c = a + b; c; }; let outer = fn() { sum(1, 2) + sum(3, 4); }; outer();",
+                expected: Object::Integer(10),
+            },
+            VmTestCase {
+                input: "let globalNum = 10; let sum = fn(a, b) { let c = a + b; c + globalNum; }; let outer = fn() { sum(1, 2) + sum(3, 4) + globalNum; }; outer() + globalNum;",
+                expected: Object::Integer(50),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_builtins() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "len(\"\");",
+                expected: Object::Integer(0),
+            },
+            VmTestCase {
+                input: "len(\"four\");",
+                expected: Object::Integer(4),
+            },
+            VmTestCase {
+                input: "len(\"hello world\");",
+                expected: Object::Integer(11),
+            },
+            VmTestCase {
+                input: "len(\"one\", \"two\");",
+                expected: Object::Error("builtin len expected 1 argument, got 2".to_string()),
+            },
+            VmTestCase {
+                input: "len([1, 2, 3]);",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "len([]);",
+                expected: Object::Integer(0),
+            },
+            VmTestCase {
+                input: "first([1, 2, 3]);",
+                expected: Object::Integer(1),
+            },
+            VmTestCase {
+                input: "first([]);",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "last([1, 2, 3]);",
+                expected: Object::Integer(3),
+            },
+            VmTestCase {
+                input: "last([]);",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "rest([1, 2, 3]);",
+                expected: int_array(&[2, 3]),
+            },
+            VmTestCase {
+                input: "rest([]);",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "push([], 1);",
+                expected: int_array(&[1]),
+            },
+        ]);
+    }
+
+    #[test]
+    fn test_eval_source_helper() {
+        let result = crate::eval_source("1 + 2 * 3").unwrap();
+        assert_eq!(result, Object::Integer(7));
+    }
+}


### PR DESCRIPTION
## Summary
- add and fix the QuickJS-style cycle collector path for monkey-gc
- align gc_scan and free_js_object behavior with QuickJS list traversal/finalization semantics
- fix GcVM/import ownership so stack temporaries and imported child refs do not leak
- update GC docs and add regression coverage for dynamic scan, finalizer order, import refs, closures, and builtins

## Tests
- cargo fmt --all
- cargo test -p monkey-gc
- cargo test