### PR TITLE
fix(playground): polish theme toggle control

### DIFF
--- a/packages/playground/src/app/globals.css
+++ b/packages/playground/src/app/globals.css
@@ -53,6 +53,102 @@ body {
   color: var(--accent-11);
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: var(--gray-11);
+  border-radius: 999px;
+}
+
+.theme-toggle:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent-8);
+  outline-offset: 2px;
+}
+
+.theme-toggle-track {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+  width: 52px;
+  height: 28px;
+  padding: 2px;
+  border-radius: 999px;
+  border: 1px solid var(--gray-a6);
+  background: var(--gray-a3);
+  box-shadow: inset 0 1px 1px var(--gray-a2);
+  transition:
+    background 160ms ease,
+    border-color 160ms ease;
+}
+
+.theme-toggle:hover:not(:disabled) .theme-toggle-track {
+  border-color: var(--gray-a8);
+  background: var(--gray-a4);
+}
+
+.theme-toggle-icon {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--gray-9);
+  transition: color 160ms ease, opacity 160ms ease;
+}
+
+.theme-toggle-icon--sun {
+  color: var(--amber-9);
+  opacity: 1;
+}
+
+.theme-toggle-icon--moon {
+  opacity: 0.55;
+}
+
+.theme-toggle--dark .theme-toggle-icon--sun {
+  color: var(--gray-9);
+  opacity: 0.55;
+}
+
+.theme-toggle--dark .theme-toggle-icon--moon {
+  color: var(--blue-9);
+  opacity: 1;
+}
+
+.theme-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: var(--color-panel-solid);
+  border: 1px solid var(--gray-a5);
+  box-shadow:
+    0 1px 2px var(--gray-a4),
+    0 0 0 1px var(--gray-a2);
+  transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  pointer-events: none;
+}
+
+.theme-toggle--dark .theme-toggle-thumb {
+  transform: translateX(24px);
+}
+
 .panel {
   min-width: 0;
   min-height: 0;

--- a/packages/playground/src/components/ThemeToggle.tsx
+++ b/packages/playground/src/components/ThemeToggle.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-import { IconButton } from '@radix-ui/themes'
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
 
 function SunIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="2" />
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="4" fill="currentColor" />
       <path
         d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
         stroke="currentColor"
@@ -20,12 +19,10 @@ function SunIcon() {
 
 function MoonIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
       <path
         d="M21 14.5A8.5 8.5 0 0 1 9.5 3 7 7 0 1 0 21 14.5Z"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinejoin="round"
+        fill="currentColor"
       />
     </svg>
   )
@@ -41,20 +38,44 @@ export function ThemeToggle() {
 
   if (!mounted) {
     return (
-      <IconButton size="2" variant="ghost" disabled aria-label="Toggle color theme" />
+      <button
+        type="button"
+        className="theme-toggle"
+        disabled
+        aria-label="Toggle color theme"
+      >
+        <span className="theme-toggle-track" aria-hidden="true">
+          <span className="theme-toggle-icon">
+            <SunIcon />
+          </span>
+          <span className="theme-toggle-icon">
+            <MoonIcon />
+          </span>
+          <span className="theme-toggle-thumb" />
+        </span>
+      </button>
     )
   }
 
   const isDark = resolvedTheme === 'dark'
 
   return (
-    <IconButton
-      size="2"
-      variant="ghost"
+    <button
+      type="button"
+      className={`theme-toggle${isDark ? ' theme-toggle--dark' : ''}`}
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-pressed={isDark}
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
     >
-      {isDark ? <SunIcon /> : <MoonIcon />}
-    </IconButton>
+      <span className="theme-toggle-track" aria-hidden="true">
+        <span className="theme-toggle-icon theme-toggle-icon--sun">
+          <SunIcon />
+        </span>
+        <span className="theme-toggle-icon theme-toggle-icon--moon">
+          <MoonIcon />
+        </span>
+        <span className="theme-toggle-thumb" />
+      </span>
+    </button>
   )
 }


### PR DESCRIPTION
## Summary

Playground 顶部的主题切换从普通 ghost `IconButton` 改成了更清晰的 sun/moon 滑动开关。

- 同时展示太阳 / 月亮图标，当前模式高亮
- 滑块位移动画，hover / focus 状态更明确
- 样式沿用 Radix Themes 的 CSS 变量，和现有 header 视觉一致

## Test plan

- [ ] 打开 playground，确认 header 右侧主题开关样式正常
- [ ] 点击切换 light / dark，滑块与图标状态正确更新
- [ ] 键盘 focus 可见，且 `aria-label` / `aria-pressed` 合理
- [ ] 窄屏下与 GitHub 链接并排不拥挤

Assisted-by: Cursor (Grok 4.5)