### PR TITLE
feat(gc): export monkey-gc REPL binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Monkey has a C-like syntax, supports **variable bindings**, **prefix** and **inf
 ## Features
 
 - Split packages to make everything minimum
-- **REPL**: A Read-Eval-Print-Loop (REPL) for Monkey tokenizer, parser, evaluator, compiler
+- **REPL**: A Read-Eval-Print-Loop (REPL) for Monkey tokenizer, parser, evaluator, compiler, and GC runtime
 - location info for ast
 - test for every module
 - **Wasm**: A WebAssembly target, thus run monkey on browser is directly supported.

--- a/gc/Cargo.toml
+++ b/gc/Cargo.toml
@@ -12,6 +12,10 @@ license = "MIT"
 name = "gc"
 path = "lib.rs"
 
+[[bin]]
+name = "monkey-gc"
+path = "main.rs"
+
 [dependencies]
 byteorder = "1.5.0"
 monkey-compiler = { path = "../compiler", version = "0.15.0" }

--- a/gc/README.md
+++ b/gc/README.md
@@ -132,6 +132,15 @@ the compatibility phase-stats view of the same atomic collection. Ordinary
 - `report.rs` defines heap snapshots and collection telemetry.
 - `frame.rs` and `vm.rs` implement the bytecode VM runtime.
 
+## REPL
+
+This crate also ships a `monkey-gc` binary with a stateful REPL (globals and
+compiler constants persist across lines), matching `monkey-compiler`:
+
+```sh
+cargo run -p monkey-gc
+```
+
 ## Development
 
 Run the crate tests from the workspace root:

--- a/gc/main.rs
+++ b/gc/main.rs
@@ -1,22 +1,19 @@
 use compiler::compiler::Compiler;
-use compiler::symbol_table::SymbolTable;
 use gc::GcVM;
-use object::Object;
 use parser::parse;
 use std::io::stdin;
 use std::io::{self, Write};
-use std::rc::Rc;
 
 fn main() {
     println!("Welcome to monkey gc by gengjiawen");
-    let mut constants: Vec<Rc<Object>> = vec![];
-    let mut symbol_table = SymbolTable::new();
-    let bootstrap = {
-        let mut compiler = Compiler::new();
-        compiler
-            .compile(&parse("").expect("empty program should parse"))
-            .expect("empty program should compile")
-    };
+    // Seed the persistent state from Compiler::new() so builtins like `len`
+    // stay resolvable; new_with_state replaces the symbol table wholesale.
+    let mut bootstrap_compiler = Compiler::new();
+    let bootstrap = bootstrap_compiler
+        .compile(&parse("").expect("empty program should parse"))
+        .expect("empty program should compile");
+    let mut symbol_table = bootstrap_compiler.symbol_table;
+    let mut constants = bootstrap_compiler.constants;
     let mut vm = GcVM::new(bootstrap);
 
     loop {
@@ -38,13 +35,19 @@ fn main() {
             }
         };
 
-        let mut compiler = Compiler::new_with_state(symbol_table, constants);
+        // Compile against clones and commit only after a successful run, so a
+        // failed line cannot leak a half-defined binding into the next one.
+        let mut compiler = Compiler::new_with_state(symbol_table.clone(), constants.clone());
         match compiler.compile(&program) {
             Ok(bytecode) => {
                 vm.set_global_names(compiler.symbol_table.global_symbols());
                 vm.load_bytecode(bytecode);
                 match vm.run_with_budget(usize::MAX) {
-                    Ok(()) => println!("{}", vm.last_result_string()),
+                    Ok(()) => {
+                        println!("{}", vm.last_result_string());
+                        symbol_table = compiler.symbol_table;
+                        constants = compiler.constants;
+                    }
                     Err(error) => eprintln!("{}", error.message),
                 }
             }
@@ -52,8 +55,5 @@ fn main() {
                 eprintln!("{}", error);
             }
         }
-
-        symbol_table = compiler.symbol_table;
-        constants = compiler.constants;
     }
 }

