### PR TITLE
perf(gc): trim hot-path slot lookups and make per-edge asserts debug-only

### DIFF
--- a/gc/gc_runtime.rs
+++ b/gc/gc_runtime.rs
@@ -83,10 +83,11 @@ impl GcRuntime {
         let mut current = self.gc_obj_list.head;
         while let Some(id) = current {
             let next = self.header(id).list_next;
-            assert_eq!(self.header(id).mark, 0);
+            debug_assert_eq!(self.header(id).mark, 0);
             self.mark_children(id, MarkFunc::Decref);
-            self.header_mut(id).mark = 1;
-            if self.header(id).ref_count == 0 {
+            let header = self.header_mut(id);
+            header.mark = 1;
+            if header.ref_count == 0 {
                 self.list_move(GcListKind::GcObj, GcListKind::Tmp, id);
             }
             current = next;
@@ -97,8 +98,9 @@ impl GcRuntime {
     fn gc_scan(&mut self) {
         let mut current = self.gc_obj_list.head;
         while let Some(id) = current {
-            assert!(self.header(id).ref_count > 0);
-            self.header_mut(id).mark = 0;
+            let header = self.header_mut(id);
+            debug_assert!(header.ref_count > 0);
+            header.mark = 0;
             self.mark_children(id, MarkFunc::ScanIncref);
             current = self.header(id).list_next;
         }
@@ -136,7 +138,7 @@ impl GcRuntime {
 
         while let Some(id) = self.gc_zero_ref_count_list.head {
             let ty = self.header(id).gc_obj_type;
-            assert!(
+            debug_assert!(
                 ty == GcObjectType::MonkeyObject || ty == GcObjectType::FunctionBytecode,
                 "unexpected deferred type: {:?}",
                 ty
@@ -205,7 +207,7 @@ impl GcRuntime {
 
         {
             let header = self.header_mut(id);
-            assert!(
+            debug_assert!(
                 header.list_kind.is_none(),
                 "object already belongs to a GC list: {:?}",
                 header.list_kind
@@ -228,11 +230,10 @@ impl GcRuntime {
     }
 
     fn list_remove(&mut self, kind: GcListKind, id: GcId) {
-        assert_eq!(self.header(id).list_kind, Some(kind), "object is not on the expected GC list");
-
         let list_ptr = self.list_ptr(kind);
         let (prev, next) = {
             let header = self.header(id);
+            debug_assert_eq!(header.list_kind, Some(kind), "object is not on the expected GC list");
             (header.list_prev, header.list_next)
         };
 
@@ -318,13 +319,12 @@ impl GcRuntime {
     /// Decrement refcount and free when it reaches zero.
     /// Matches QuickJS `JS_FreeValueRT` for GC objects.
     pub fn free_gc(&mut self, id: GcId) {
-        if !self.object_exists(id) {
-            return;
-        }
-        let ref_count = {
-            let header = self.header_mut(id);
-            header.ref_count -= 1;
-            header.ref_count
+        let ref_count = match self.objects.get_mut(id).and_then(|slot| slot.as_mut()) {
+            Some(entry) => {
+                entry.header.ref_count -= 1;
+                entry.header.ref_count
+            }
+            None => return,
         };
 
         if ref_count > 0 {
@@ -460,9 +460,10 @@ impl GcRuntime {
     // --- Phase 1: trial deletion ---
 
     fn gc_decref_child(&mut self, id: GcId) {
-        assert!(self.header(id).ref_count > 0);
-        self.header_mut(id).ref_count -= 1;
-        if self.header(id).ref_count == 0 && self.header(id).mark == 1 {
+        let header = self.header_mut(id);
+        debug_assert!(header.ref_count > 0);
+        header.ref_count -= 1;
+        if header.ref_count == 0 && header.mark == 1 {
             self.list_move(GcListKind::GcObj, GcListKind::Tmp, id);
         }
     }
@@ -470,8 +471,9 @@ impl GcRuntime {
     // --- Phase 2: restore live refs ---
 
     fn gc_scan_incref_child(&mut self, id: GcId) {
-        self.header_mut(id).ref_count += 1;
-        if self.header(id).ref_count == 1 {
+        let header = self.header_mut(id);
+        header.ref_count += 1;
+        if header.ref_count == 1 {
             self.list_move(GcListKind::Tmp, GcListKind::GcObj, id);
             self.header_mut(id).mark = 0;
         }
@@ -491,7 +493,7 @@ impl GcRuntime {
                 break;
             }
             let id = id.unwrap();
-            assert_eq!(self.header(id).ref_count, 0);
+            debug_assert_eq!(self.header(id).ref_count, 0);
             self.free_gc_object(id);
         }
         self.gc_phase = GcPhase::None;


### PR DESCRIPTION
## Summary

Constant-factor cleanups on the collector hot paths, from a pass over `gc_runtime.rs`. No behavior change in release builds; debug/test builds keep every invariant check.

**1. Per-object / per-edge asserts become `debug_assert!`**

`assert!` stays active in Rust release builds, unlike QuickJS's `assert()` under `NDEBUG`. The checks in the phase loops (`gc_decref`, `gc_scan`, `gc_free_cycles`, `free_zero_refcount`), the child callbacks (`gc_decref_child`), and every list link/unlink (`list_push_back`, `list_remove`) now compile out in release. Their panic paths also blocked LLVM from merging adjacent slot lookups. The once-per-collection `tmp_obj_list` empty assert in `gc_decref` stays a hard assert.

**2. One header lookup per callback instead of one per field access**

Every `header()`/`header_mut()` call is a bounds check + `Option` unwrap on the slot table. Hot spots now borrow the header once:
- `gc_decref_child`: 4 lookups per edge → 1
- `gc_scan_incref_child`: 3 → 1 (plus one on the rare rescue branch)
- `free_gc` (runs on every VM value drop): `object_exists` pre-check + `header_mut` → a single `get_mut`, keeping the lenient early return for stale ids
- `gc_decref`/`gc_scan` loop bodies and `list_remove` merge their adjacent reads

Complexity was already O(objects + edges) with O(1) intrusive-list ops — this only trims per-edge constants.

## Test plan

- `cargo test -p monkey-gc`: 78 passed (debug profile, so all converted asserts still exercised)
- `cargo build -p monkey-gc` debug + `--release`: no new warnings in `gc/` (only the pre-existing `heap.rs` `header_mut` dead-code note)
- `cargo clippy -p monkey-gc`: no findings in `gc_runtime.rs`
- `cargo fmt -p monkey-gc -- --check`: clean for touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)