### PR TITLE
fix(ci): pin npm to 11.x for release publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,6 +70,9 @@ jobs:
             })
             core.info(`Triggered prepare-release.yml on ${releasePr.head.ref}`)
       - uses: actions/checkout@v6
+      - name: Pin npm to 11.x
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm install -g npm@11
       - run: npx envinfo
       - run: cargo workspaces publish --from-git --token $CARGO_TOKEN
         env:


### PR DESCRIPTION
## Summary

Release job failed on `npm publish` because `gengjiawen/node-build` currently ships **npm 12.0.0**, which errors with `Cannot find module 'sigstore'` during provenance/publish.

## Change

In `.github/workflows/release-please.yml`, install `npm@11` before publish steps when a release is created.

## Verification

- Failed run: https://github.com/gengjiawen/monkey-rust/actions/runs/29073442755/job/86299754319
- envinfo from that run: `npm: 12.0.0`
- Workflow YAML change only; no app code changes.