--- a/gc/main.rs
+++ b/gc/main.rs
@@ -1,0 +1,59 @@
+use compiler::compiler::Compiler;
+use compiler::symbol_table::SymbolTable;
+use gc::GcVM;
+use object::Object;
+use parser::parse;
+use std::io::stdin;
+use std::io::{self, Write};
+use std::rc::Rc;
+
+fn main() {
+    println!("Welcome to monkey gc by gengjiawen");
+    let mut constants: Vec<Rc<Object>> = vec![];
+    let mut symbol_table = SymbolTable::new();
+    let bootstrap = {
+        let mut compiler = Compiler::new();
+        compiler
+            .compile(&parse("").expect("empty program should parse"))
+            .expect("empty program should compile")
+    };
+    let mut vm = GcVM::new(bootstrap);
+
+    loop {
+        print!("> ");
+        io::stdout().flush().unwrap();
+        let mut input = String::new();
+        stdin().read_line(&mut input).unwrap();
+
+        if input.trim_end().is_empty() {
+            println!("bye");
+            std::process::exit(0);
+        }
+
+        let program = match parse(&input) {
+            Ok(node) => node,
+            Err(errors) => {
+                eprintln!("parse error: {}", errors[0]);
+                continue;
+            }
+        };
+
+        let mut compiler = Compiler::new_with_state(symbol_table, constants);
+        match compiler.compile(&program) {
+            Ok(bytecode) => {
+                vm.set_global_names(compiler.symbol_table.global_symbols());
+                vm.load_bytecode(bytecode);
+                match vm.run_with_budget(usize::MAX) {
+                    Ok(()) => println!("{}", vm.last_result_string()),
+                    Err(error) => eprintln!("{}", error.message),
+                }
+            }
+            Err(error) => {
+                eprintln!("{}", error);
+            }
+        }
+
+        symbol_table = compiler.symbol_table;
+        constants = compiler.constants;
+    }
+}

--- a/gc/tests/repl_test.rs
+++ b/gc/tests/repl_test.rs
@@ -1,0 +1,62 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_repl(input: &str) -> (String, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_monkey-gc"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("monkey-gc binary should start");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin should be piped")
+        .write_all(input.as_bytes())
+        .expect("writing REPL input should succeed");
+    let output = child
+        .wait_with_output()
+        .expect("monkey-gc should exit cleanly");
+    (
+        String::from_utf8(output.stdout).expect("stdout should be utf-8"),
+        String::from_utf8(output.stderr).expect("stderr should be utf-8"),
+    )
+}
+
+#[test]
+fn repl_resolves_builtins() {
+    let (stdout, stderr) = run_repl("len([1, 2, 3]);\n\n");
+    assert!(
+        stdout.contains("3"),
+        "expected builtin result in stdout, got: {stdout:?} (stderr: {stderr:?})"
+    );
+    assert!(
+        !stderr.contains("Undefined variable"),
+        "builtins should resolve, got stderr: {stderr:?}"
+    );
+}
+
+#[test]
+fn repl_does_not_commit_state_from_failed_lines() {
+    // The failed `let` must not leak a ghost `x` binding: the follow-up
+    // `x;` has to be rejected instead of evaluating to null.
+    let (stdout, stderr) = run_repl("let x = 1 / 0;\nx;\n\n");
+    assert!(
+        stderr.contains("division by zero"),
+        "expected runtime error, got stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("undefined variable 'x'"),
+        "ghost binding survived a failed line, stdout: {stdout:?}, stderr: {stderr:?}"
+    );
+}
+
+#[test]
+fn repl_keeps_state_across_successful_lines() {
+    let (stdout, stderr) = run_repl("let answer = 21 * 2;\nanswer;\n\n");
+    assert!(
+        stdout.contains("42"),
+        "expected persisted global in stdout: {stdout:?} (stderr: {stderr:?})"
+    );
+    assert!(stderr.is_empty(), "unexpected stderr: {stderr:?}");
+}

