### PR TITLE
fix(ci): stop prepare-dist from auto-committing on every new branch

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - 'release-*'
       - 'release/*'
-  create:
-    branches:
-      - 'release-*'
-      - 'release/*'
   workflow_dispatch:
 jobs:
   prepare-dist:


### PR DESCRIPTION
## 问题

`prepare-release.yml` 的 `on.create` 下写了 `branches: ['release-*', 'release/*']`,但 GitHub Actions 对 `create` 事件**不支持分支过滤**——这些行被静默忽略。结果是任何新分支一创建,prepare-dist 都会跑,并由 git-auto-commit-action 把 `chore: prepare rust packages` 直接推到那个分支上。

这个 bug 一直潜伏:以前版本是同步的,bump 脚本空跑、无 diff 就不提交。0.15.2 发布(#270)合并后,main 上 `package.json`(0.15.2)和各 `Cargo.toml`(0.15.1)暂时不同步,脚本在每个新分支上都有活干,问题随之显形——今天 `docs/gc-report-edges`(污染了 #273,已 force-push 清掉)和 `feat/gc-trial-deletion-teaching` 都被塞进了版本号提交。

## 修复

直接删掉 `create:` 触发块。不丢任何场景:

- 人工推送新的 `release-*` 分支时,`push` 事件本来就会触发(对新建分支同样生效,且它的过滤器是有效的);
- release-please 机器人创建的分支用 `GITHUB_TOKEN` 推送,从来不会触发事件——所以 release-please.yml 里才有那步显式 `workflow_dispatch`,该路径不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
