### PR TITLE
fix(lexer)!: make EOF span zero-width

### DIFF
--- a/lexer/lexer_test.rs
+++ b/lexer/lexer_test.rs
@@ -85,6 +85,30 @@ mod tests {
         assert_eq!(tokens.last().unwrap().kind, TokenKind::EOF);
     }
 
+    fn assert_eof_span(input: &str) {
+        let mut l = Lexer::new(input);
+        let tokens = test_token_set(&mut l);
+        let eof = tokens.last().unwrap();
+        assert_eq!(eof.kind, TokenKind::EOF);
+        assert_eq!(eof.span.start, input.len());
+        assert_eq!(eof.span.end, input.len());
+    }
+
+    #[test]
+    fn eof_span_is_zero_width_for_empty_input() {
+        assert_eof_span("");
+    }
+
+    #[test]
+    fn eof_span_is_zero_width_after_trailing_whitespace_and_comments() {
+        assert_eof_span("let x = 5;   \n// trailing comment\n\t  ");
+    }
+
+    #[test]
+    fn eof_span_is_zero_width_for_non_ascii_input() {
+        assert_eof_span(r#""你好"; let x = 1;"#);
+    }
+
     #[test]
     fn test_comments_then_blank_line() {
         // Ensure comments followed by a blank line are skipped correctly

--- a/lexer/lib.rs
+++ b/lexer/lib.rs
@@ -48,11 +48,11 @@ impl<'a> Lexer<'a> {
         self.skip_ignorable();
         let start = self.position;
         if self.ch == '\0' {
-            self.read_char();
+            // EOF consumes no source bytes; keep a zero-width span at input.len().
             return Token {
                 span: Span {
                     start,
-                    end: start + 1,
+                    end: start,
                 },
                 kind: TokenKind::EOF,
             };

--- a/lexer/snapshots/lexer__lexer_test__tests__array.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__array.snap
@@ -37,7 +37,7 @@ expression: "[3]"
     },
     "span": {
       "start": 3,
-      "end": 4
+      "end": 3
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__bool.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__bool.snap
@@ -48,7 +48,7 @@ expression: let y=true
     },
     "span": {
       "start": 10,
-      "end": 11
+      "end": 10
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__comments.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__comments.snap
@@ -9,7 +9,7 @@ expression: // I am comments
     },
     "span": {
       "start": 16,
-      "end": 17
+      "end": 16
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__comments_then_blank_line.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__comments_then_blank_line.snap
@@ -49,7 +49,7 @@ expression: "// comment\n\nlet x = 5"
     },
     "span": {
       "start": 21,
-      "end": 22
+      "end": 21
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__complex.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__complex.snap
@@ -711,7 +711,7 @@ expression: "\n// welcome to monkeylang\nlet five = 5;\nlet ten = 10;\n\nlet add
     },
     "span": {
       "start": 211,
-      "end": 212
+      "end": 211
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__hash.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__hash.snap
@@ -132,7 +132,7 @@ expression: "{\"one\": 1, \"two\": 2, \"three\": 3}"
     },
     "span": {
       "start": 32,
-      "end": 33
+      "end": 32
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__let.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__let.snap
@@ -49,7 +49,7 @@ expression: let x=5
     },
     "span": {
       "start": 7,
-      "end": 8
+      "end": 7
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__let_with_space.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__let_with_space.snap
@@ -49,7 +49,7 @@ expression: let x = 5
     },
     "span": {
       "start": 9,
-      "end": 10
+      "end": 9
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__simple.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__simple.snap
@@ -90,7 +90,7 @@ expression: "=+(){},:;"
     },
     "span": {
       "start": 9,
-      "end": 10
+      "end": 9
     }
   }
 ]

--- a/lexer/snapshots/lexer__lexer_test__tests__string.snap
+++ b/lexer/snapshots/lexer__lexer_test__tests__string.snap
@@ -19,7 +19,7 @@ expression: "\"a\""
     },
     "span": {
       "start": 3,
-      "end": 4
+      "end": 3
     }
   }
 ]

--- a/parser/snapshots/parser__ast_tree_test__tests__test_array.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_array.snap
@@ -34,7 +34,7 @@ expression: "[1, true]"
     ],
     "span": {
       "start": 0,
-      "end": 10
+      "end": 9
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_binary.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_binary.snap
@@ -65,7 +65,7 @@ expression: 1 + 2 * 3
     ],
     "span": {
       "start": 0,
-      "end": 10
+      "end": 9
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_binary_nested.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_binary_nested.snap
@@ -65,7 +65,7 @@ expression: 1+2+3
     ],
     "span": {
       "start": 0,
-      "end": 6
+      "end": 5
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_func_call.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_func_call.snap
@@ -42,7 +42,7 @@ expression: "add(1, 2)"
     ],
     "span": {
       "start": 0,
-      "end": 10
+      "end": 9
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_func_declaration.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_func_declaration.snap
@@ -44,7 +44,7 @@ expression: "fn(x) { x };"
     ],
     "span": {
       "start": 0,
-      "end": 13
+      "end": 12
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_func_with_name.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_func_with_name.snap
@@ -63,7 +63,7 @@ expression: "let my_func = fn(x) { x };"
     ],
     "span": {
       "start": 0,
-      "end": 27
+      "end": 26
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_hash.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_hash.snap
@@ -36,7 +36,7 @@ expression: "{\"a\": 1}"
     ],
     "span": {
       "start": 0,
-      "end": 9
+      "end": 8
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_if.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_if.snap
@@ -82,7 +82,7 @@ expression: "if (x < y) { x } else { y }"
     ],
     "span": {
       "start": 0,
-      "end": 28
+      "end": 27
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_index.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_index.snap
@@ -32,7 +32,7 @@ expression: "a[1]"
     ],
     "span": {
       "start": 0,
-      "end": 5
+      "end": 4
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_let.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_let.snap
@@ -36,7 +36,7 @@ expression: let a = 3
     ],
     "span": {
       "start": 0,
-      "end": 10
+      "end": 9
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_return.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_return.snap
@@ -24,7 +24,7 @@ expression: return 3
     ],
     "span": {
       "start": 0,
-      "end": 9
+      "end": 8
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_string.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_string.snap
@@ -17,7 +17,7 @@ expression: "\"jw\""
     ],
     "span": {
       "start": 0,
-      "end": 5
+      "end": 4
     }
   }
 }

--- a/parser/snapshots/parser__ast_tree_test__tests__test_unary.snap
+++ b/parser/snapshots/parser__ast_tree_test__tests__test_unary.snap
@@ -33,7 +33,7 @@ expression: "-3"
     ],
     "span": {
       "start": 0,
-      "end": 3
+      "end": 2
     }
   }
 }


### PR DESCRIPTION
## Summary
- Emit EOF with a zero-width span at `input.len()..input.len()` instead of the out-of-bounds `input.len()..input.len()+1`
- Add focused lexer coverage for empty input, trailing whitespace/comments, and non-ASCII input
- Refresh affected lexer and parser snapshots (`Program.span.end` follows EOF)

Closes #268

## Breaking change
This changes the public token and AST span contract: EOF and `Program.span.end` are now `input.len()` instead of `input.len() + 1`. Downstream snapshot, diagnostic, formatter, and source-map consumers may need updates.

## Test plan
- [x] `cargo test` (full workspace)
- [x] New EOF span assertions for empty / trailing ignorable / non-ASCII input
- [x] Lexer + parser snapshots updated


Made with [Cursor](https://cursor.com)