--- a/gc/vm.rs
+++ b/gc/vm.rs
@@ -132,6 +132,76 @@ impl GcVM {
         }
     }
 
+    /// Replace the current main program while preserving the heap and globals.
+    ///
+    /// Used by the REPL so later lines can read bindings created earlier. Old
+    /// constant-pool owning refs are released; objects still reachable from
+    /// globals stay alive.
+    pub fn load_bytecode(&mut self, bytecode: Bytecode) {
+        let Bytecode {
+            instructions,
+            constants: object_constants,
+            debug_info: main_debug_info,
+            function_debug_info: object_function_debug_info,
+        } = bytecode;
+
+        self.clear_stack_range(0, self.sp);
+        self.sp = 0;
+
+        for reference in self.constants.drain(..) {
+            self.heap.free(reference);
+        }
+        self.function_debug_info.clear();
+
+        let old_main = self.frames[0].cl.func;
+        self.heap.free(old_main);
+
+        self.constants = object_constants
+            .iter()
+            .map(|constant| import_object(&mut self.heap, constant))
+            .collect::<Vec<_>>();
+        self.function_debug_info = object_function_debug_info
+            .into_iter()
+            .filter_map(|(index, debug_info)| {
+                self.constants
+                    .get(index)
+                    .copied()
+                    .map(|reference| (reference, debug_info))
+            })
+            .collect();
+        self.main_debug_info = main_debug_info;
+
+        let main_fn = alloc_value(
+            &mut self.heap,
+            Value::CompiledFunction(object::CompiledFunction {
+                name: String::new(),
+                instructions: instructions.data,
+                num_locals: 0,
+                num_parameters: 0,
+            }),
+        );
+        let main_instructions = compiled_instructions(&self.heap, main_fn);
+        let main_frame = Frame::new(
+            GcClosure {
+                func: main_fn,
+                free: vec![],
+            },
+            main_instructions,
+            0,
+        );
+        let empty_frame = Frame::new(
+            GcClosure {
+                func: main_fn,
+                free: vec![],
+            },
+            vec![],
+            0,
+        );
+        self.frames = vec![empty_frame; MAX_FRAMES];
+        self.frames[0] = main_frame;
+        self.frame_index = 1;
+    }
+
     pub fn heap(&self) -> &GcHeap {
         &self.heap
     }

