### PR TITLE
fix(gc): avoid experimental trait upcasting in object_downcast

### DIFF
--- a/gc/gc_test.rs
+++ b/gc/gc_test.rs
@@ -1,4 +1,5 @@
 use crate::{GcHeap, GcObject, GcObjectType, GcRef, MarkFunc};
+use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -49,6 +50,14 @@ impl GcObject for TestNode {
             .borrow_mut()
             .insert(id, rt.ref_count(id));
         self.freed.set(true);
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/gc/runtime.rs
+++ b/gc/runtime.rs
@@ -18,6 +18,8 @@ pub enum MarkFunc {
 pub trait GcObject: Any {
     fn trace(&self, visit: &mut dyn FnMut(GcId));
     fn on_free(&mut self, _rt: &mut GcRuntime) {}
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
 struct GcObjectEntry {
@@ -358,12 +360,12 @@ impl GcRuntime {
 
     pub fn object_downcast<T: GcObject>(&self, id: GcId) -> Option<&T> {
         let entry = self.objects.get(id)?.as_ref()?;
-        (entry.object.as_ref()?.as_ref() as &dyn Any).downcast_ref()
+        entry.object.as_ref()?.as_ref().as_any().downcast_ref()
     }
 
     pub fn object_downcast_mut<T: GcObject>(&mut self, id: GcId) -> Option<&mut T> {
         let entry = self.objects.get_mut(id)?.as_mut()?;
-        (entry.object.as_mut()?.as_mut() as &mut dyn Any).downcast_mut()
+        entry.object.as_mut()?.as_mut().as_any_mut().downcast_mut()
     }
 
     // --- Phase 1: trial deletion ---

--- a/gc/value.rs
+++ b/gc/value.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
@@ -41,6 +42,14 @@ pub struct ValueCell {
 impl GcObject for ValueCell {
     fn trace(&self, visit: &mut dyn FnMut(crate::GcId)) {
         self.value.trace(&mut |reference| visit(reference.0));
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 


### PR DESCRIPTION
Replace casts from dyn GcObject to dyn Any with explicit as_any/as_any_mut methods on the GcObject trait. Trait upcasting coercion is still unstable (E0658) and breaks cargo build on stable Rust.

Assisted-by: Cursor Agent