--- a/gc/vm.rs
+++ b/gc/vm.rs
@@ -148,6 +148,11 @@ impl GcVM {
         self.clear_stack_range(0, self.sp);
         self.sp = 0;
 
+        // Reset the last result so statements that never pop (e.g. a bare
+        // `let`) report null instead of the previous program's result.
+        self.heap.free(self.last_popped);
+        self.last_popped = self.heap.dup(self.null);
+
         for reference in self.constants.drain(..) {
             self.heap.free(reference);
         }

--- a/gc/vm_test.rs
+++ b/gc/vm_test.rs
@@ -499,6 +499,34 @@ mod tests {
     }
 
     #[test]
+    fn test_load_bytecode_preserves_globals() {
+        let mut symbol_table = compiler::symbol_table::SymbolTable::new();
+        let mut constants = vec![];
+
+        let bootstrap = {
+            let mut compiler = Compiler::new();
+            compiler.compile(&parse("").unwrap()).unwrap()
+        };
+        let mut vm = GcVM::new(bootstrap);
+
+        let first = parse("let answer = 21 * 2;").unwrap();
+        let mut compiler = Compiler::new_with_state(symbol_table, constants);
+        let bytecode = compiler.compile(&first).unwrap();
+        vm.load_bytecode(bytecode);
+        vm.run();
+        symbol_table = compiler.symbol_table;
+        constants = compiler.constants;
+
+        let second = parse("answer;").unwrap();
+        let mut compiler = Compiler::new_with_state(symbol_table, constants);
+        let bytecode = compiler.compile(&second).unwrap();
+        vm.load_bytecode(bytecode);
+        vm.run();
+
+        assert_eq!(vm.export_last_result(), Some(Object::Integer(42)));
+    }
+
+    #[test]
     fn test_class_semantics() {
         run_gc_vm_tests(vec![
             VmTestCase {

--- a/gc/vm_test.rs
+++ b/gc/vm_test.rs
@@ -527,6 +527,37 @@ mod tests {
     }
 
     #[test]
+    fn test_load_bytecode_resets_last_result() {
+        let mut symbol_table = compiler::symbol_table::SymbolTable::new();
+        let mut constants = vec![];
+
+        let bootstrap = {
+            let mut compiler = Compiler::new();
+            compiler.compile(&parse("").unwrap()).unwrap()
+        };
+        let mut vm = GcVM::new(bootstrap);
+
+        let first = parse("1 + 1;").unwrap();
+        let mut compiler = Compiler::new_with_state(symbol_table, constants);
+        let bytecode = compiler.compile(&first).unwrap();
+        vm.load_bytecode(bytecode);
+        vm.run();
+        assert_eq!(vm.export_last_result(), Some(Object::Integer(2)));
+        symbol_table = compiler.symbol_table;
+        constants = compiler.constants;
+
+        // A bare `let` never pops, so the result must reset to null instead
+        // of echoing the previous program's result.
+        let second = parse("let a = 5;").unwrap();
+        let mut compiler = Compiler::new_with_state(symbol_table, constants);
+        let bytecode = compiler.compile(&second).unwrap();
+        vm.load_bytecode(bytecode);
+        vm.run();
+
+        assert_eq!(vm.export_last_result(), Some(Object::Null));
+    }
+
+    #[test]
     fn test_class_semantics() {
         run_gc_vm_tests(vec![
             VmTestCase {

--- a/gc/vm_test.rs
+++ b/gc/vm_test.rs
@@ -558,6 +558,26 @@ mod tests {
     }
 
     #[test]
+    fn test_load_bytecode_resolves_builtins_from_bootstrap_state() {
+        // Mirror the REPL: persistent symbol table and constants must come
+        // from Compiler::new(), which registers builtins; a bare
+        // SymbolTable::new() would make `len` unresolvable.
+        let mut bootstrap_compiler = Compiler::new();
+        let bootstrap = bootstrap_compiler.compile(&parse("").unwrap()).unwrap();
+        let symbol_table = bootstrap_compiler.symbol_table;
+        let constants = bootstrap_compiler.constants;
+        let mut vm = GcVM::new(bootstrap);
+
+        let program = parse("len([1, 2, 3]);").unwrap();
+        let mut compiler = Compiler::new_with_state(symbol_table, constants);
+        let bytecode = compiler.compile(&program).unwrap();
+        vm.load_bytecode(bytecode);
+        vm.run();
+
+        assert_eq!(vm.export_last_result(), Some(Object::Integer(3)));
+    }
+
+    #[test]
     fn test_class_semantics() {
         run_gc_vm_tests(vec![
             VmTestCase {


### PR DESCRIPTION
## Summary
- Export a `monkey-gc` Rust binary (`cargo run -p monkey-gc`) with a stateful REPL, matching the other Monkey crates
- Add `GcVM::load_bytecode` so later REPL lines keep heap globals across recompiles
- Document the binary in `gc/README.md` and the top-level README REPL list

## Test plan
- [x] `cargo test -p monkey-gc`
- [x] `printf 'let x = 41 + 1;\nx;\n\n' | cargo run -q -p monkey-gc` prints `null` then `42`
- [ ] `cargo install --path gc` installs a `monkey-gc` binary


Made with [Cursor](https://cursor.com)