### PR TITLE
feat(playground): add step-by-step GC phase replay to the report view

### DIFF
--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -20,6 +20,7 @@ Repo: https://github.com/gengjiawen/monkey-rust
 - Before/after heap snapshots, per-value-kind counts, and diagnostics for the three collector phases
 - Object decision walkthrough (RC before / heap in-edges / trial RC / Candidate|Survivor / Scan / Final)
 - Visited heap edges with typed relations (`fields["next"]`, `items[0]`, …) and Scan reachability witnesses
+- Heap topology graph plus a step-by-step phase replay that animates trial deletion, Scan restores, and freeing over the same drawing
 - Tagged parse/compile/runtime errors and stale-request protection for GC runs
 
 The GC view executes only when **Run GC** is pressed. Editing never runs the

--- a/packages/playground/src/GcReportView.tsx
+++ b/packages/playground/src/GcReportView.tsx
@@ -22,6 +22,7 @@ import {
   valueKinds,
 } from './gcReport'
 import { HeapGraphView } from './HeapGraphView'
+import { PhaseReplayView } from './PhaseReplayView'
 
 export type GcPanelState =
   | { status: 'idle' }
@@ -1135,6 +1136,7 @@ export function GcReportView({ state, onErrorSpanSelect }: GcReportViewProps) {
       </section>
 
       <HeapGraphView report={report} />
+      <PhaseReplayView report={report} />
       <ObjectDecisionWalkthrough report={report} />
       <VisitedHeapEdges report={report} />
 

--- a/packages/playground/src/PhaseReplayView.tsx
+++ b/packages/playground/src/PhaseReplayView.tsx
@@ -1,0 +1,251 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type { GcCollectionReport } from './gcReport'
+import { buildReplayPlan, replayStepSource } from './phaseReplay'
+
+// mermaid.render needs a document-unique element id per invocation.
+let renderSequence = 0
+
+const PLAY_STEP_MS = 1200
+
+const replayCardClass =
+  'flex flex-col gap-2.5 rounded-[10px] border border-(--gray-a5) bg-(--color-panel-solid) p-4 shadow-[0_1px_2px_var(--black-a3)]'
+
+const replayButtonClass =
+  'cursor-pointer rounded-md border border-(--gray-a6) bg-transparent px-2.5 py-1 text-xs leading-[inherit] text-(--gray-11) [font-family:inherit] hover:bg-(--gray-a3) disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent'
+
+// `gc-replay-canvas` carries no styles; it is a hook for tests. Styling
+// lives in the utilities below.
+const replayCanvasClass = [
+  'gc-replay-canvas overflow-x-auto py-1',
+  // The rendered SVG carries a viewBox; keep it centered and shrink-to-fit.
+  '[&_svg]:mx-auto [&_svg]:block [&_svg]:h-auto [&_svg]:max-w-full',
+  // mermaid sizes each label's foreignObject with the font active at render
+  // time; if the client font metrics differ even slightly, foreignObject's
+  // default overflow: hidden amputates the last characters. Painting past
+  // the box is the lesser evil.
+  '[&_foreignObject]:overflow-visible',
+  // Node state colors. Survivor / restored / external mirror HeapGraphView's
+  // canvas; candidate shares the amber of the walkthrough badge, garbage
+  // shares the freed red, and a freed node additionally fades out. Color is
+  // never the only channel: the caption and the counts line under the
+  // controls narrate every transition as text. `!` outweighs mermaid's own
+  // #id-prefixed node styles.
+  '[&_.node.candidate_:is(rect,path,polygon)]:fill-(--amber-a3)! [&_.node.candidate_:is(rect,path,polygon)]:stroke-(--amber-a6)! [&_.node.candidate_.nodeLabel]:text-(--amber-11)!',
+  '[&_.node.survivor_:is(rect,path,polygon)]:fill-(--green-a3)! [&_.node.survivor_:is(rect,path,polygon)]:stroke-(--green-a6)! [&_.node.survivor_.nodeLabel]:text-(--green-11)!',
+  '[&_.node.restored_:is(rect,path,polygon)]:fill-(--blue-a3)! [&_.node.restored_:is(rect,path,polygon)]:stroke-(--blue-a6)! [&_.node.restored_.nodeLabel]:text-(--blue-11)!',
+  '[&_.node.garbage_:is(rect,path,polygon)]:fill-(--red-a3)! [&_.node.garbage_:is(rect,path,polygon)]:stroke-(--red-a6)! [&_.node.garbage_.nodeLabel]:text-(--red-11)!',
+  '[&_.node.freed_:is(rect,path,polygon)]:fill-(--red-a3)! [&_.node.freed_:is(rect,path,polygon)]:stroke-(--red-a6)! [&_.node.freed_.nodeLabel]:text-(--red-11)! [&_.node.freed]:opacity-45',
+  '[&_.node.external_:is(rect,path,polygon)]:fill-(--gray-a2)! [&_.node.external_:is(rect,path,polygon)]:stroke-(--gray-a8)! [&_.node.external_:is(rect,path,polygon)]:[stroke-dasharray:4_3]! [&_.node.external_.nodeLabel]:text-(--gray-11)!',
+  // The node(s) the current step narrates get a heavier outline.
+  '[&_.node.active_:is(rect,path,polygon)]:[stroke-width:2.5px]!',
+].join(' ')
+
+const mutedClass = 'text-xs text-(--gray-10)'
+
+const metaClass = 'm-0 text-xs text-(--gray-11)'
+
+const captionClass =
+  'block min-h-[3em] text-[13px] leading-normal text-(--gray-12)'
+
+type RenderState =
+  | { status: 'rendering' }
+  | { status: 'rendered'; svg: string }
+  | { status: 'failed'; message: string }
+
+export function PhaseReplayView({ report }: { report: GcCollectionReport }) {
+  const plan = useMemo(() => buildReplayPlan(report), [report])
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
+  const [stepIndex, setStepIndex] = useState(0)
+  const [playing, setPlaying] = useState(false)
+  const [renderState, setRenderState] = useState<RenderState>({
+    status: 'rendering',
+  })
+  const sectionRef = useRef<HTMLElement>(null)
+
+  const stepCount = plan.status === 'ok' ? plan.steps.length : 0
+  const boundedIndex = Math.min(stepIndex, Math.max(0, stepCount - 1))
+  const step = plan.status === 'ok' ? plan.steps[boundedIndex] : null
+  const source =
+    plan.status === 'ok' && step ? replayStepSource(plan.model, step) : null
+
+  // A new report means a new plan: rewind to the first step.
+  useEffect(() => {
+    setStepIndex(0)
+    setPlaying(false)
+  }, [plan])
+
+  useEffect(() => {
+    if (!playing) {
+      return
+    }
+    if (boundedIndex >= stepCount - 1) {
+      setPlaying(false)
+      return
+    }
+    const timer = window.setTimeout(() => {
+      setStepIndex((current) => Math.min(current + 1, stepCount - 1))
+    }, PLAY_STEP_MS)
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [playing, boundedIndex, stepCount])
+
+  useEffect(() => {
+    if (source === null) {
+      return
+    }
+    let cancelled = false
+    // Keep the previous frame visible while the next one renders; resetting
+    // to a placeholder would flash the card on every step.
+    setRenderState((previous) =>
+      previous.status === 'rendered' ? previous : { status: 'rendering' }
+    )
+
+    const renderFrame = async () => {
+      try {
+        const { default: mermaid } = await import('mermaid')
+        // Same trick as HeapGraphView: mermaid measures labels outside the
+        // Radix theme scope, so hand it the resolved font stack to keep
+        // measurement and display in agreement.
+        const fontFamily = sectionRef.current
+          ? getComputedStyle(sectionRef.current).fontFamily
+          : ''
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: 'strict',
+          theme: isDark ? 'dark' : 'default',
+          ...(fontFamily ? { fontFamily } : {}),
+        })
+        renderSequence += 1
+        const { svg } = await mermaid.render(
+          `gc-phase-replay-${renderSequence}`,
+          source
+        )
+        if (!cancelled) {
+          setRenderState({ status: 'rendered', svg })
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setRenderState({
+            status: 'failed',
+            message: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+    }
+    void renderFrame()
+
+    return () => {
+      cancelled = true
+    }
+  }, [source, isDark])
+
+  const goTo = (index: number) => {
+    setPlaying(false)
+    setStepIndex(Math.max(0, Math.min(index, stepCount - 1)))
+  }
+
+  const togglePlay = () => {
+    if (playing) {
+      setPlaying(false)
+      return
+    }
+    if (boundedIndex >= stepCount - 1) {
+      setStepIndex(0)
+    }
+    setPlaying(true)
+  }
+
+  return (
+    <section
+      ref={sectionRef}
+      className={replayCardClass}
+      aria-label="Phase replay"
+    >
+      <h2 className="m-0 text-base text-(--gray-12)">Phase replay</h2>
+      {plan.status === 'unavailable' ? (
+        <p className={mutedClass}>{plan.reason}</p>
+      ) : step === null ? null : (
+        <>
+          <p className={`m-0 ${mutedClass}`}>
+            Deterministic replay reconstructed from the report&apos;s sorted
+            edges and witness paths — not the collector&apos;s actual event
+            order. The real collector ran all three phases atomically before
+            anything was displayed.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              className={replayButtonClass}
+              onClick={togglePlay}
+            >
+              {playing
+                ? 'Pause'
+                : boundedIndex >= stepCount - 1
+                  ? 'Replay'
+                  : 'Play'}
+            </button>
+            <button
+              type="button"
+              className={replayButtonClass}
+              onClick={() => goTo(boundedIndex - 1)}
+              disabled={boundedIndex === 0}
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              className={replayButtonClass}
+              onClick={() => goTo(boundedIndex + 1)}
+              disabled={boundedIndex >= stepCount - 1}
+            >
+              Next
+            </button>
+            <input
+              type="range"
+              className="min-w-[140px] flex-1"
+              min={0}
+              max={stepCount - 1}
+              step={1}
+              value={boundedIndex}
+              onChange={(event) => goTo(Number(event.target.value))}
+              aria-label="Replay step"
+            />
+            <span className={metaClass}>
+              Step {boundedIndex + 1} of {stepCount} · {step.phase}
+            </span>
+          </div>
+          <output className={captionClass} aria-live="polite">
+            {step.caption}
+          </output>
+          <p className={metaClass}>
+            Candidates {step.counts.candidates} · Restored{' '}
+            {step.counts.restored} · Garbage {step.counts.garbage} · Freed{' '}
+            {step.counts.freed}
+          </p>
+          {renderState.status === 'rendered' ? (
+            <div
+              className={replayCanvasClass}
+              // mermaid output is generated from validated report data and
+              // rendered under securityLevel: 'strict'.
+              dangerouslySetInnerHTML={{ __html: renderState.svg }}
+            />
+          ) : renderState.status === 'failed' ? (
+            <p className={mutedClass} role="alert">
+              The replay frame could not be rendered: {renderState.message}
+            </p>
+          ) : (
+            <output className={mutedClass} aria-live="polite">
+              Rendering replay…
+            </output>
+          )}
+        </>
+      )}
+    </section>
+  )
+}

--- a/packages/playground/src/heapGraph.ts
+++ b/packages/playground/src/heapGraph.ts
@@ -52,20 +52,47 @@ function globalNamesLabel(names: string[]): string {
   return names.length <= 2 ? shown : `${shown} +${names.length - 2} more`
 }
 
+/** One drawable arrow: parallel visited edges merged, labels in visit order. */
+export interface MergedHeapEdge {
+  fromId: number
+  toId: number
+  labels: string[]
+}
+
 /**
- * Build a mermaid flowchart of the heap topology the collector actually
- * visited: solid arrows are the reported heap-to-heap edges, and a single
- * "External refs" pseudo-node stands in for every non-heap reference
- * (constants, global slots, VM stack) with one dotted arrow per trial
- * survivor labeled by its trial reference count.
+ * The drawable slice of a collection report, shared by the static topology
+ * graph and the phase replay so both emit the exact same nodes and arrows
+ * (and therefore the exact same mermaid layout).
+ */
+export interface HeapGraphModel {
+  /** Drawn object ids, ascending. */
+  sortedIds: number[]
+  labels: Map<number, string>
+  decisions: Map<number, ObjectDecision>
+  globalNames: Map<number, string[]>
+  /** Sorted by (fromId, toId); array order matches emitted link order. */
+  mergedEdges: MergedHeapEdge[]
+  /** Trial survivors that get a dotted External refs arrow, ascending id. */
+  externalTargets: ObjectDecision[]
+  droppedIsolated: number
+}
+
+export type HeapGraphModelResult =
+  | { status: 'ok'; model: HeapGraphModel }
+  | { status: 'unavailable'; reason: string }
+
+/**
+ * Collect the drawable topology of the heap the collector actually visited.
  *
  * Only objects that participate in at least one reported edge, plus every
  * candidate, become nodes; isolated survivors (mostly VM bookkeeping values)
  * are dropped and counted in `droppedIsolated`. When the report truncated
- * edge or decision details the graph would silently lie, so it is reported
- * as unavailable instead.
+ * edge or decision details the drawing would silently lie, so the model is
+ * reported as unavailable instead.
  */
-export function buildHeapGraph(report: GcCollectionReport): HeapGraph {
+export function buildHeapGraphModel(
+  report: GcCollectionReport
+): HeapGraphModelResult {
   const trial = report.phases.trialDeletion
   if (trial.omittedObjectDecisions > 0 || trial.omittedEdgeDetails > 0) {
     return {
@@ -131,53 +158,102 @@ export function buildHeapGraph(report: GcCollectionReport): HeapGraph {
         decision.trialRefCount > 0
     )
 
+  const mergedEdgeMap = new Map<string, MergedHeapEdge>()
+  for (const edge of trial.visitedEdges) {
+    const key = `${edge.fromId}->${edge.toId}`
+    const label = formatEdgeRelation(edge.relation)
+    const entry = mergedEdgeMap.get(key)
+    if (entry) {
+      entry.labels.push(label)
+    } else {
+      mergedEdgeMap.set(key, { fromId: edge.fromId, toId: edge.toId, labels: [label] })
+    }
+  }
+  const mergedEdges = [...mergedEdgeMap.values()].sort(
+    (left, right) => left.fromId - right.fromId || left.toId - right.toId
+  )
+
+  return {
+    status: 'ok',
+    model: {
+      sortedIds,
+      labels,
+      decisions,
+      globalNames,
+      mergedEdges,
+      externalTargets,
+      droppedIsolated,
+    },
+  }
+}
+
+/** Per-node hooks for renderHeapGraphModel. */
+export interface NodeDecoration {
+  /** Extra text between the object label and its global-names line. */
+  suffix?: string
+  /** mermaid ::: class attached to the node. */
+  className?: string
+}
+
+/**
+ * Emit mermaid source for a model. Link order is deterministic: solid merged
+ * edges first (so `linkStyle N` addresses `mergedEdges[N]`), then one dotted
+ * External refs arrow per external target. `extraLines` (linkStyle / class
+ * statements) never affect layout, only styling.
+ */
+export function renderHeapGraphModel(
+  model: HeapGraphModel,
+  decorate: (id: number) => NodeDecoration,
+  extraLines: readonly string[] = []
+): string {
   const lines: string[] = ['flowchart LR']
-  if (externalTargets.length > 0) {
+  if (model.externalTargets.length > 0) {
     lines.push(
       '  ext(["External refs<br/>constants · globals · stack"]):::external'
     )
   }
-  for (const id of sortedIds) {
-    const label = escapeMermaidText(labels.get(id) ?? `Object#${id}`)
-    const names = globalNames.get(id)
+  for (const id of model.sortedIds) {
+    const label = escapeMermaidText(model.labels.get(id) ?? `Object#${id}`)
+    const names = model.globalNames.get(id)
     const nameLine = names
       ? `<br/><i>global${names.length > 1 ? 's' : ''}: ${globalNamesLabel(names)}</i>`
       : ''
-    const decision = decisions.get(id)
-    const fate = decision ? fateClass(decision) : null
-    const fateSuffix = fate ? ` · ${FATE_TEXT[fate]}` : ''
-    const fateTag = fate ? `:::${fate}` : ''
-    lines.push(`  o${id}["${label}${fateSuffix}${nameLine}"]${fateTag}`)
+    const { suffix = '', className } = decorate(id)
+    const classTag = className ? `:::${className}` : ''
+    lines.push(`  o${id}["${label}${suffix}${nameLine}"]${classTag}`)
   }
-
-  const mergedEdges = new Map<
-    string,
-    { fromId: number; toId: number; labels: string[] }
-  >()
-  for (const edge of trial.visitedEdges) {
-    const key = `${edge.fromId}->${edge.toId}`
-    const label = formatEdgeRelation(edge.relation)
-    const entry = mergedEdges.get(key)
-    if (entry) {
-      entry.labels.push(label)
-    } else {
-      mergedEdges.set(key, { fromId: edge.fromId, toId: edge.toId, labels: [label] })
-    }
-  }
-  const sortedEdges = [...mergedEdges.values()].sort(
-    (left, right) => left.fromId - right.fromId || left.toId - right.toId
-  )
-  for (const edge of sortedEdges) {
+  for (const edge of model.mergedEdges) {
     const label = escapeMermaidText(mergedEdgeLabel(edge.labels))
     lines.push(`  o${edge.fromId} -- "${label}" --> o${edge.toId}`)
   }
-  for (const decision of externalTargets) {
+  for (const decision of model.externalTargets) {
     lines.push(`  ext -. "×${decision.trialRefCount}" .-> o${decision.objectId}`)
   }
-
+  lines.push(...extraLines)
   // No classDef lines: mermaid still adds the ::: class names to each node's
-  // SVG class attribute, and HeapGraphView's canvas styles them with the same
-  // Radix tokens as the walkthrough badges (classDef cannot express CSS
-  // variables).
-  return { status: 'ok', source: lines.join('\n'), droppedIsolated }
+  // SVG class attribute, and the canvas Tailwind variants in HeapGraphView /
+  // PhaseReplayView style them with the same Radix tokens as the walkthrough
+  // badges (classDef cannot express CSS variables).
+  return lines.join('\n')
+}
+
+/**
+ * Build a mermaid flowchart of the heap topology the collector actually
+ * visited: solid arrows are the reported heap-to-heap edges, and a single
+ * "External refs" pseudo-node stands in for every non-heap reference
+ * (constants, global slots, VM stack) with one dotted arrow per trial
+ * survivor labeled by its trial reference count.
+ */
+export function buildHeapGraph(report: GcCollectionReport): HeapGraph {
+  const result = buildHeapGraphModel(report)
+  if (result.status === 'unavailable') {
+    return result
+  }
+  const { model } = result
+  const source = renderHeapGraphModel(model, (id) => {
+    const decision = model.decisions.get(id)
+    const fate = decision ? fateClass(decision) : null
+    return fate ? { suffix: ` · ${FATE_TEXT[fate]}`, className: fate } : {}
+  })
+  return { status: 'ok', source, droppedIsolated: model.droppedIsolated }
 }

--- a/packages/playground/src/phaseReplay.ts
+++ b/packages/playground/src/phaseReplay.ts
@@ -1,0 +1,461 @@
+import type {
+  GcCollectionReport,
+  ObjectDecision,
+  RestorationWitness,
+} from './gcReport'
+import { formatEdgeRelation } from './gcReport'
+import type { HeapGraphModel } from './heapGraph'
+import { buildHeapGraphModel, renderHeapGraphModel } from './heapGraph'
+
+/**
+ * Node state as the replay steps through the report. `pending` objects have
+ * not been classified yet and keep the default node style.
+ */
+export type ReplayNodeStatus =
+  | 'pending'
+  | 'candidate'
+  | 'survivor'
+  | 'restored'
+  | 'garbage'
+  | 'freed'
+
+export type ReplayPhase =
+  | 'Start'
+  | 'Trial deletion'
+  | 'Scan'
+  | 'Free cycles'
+  | 'Done'
+
+export interface ReplayCounts {
+  candidates: number
+  restored: number
+  garbage: number
+  freed: number
+}
+
+export interface ReplayStep {
+  phase: ReplayPhase
+  caption: string
+  statuses: ReadonlyMap<number, ReplayNodeStatus>
+  /** Objects this step is about; they get the heavier `active` outline. */
+  activeNodeIds: number[]
+  /** mergedEdges indices drawn bold in this frame. */
+  boldEdgeIndices: number[]
+  /** mergedEdges indices drawn dimmed in this frame. */
+  dimmedEdgeIndices: number[]
+  counts: ReplayCounts
+}
+
+export type ReplayPlan =
+  | { status: 'ok'; model: HeapGraphModel; steps: ReplayStep[] }
+  | { status: 'unavailable'; reason: string }
+
+const INCONSISTENT_REASON =
+  'This report’s details do not fold into a consistent step-by-step replay; use the walkthrough table instead.'
+
+function plural(count: number, word: string): string {
+  return count === 1 ? word : `${word}s`
+}
+
+function listLabels(ids: number[], label: (id: number) => string): string {
+  const shown = ids.slice(0, 3).map(label).join(', ')
+  return ids.length <= 3 ? shown : `${shown} +${ids.length - 3} more`
+}
+
+/**
+ * Fold a collection report into an ordered list of replay steps: one per
+ * subtracted edge (trial deletion), one per restoration witness (scan), and
+ * one per freed object (free cycles), with phase-boundary summaries between.
+ *
+ * The replay is a deterministic reconstruction from the report's sorted
+ * edges and witness paths, not a recording of the collector's own traversal
+ * order. It refuses to build (status `unavailable`) whenever the topology
+ * graph is unavailable, when witnesses were truncated, or when the details
+ * do not fold back into the reported per-object numbers.
+ */
+export function buildReplayPlan(report: GcCollectionReport): ReplayPlan {
+  const modelResult = buildHeapGraphModel(report)
+  if (modelResult.status === 'unavailable') {
+    // Deliberately different copy from the topology card right above, which
+    // already explains the underlying limit in detail.
+    return {
+      status: 'unavailable',
+      reason:
+        'The replay steps through the drawn heap topology, which is unavailable for this report; the topology card above explains why.',
+    }
+  }
+  const { model } = modelResult
+  const scan = report.phases.scan
+  if (scan.omittedWitnesses > 0) {
+    return {
+      status: 'unavailable',
+      reason:
+        'This report truncated restoration witnesses, so the Scan phase cannot be replayed faithfully. Use the walkthrough table instead.',
+    }
+  }
+
+  const inconsistent = (): ReplayPlan => ({
+    status: 'unavailable',
+    reason: INCONSISTENT_REASON,
+  })
+
+  const decisionOf = (id: number): ObjectDecision | undefined =>
+    model.decisions.get(id)
+  const label = (id: number): string => model.labels.get(id) ?? `Object#${id}`
+
+  // Every drawn object needs a decision to seed and check the RC ledger.
+  const rc = new Map<number, number>()
+  for (const id of model.sortedIds) {
+    const decision = decisionOf(id)
+    if (!decision) {
+      return inconsistent()
+    }
+    rc.set(id, decision.refCountBefore)
+  }
+
+  const candidateIds = model.sortedIds.filter(
+    (id) => decisionOf(id)?.decision === 'candidate'
+  )
+  const survivorIds = model.sortedIds.filter(
+    (id) => decisionOf(id)?.decision === 'survivor'
+  )
+  const restoredIds = candidateIds.filter(
+    (id) => decisionOf(id)?.final === 'retained'
+  )
+  const garbageIds = candidateIds.filter(
+    (id) => decisionOf(id)?.final === 'freed'
+  )
+  if (
+    scan.restored !== restoredIds.length ||
+    scan.garbageCandidates !== garbageIds.length ||
+    report.phases.freeCycles.freed !== garbageIds.length
+  ) {
+    return inconsistent()
+  }
+
+  // Merged-edge index by "from->to" so trial and witness steps can point at
+  // the exact arrow they narrate (linkStyle N addresses mergedEdges[N]).
+  const edgeIndexByKey = new Map<string, number>()
+  model.mergedEdges.forEach((edge, index) => {
+    edgeIndexByKey.set(`${edge.fromId}->${edge.toId}`, index)
+  })
+
+  const witnessByObject = new Map<number, RestorationWitness>()
+  for (const witness of scan.restorationWitnesses) {
+    if (witnessByObject.has(witness.objectId)) {
+      return inconsistent()
+    }
+    witnessByObject.set(witness.objectId, witness)
+  }
+  if (witnessByObject.size !== restoredIds.length) {
+    return inconsistent()
+  }
+  for (const id of restoredIds) {
+    const witness = witnessByObject.get(id)
+    if (
+      !witness ||
+      !model.decisions.has(witness.rootId) ||
+      !model.decisions.has(witness.predecessorId) ||
+      !edgeIndexByKey.has(`${witness.predecessorId}->${witness.objectId}`)
+    ) {
+      return inconsistent()
+    }
+  }
+
+  // Order restore steps parents-first: depth along the predecessor chain
+  // (survivor predecessors sit at depth 0), ties by object id. Witnesses form
+  // a forest; a predecessor cycle means the report is broken.
+  const depths = new Map<number, number>()
+  const resolveDepth = (id: number, trail: Set<number>): number | null => {
+    const witness = witnessByObject.get(id)
+    if (!witness) {
+      return 0
+    }
+    const known = depths.get(id)
+    if (known !== undefined) {
+      return known
+    }
+    if (trail.has(id)) {
+      return null
+    }
+    trail.add(id)
+    const parent = resolveDepth(witness.predecessorId, trail)
+    if (parent === null) {
+      return null
+    }
+    depths.set(id, parent + 1)
+    return parent + 1
+  }
+  for (const id of restoredIds) {
+    if (resolveDepth(id, new Set()) === null) {
+      return inconsistent()
+    }
+  }
+  const orderedWitnesses = restoredIds
+    .flatMap((id) => {
+      const witness = witnessByObject.get(id)
+      return witness ? [witness] : []
+    })
+    .sort(
+      (left, right) =>
+        (depths.get(left.objectId) ?? 0) - (depths.get(right.objectId) ?? 0) ||
+        left.objectId - right.objectId
+    )
+
+  const statuses = new Map<number, ReplayNodeStatus>(
+    model.sortedIds.map((id) => [id, 'pending' as ReplayNodeStatus])
+  )
+  const steps: ReplayStep[] = []
+  const pushStep = (step: {
+    phase: ReplayPhase
+    caption: string
+    activeNodeIds?: number[]
+    boldEdgeIndices?: number[]
+    dimmedEdgeIndices?: number[]
+  }) => {
+    const counts: ReplayCounts = { candidates: 0, restored: 0, garbage: 0, freed: 0 }
+    for (const status of statuses.values()) {
+      if (status === 'candidate') {
+        counts.candidates += 1
+      } else if (status === 'restored') {
+        counts.restored += 1
+      } else if (status === 'garbage') {
+        counts.garbage += 1
+      } else if (status === 'freed') {
+        counts.freed += 1
+      }
+    }
+    steps.push({
+      phase: step.phase,
+      caption: step.caption,
+      statuses: new Map(statuses),
+      activeNodeIds: step.activeNodeIds ?? [],
+      boldEdgeIndices: step.boldEdgeIndices ?? [],
+      dimmedEdgeIndices: step.dimmedEdgeIndices ?? [],
+      counts,
+    })
+  }
+
+  pushStep({
+    phase: 'Start',
+    caption: `Before the collector runs: ${model.sortedIds.length} drawn ${plural(
+      model.sortedIds.length,
+      'object'
+    )} hold their current reference counts. Solid arrows are the heap-to-heap references Trial deletion will subtract.`,
+  })
+
+  // Phase 1 — one step per visited edge, in the report's sorted order.
+  const consumedPerEdge = model.mergedEdges.map(() => 0)
+  const dimmedEdges: number[] = []
+  for (const edge of report.phases.trialDeletion.visitedEdges) {
+    const mergedIndex = edgeIndexByKey.get(`${edge.fromId}->${edge.toId}`)
+    const before = rc.get(edge.toId)
+    if (mergedIndex === undefined || before === undefined || before <= 0) {
+      return inconsistent()
+    }
+    const after = before - 1
+    rc.set(edge.toId, after)
+    consumedPerEdge[mergedIndex] += 1
+    if (consumedPerEdge[mergedIndex] === model.mergedEdges[mergedIndex].labels.length) {
+      dimmedEdges.push(mergedIndex)
+    }
+    let caption = `Trial deletion subtracts the ${formatEdgeRelation(
+      edge.relation
+    )} reference ${label(edge.fromId)} → ${label(edge.toId)}: RC ${before} → ${after}.`
+    if (after === 0) {
+      statuses.set(edge.toId, 'candidate')
+      caption += ` ${label(edge.toId)} drops to RC 0 and becomes a Candidate (not yet known to be garbage).`
+    }
+    pushStep({
+      phase: 'Trial deletion',
+      caption,
+      activeNodeIds: [edge.fromId, edge.toId],
+      boldEdgeIndices: [mergedIndex],
+      dimmedEdgeIndices: dimmedEdges.filter((index) => index !== mergedIndex),
+    })
+  }
+
+  // The fold must land exactly on the reported trial RCs, and every reported
+  // candidate must have been caught reaching zero along the way.
+  for (const id of model.sortedIds) {
+    if (rc.get(id) !== decisionOf(id)?.trialRefCount) {
+      return inconsistent()
+    }
+  }
+  for (const id of candidateIds) {
+    if (statuses.get(id) !== 'candidate') {
+      return inconsistent()
+    }
+  }
+
+  for (const id of survivorIds) {
+    statuses.set(id, 'survivor')
+  }
+  const allDimmed = [...dimmedEdges]
+
+  if (candidateIds.length === 0) {
+    pushStep({
+      phase: 'Trial deletion',
+      caption:
+        'Trial deletion complete: every drawn object kept RC above 0, so there are no Candidates and nothing for Scan or Free cycles to do.',
+      dimmedEdgeIndices: allDimmed,
+    })
+    pushStep({
+      phase: 'Done',
+      caption:
+        'Collection complete: nothing was freed — every drawn object is retained.',
+    })
+    return { status: 'ok', model, steps }
+  }
+
+  pushStep({
+    phase: 'Trial deletion',
+    caption:
+      `Trial deletion complete: ${candidateIds.length} ${plural(
+        candidateIds.length,
+        'Candidate'
+      )} at RC 0` +
+      (survivorIds.length > 0
+        ? `; ${survivorIds.length} Trial ${plural(
+            survivorIds.length,
+            'survivor'
+          )} ${survivorIds.length === 1 ? 'keeps' : 'keep'} a positive RC from non-heap references (dotted arrows).`
+        : '; no drawn object kept a positive RC.'),
+    activeNodeIds: survivorIds,
+    dimmedEdgeIndices: allDimmed,
+  })
+
+  // Phase 2 — witness-ordered restores, then the garbage verdict.
+  const boldWitnessEdges: number[] = []
+  if (orderedWitnesses.length > 0) {
+    pushStep({
+      phase: 'Scan',
+      caption: `Scan walks the Trial ${plural(
+        survivorIds.length,
+        'survivor'
+      )} and gives back the references they hold; any Candidate reachable from a survivor is rescued.`,
+      activeNodeIds: survivorIds,
+    })
+    for (const witness of orderedWitnesses) {
+      const edgeIndex = edgeIndexByKey.get(
+        `${witness.predecessorId}->${witness.objectId}`
+      )
+      if (edgeIndex === undefined) {
+        return inconsistent()
+      }
+      statuses.set(witness.objectId, 'restored')
+      boldWitnessEdges.push(edgeIndex)
+      const via =
+        witness.predecessorId === witness.rootId
+          ? 'directly'
+          : `through ${label(witness.predecessorId)}`
+      pushStep({
+        phase: 'Scan',
+        caption: `Scan restores ${label(
+          witness.objectId
+        )}: the witness path from Trial survivor ${label(
+          witness.rootId
+        )} reaches it ${via} via ${formatEdgeRelation(
+          witness.relation
+        )}, so its RC climbs back above zero — it will be retained.`,
+        activeNodeIds: [witness.predecessorId, witness.objectId],
+        boldEdgeIndices: [...boldWitnessEdges],
+      })
+    }
+  }
+
+  if (garbageIds.length > 0) {
+    for (const id of garbageIds) {
+      statuses.set(id, 'garbage')
+    }
+    const listed = listLabels(garbageIds, label)
+    pushStep({
+      phase: 'Scan',
+      caption:
+        orderedWitnesses.length > 0
+          ? `Scan complete: no Trial survivor reaches ${listed}, so ${
+              garbageIds.length === 1 ? 'it stays' : 'they stay'
+            } on the candidate list as garbage.`
+          : `Scan rescues nothing: no Trial survivor reaches any Candidate, so ${listed} ${
+              garbageIds.length === 1 ? 'stays' : 'stay'
+            } on the candidate list as garbage.`,
+      activeNodeIds: garbageIds,
+      boldEdgeIndices: [...boldWitnessEdges],
+    })
+  } else {
+    pushStep({
+      phase: 'Scan',
+      caption:
+        'Scan complete: every Candidate was reachable from a Trial survivor; the candidate list is empty and Free cycles has nothing to free.',
+      boldEdgeIndices: [...boldWitnessEdges],
+    })
+  }
+
+  // Phase 3 — free the remaining candidates in id order.
+  const freedEdgeDim = new Set<number>()
+  for (const id of garbageIds) {
+    statuses.set(id, 'freed')
+    model.mergedEdges.forEach((edge, index) => {
+      if (edge.fromId === id || edge.toId === id) {
+        freedEdgeDim.add(index)
+      }
+    })
+    pushStep({
+      phase: 'Free cycles',
+      caption: `Free cycles frees ${label(id)} and returns its memory to the allocator.`,
+      activeNodeIds: [id],
+      boldEdgeIndices: [...boldWitnessEdges],
+      dimmedEdgeIndices: [...freedEdgeDim],
+    })
+  }
+
+  const retained = survivorIds.length + restoredIds.length
+  pushStep({
+    phase: 'Done',
+    caption:
+      garbageIds.length > 0
+        ? `Collection complete: ${garbageIds.length} ${plural(
+            garbageIds.length,
+            'object'
+          )} freed, ${retained} drawn ${plural(retained, 'object')} retained.`
+        : `Collection complete: nothing was freed — all ${retained} drawn objects are retained.`,
+    boldEdgeIndices: [...boldWitnessEdges],
+    dimmedEdgeIndices: [...freedEdgeDim],
+  })
+
+  return { status: 'ok', model, steps }
+}
+
+/**
+ * Mermaid source for one replay frame. Every frame emits the identical node
+ * and edge statements (same labels, same order) so mermaid computes the same
+ * layout; frames differ only in ::: status classes, the `active` class list,
+ * and theme-neutral linkStyle emphasis (bold width / dimmed opacity).
+ */
+export function replayStepSource(
+  model: HeapGraphModel,
+  step: ReplayStep
+): string {
+  const extraLines: string[] = []
+  for (const index of step.dimmedEdgeIndices) {
+    if (!step.boldEdgeIndices.includes(index)) {
+      extraLines.push(`  linkStyle ${index} opacity:0.35`)
+    }
+  }
+  for (const index of step.boldEdgeIndices) {
+    extraLines.push(`  linkStyle ${index} stroke-width:3.5px`)
+  }
+  if (step.activeNodeIds.length > 0) {
+    extraLines.push(
+      `  class ${step.activeNodeIds.map((id) => `o${id}`).join(',')} active`
+    )
+  }
+  return renderHeapGraphModel(
+    model,
+    (id) => {
+      const status = step.statuses.get(id)
+      return status && status !== 'pending' ? { className: status } : {}
+    },
+    extraLines
+  )
+}

--- a/packages/playground/src/test/PhaseReplayView.test.tsx
+++ b/packages/playground/src/test/PhaseReplayView.test.tsx
@@ -1,0 +1,211 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  GcCollectionReport,
+  ObjectDecision,
+  ValueKindCounts,
+} from '../gcReport'
+
+const { initializeMock, renderMock, useThemeMock } = vi.hoisted(() => ({
+  initializeMock: vi.fn(),
+  renderMock: vi.fn(),
+  useThemeMock: vi.fn(),
+}))
+
+vi.mock('mermaid', () => ({
+  default: { initialize: initializeMock, render: renderMock },
+}))
+
+vi.mock('next-themes', () => ({
+  useTheme: useThemeMock,
+}))
+
+import { PhaseReplayView } from '../PhaseReplayView'
+
+const counts = (): ValueKindCounts => ({
+  class: 0,
+  instance: 0,
+  boundMethod: 0,
+  closure: 0,
+  array: 0,
+  hash: 0,
+  integer: 0,
+  boolean: 0,
+  string: 0,
+  null: 0,
+  error: 0,
+  compiledFunction: 0,
+  builtin: 0,
+  other: 0,
+})
+
+function cycleReport({
+  omittedEdgeDetails = 0,
+  omittedWitnesses = 0,
+}: {
+  omittedEdgeDetails?: number
+  omittedWitnesses?: number
+} = {}): GcCollectionReport {
+  const decisions: ObjectDecision[] = [20, 21].map((objectId) => ({
+    objectId,
+    refCountBefore: 1,
+    heapIncomingEdges: 1,
+    trialRefCount: 0,
+    decision: 'candidate',
+    final: 'freed',
+  }))
+  const objects = [20, 21].map((id) => ({
+    id,
+    kind: 'instance' as const,
+    label: `Instance(Node)#${id}`,
+  }))
+  const snapshot = { objectCount: 2, trackedBytes: 0, byValueKind: counts() }
+  return {
+    before: snapshot,
+    after: snapshot,
+    objects,
+    globalRoots: [],
+    omittedGlobalRoots: 0,
+    phases: {
+      trialDeletion: {
+        edgesVisited: 2 + omittedEdgeDetails,
+        candidates: 2,
+        objectDecisions: decisions,
+        visitedEdges: [
+          {
+            fromId: 20,
+            toId: 21,
+            relation: { kind: 'instanceField', name: 'next' },
+          },
+          {
+            fromId: 21,
+            toId: 20,
+            relation: { kind: 'instanceField', name: 'next' },
+          },
+        ],
+        omittedObjectDecisions: 0,
+        omittedEdgeDetails,
+      },
+      scan: {
+        restored: 0,
+        garbageCandidates: 2,
+        restoredObjects: [],
+        garbageCandidateObjects: objects,
+        restorationWitnesses: [],
+        omittedWitnesses,
+      },
+      freeCycles: { freed: 2 },
+    },
+    collectedByValueKind: counts(),
+  }
+}
+
+describe('PhaseReplayView', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    initializeMock.mockReset()
+    renderMock.mockReset()
+    useThemeMock.mockReset()
+    useThemeMock.mockReturnValue({ resolvedTheme: 'light' })
+  })
+
+  it('renders the first step and walks forward through the plan', async () => {
+    renderMock.mockResolvedValue({ svg: '<svg><title>frame</title></svg>' })
+    const { container } = render(<PhaseReplayView report={cycleReport()} />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Phase replay' })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Deterministic replay/)).toBeInTheDocument()
+    expect(screen.getByText('Step 1 of 8 · Start')).toBeInTheDocument()
+    expect(screen.getByText(/Before the collector runs/)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(container.querySelector('.gc-replay-canvas svg')).not.toBeNull()
+    })
+    expect(initializeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ securityLevel: 'strict', theme: 'default' })
+    )
+    const [id, firstSource] = renderMock.mock.calls[0] as [string, string]
+    expect(id).toMatch(/^gc-phase-replay-\d+$/)
+    expect(firstSource).toContain('flowchart LR')
+    expect(firstSource).not.toContain(':::candidate')
+
+    expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(
+      screen.getByText('Step 2 of 8 · Trial deletion')
+    ).toBeInTheDocument()
+    expect(screen.getByText(/RC 1 → 0/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Back' })).toBeEnabled()
+    await waitFor(() => {
+      expect(renderMock).toHaveBeenCalledTimes(2)
+    })
+    const secondSource = renderMock.mock.calls[1][1] as string
+    expect(secondSource).toContain(':::candidate')
+    expect(secondSource).toContain('linkStyle 0 stroke-width:3.5px')
+  })
+
+  it('jumps to the final step through the slider', async () => {
+    renderMock.mockResolvedValue({ svg: '<svg></svg>' })
+    render(<PhaseReplayView report={cycleReport()} />)
+
+    fireEvent.change(screen.getByRole('slider', { name: 'Replay step' }), {
+      target: { value: '7' },
+    })
+
+    expect(screen.getByText('Step 8 of 8 · Done')).toBeInTheDocument()
+    expect(screen.getByText(/Collection complete: 2 objects freed/)).toBeInTheDocument()
+    expect(screen.getByText(/Freed 2/)).toBeInTheDocument()
+    // At the end the play button offers to start over.
+    expect(
+      await screen.findByRole('button', { name: 'Replay' })
+    ).toBeInTheDocument()
+  })
+
+  it('toggles between play and pause', async () => {
+    renderMock.mockResolvedValue({ svg: '<svg></svg>' })
+    render(<PhaseReplayView report={cycleReport()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }))
+    expect(
+      await screen.findByRole('button', { name: 'Pause' })
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause' }))
+    expect(
+      await screen.findByRole('button', { name: 'Play' })
+    ).toBeInTheDocument()
+  })
+
+  it('explains why a truncated report cannot be replayed', () => {
+    render(<PhaseReplayView report={cycleReport({ omittedEdgeDetails: 1 })} />)
+
+    expect(
+      screen.getByText(/topology card above explains why/)
+    ).toBeInTheDocument()
+    expect(renderMock).not.toHaveBeenCalled()
+  })
+
+  it('explains why truncated witnesses block the replay', () => {
+    render(<PhaseReplayView report={cycleReport({ omittedWitnesses: 1 })} />)
+
+    expect(
+      screen.getByText(/truncated restoration witnesses/)
+    ).toBeInTheDocument()
+    expect(renderMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a mermaid rendering failure', async () => {
+    renderMock.mockRejectedValue(new Error('boom'))
+    render(<PhaseReplayView report={cycleReport()} />)
+
+    expect(
+      await screen.findByText(/The replay frame could not be rendered: boom/)
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/playground/src/test/heapGraphParse.test.ts
+++ b/packages/playground/src/test/heapGraphParse.test.ts
@@ -9,6 +9,7 @@ import type {
   ValueKindCounts,
 } from '../gcReport'
 import { buildHeapGraph } from '../heapGraph'
+import { buildReplayPlan, replayStepSource } from '../phaseReplay'
 
 const counts = (): ValueKindCounts => ({
   class: 0,
@@ -109,6 +110,99 @@ function report(): GcCollectionReport {
   }
 }
 
+// A replayable report: rooted witness chain (1 → 12) plus a garbage cycle
+// (13 ↔ 14), so the frames exercise every status class, the active class
+// list, and both linkStyle emphases (bold and dimmed).
+function replayableReport(): GcCollectionReport {
+  const decisions: ObjectDecision[] = [
+    {
+      objectId: 1,
+      refCountBefore: 2,
+      heapIncomingEdges: 0,
+      trialRefCount: 2,
+      decision: 'survivor',
+      final: 'retained',
+    },
+    {
+      objectId: 12,
+      refCountBefore: 1,
+      heapIncomingEdges: 1,
+      trialRefCount: 0,
+      decision: 'candidate',
+      final: 'retained',
+    },
+    {
+      objectId: 13,
+      refCountBefore: 1,
+      heapIncomingEdges: 1,
+      trialRefCount: 0,
+      decision: 'candidate',
+      final: 'freed',
+    },
+    {
+      objectId: 14,
+      refCountBefore: 1,
+      heapIncomingEdges: 1,
+      trialRefCount: 0,
+      decision: 'candidate',
+      final: 'freed',
+    },
+  ]
+  const objects = [
+    { id: 1, kind: 'array' as const, label: 'Array#1' },
+    { id: 12, kind: 'instance' as const, label: 'Instance(Node)#12' },
+    { id: 13, kind: 'instance' as const, label: 'Instance(Node)#13' },
+    { id: 14, kind: 'instance' as const, label: 'Instance(Node)#14' },
+  ]
+  const snapshot = { objectCount: 4, trackedBytes: 0, byValueKind: counts() }
+  return {
+    before: snapshot,
+    after: snapshot,
+    objects,
+    globalRoots: [{ name: 'holder', objectId: 1 }],
+    omittedGlobalRoots: 0,
+    phases: {
+      trialDeletion: {
+        edgesVisited: 3,
+        candidates: 3,
+        objectDecisions: decisions,
+        visitedEdges: [
+          { fromId: 1, toId: 12, relation: { kind: 'arrayElement', index: 0 } },
+          {
+            fromId: 13,
+            toId: 14,
+            relation: { kind: 'instanceField', name: 'next' },
+          },
+          {
+            fromId: 14,
+            toId: 13,
+            relation: { kind: 'instanceField', name: 'next' },
+          },
+        ],
+        omittedObjectDecisions: 0,
+        omittedEdgeDetails: 0,
+      },
+      scan: {
+        restored: 1,
+        garbageCandidates: 2,
+        restoredObjects: [objects[1]],
+        garbageCandidateObjects: [objects[2], objects[3]],
+        restorationWitnesses: [
+          {
+            objectId: 12,
+            rootId: 1,
+            predecessorId: 1,
+            relation: { kind: 'arrayElement', index: 0 },
+          },
+        ],
+        omittedWitnesses: 0,
+      },
+      freeCycles: { freed: 2 },
+    },
+    collectedByValueKind: counts(),
+  }
+}
+
 describe('heap graph mermaid syntax', () => {
   it('is accepted by the real mermaid parser', async () => {
     const graph = buildHeapGraph(report())
@@ -118,5 +212,18 @@ describe('heap graph mermaid syntax', () => {
 
     mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' })
     await expect(mermaid.parse(graph.source)).resolves.toBeTruthy()
+  })
+
+  it('accepts every phase replay frame', async () => {
+    const plan = buildReplayPlan(replayableReport())
+    if (plan.status !== 'ok') {
+      throw new Error(`expected an ok plan, got: ${plan.reason}`)
+    }
+
+    mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' })
+    for (const step of plan.steps) {
+      const source = replayStepSource(plan.model, step)
+      await expect(mermaid.parse(source)).resolves.toBeTruthy()
+    }
   })
 })

--- a/packages/playground/src/test/phaseReplay.test.ts
+++ b/packages/playground/src/test/phaseReplay.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  GcCollectionReport,
+  GcObjectSummary,
+  GlobalRoot,
+  ObjectDecision,
+  RestorationWitness,
+  ValueKindCounts,
+  VisitedEdge,
+} from '../gcReport'
+import { buildReplayPlan, replayStepSource } from '../phaseReplay'
+
+const counts = (): ValueKindCounts => ({
+  class: 0,
+  instance: 0,
+  boundMethod: 0,
+  closure: 0,
+  array: 0,
+  hash: 0,
+  integer: 0,
+  boolean: 0,
+  string: 0,
+  null: 0,
+  error: 0,
+  compiledFunction: 0,
+  builtin: 0,
+  other: 0,
+})
+
+function survivor(objectId: number, trialRefCount = 1): ObjectDecision {
+  return {
+    objectId,
+    refCountBefore: trialRefCount,
+    heapIncomingEdges: 0,
+    trialRefCount,
+    decision: 'survivor',
+    final: 'retained',
+  }
+}
+
+function candidate(
+  objectId: number,
+  final: 'retained' | 'freed'
+): ObjectDecision {
+  return {
+    objectId,
+    refCountBefore: 1,
+    heapIncomingEdges: 1,
+    trialRefCount: 0,
+    decision: 'candidate',
+    final,
+  }
+}
+
+function makeReport(options: {
+  objects: GcObjectSummary[]
+  decisions: ObjectDecision[]
+  edges?: VisitedEdge[]
+  globalRoots?: GlobalRoot[]
+  witnesses?: RestorationWitness[]
+  omittedEdgeDetails?: number
+  omittedObjectDecisions?: number
+  omittedWitnesses?: number
+}): GcCollectionReport {
+  const edges = options.edges ?? []
+  const restoredObjects = options.objects.filter((object) =>
+    options.decisions.some(
+      (decision) =>
+        decision.objectId === object.id &&
+        decision.decision === 'candidate' &&
+        decision.final === 'retained'
+    )
+  )
+  const garbageObjects = options.objects.filter((object) =>
+    options.decisions.some(
+      (decision) => decision.objectId === object.id && decision.final === 'freed'
+    )
+  )
+  const snapshot = {
+    objectCount: options.objects.length,
+    trackedBytes: 0,
+    byValueKind: counts(),
+  }
+  return {
+    before: snapshot,
+    after: snapshot,
+    objects: options.objects,
+    globalRoots: options.globalRoots ?? [],
+    omittedGlobalRoots: 0,
+    phases: {
+      trialDeletion: {
+        edgesVisited: edges.length + (options.omittedEdgeDetails ?? 0),
+        candidates: restoredObjects.length + garbageObjects.length,
+        objectDecisions: options.decisions,
+        visitedEdges: edges,
+        omittedObjectDecisions: options.omittedObjectDecisions ?? 0,
+        omittedEdgeDetails: options.omittedEdgeDetails ?? 0,
+      },
+      scan: {
+        restored: restoredObjects.length,
+        garbageCandidates: garbageObjects.length,
+        restoredObjects,
+        garbageCandidateObjects: garbageObjects,
+        restorationWitnesses: options.witnesses ?? [],
+        omittedWitnesses: options.omittedWitnesses ?? 0,
+      },
+      freeCycles: { freed: garbageObjects.length },
+    },
+    collectedByValueKind: counts(),
+  }
+}
+
+/** The pure garbage cycle: 20 ↔ 21, both freed. */
+function cycleReport(options: {
+  omittedEdgeDetails?: number
+  omittedWitnesses?: number
+} = {}): GcCollectionReport {
+  return makeReport({
+    objects: [20, 21].map((id) => ({
+      id,
+      kind: 'instance' as const,
+      label: `Instance(Node)#${id}`,
+    })),
+    decisions: [candidate(20, 'freed'), candidate(21, 'freed')],
+    edges: [
+      { fromId: 20, toId: 21, relation: { kind: 'instanceField', name: 'next' } },
+      { fromId: 21, toId: 20, relation: { kind: 'instanceField', name: 'next' } },
+    ],
+    ...options,
+  })
+}
+
+/** A rooted chain: survivor Array#1 → Array#2 → Array#3, both restored. */
+function rootedChainReport(options: {
+  witnesses?: RestorationWitness[]
+  omittedWitnesses?: number
+} = {}): GcCollectionReport {
+  return makeReport({
+    objects: [1, 2, 3].map((id) => ({
+      id,
+      kind: 'array' as const,
+      label: `Array#${id}`,
+    })),
+    decisions: [
+      survivor(1, 1),
+      candidate(2, 'retained'),
+      candidate(3, 'retained'),
+    ],
+    edges: [
+      { fromId: 1, toId: 2, relation: { kind: 'arrayElement', index: 0 } },
+      { fromId: 2, toId: 3, relation: { kind: 'arrayElement', index: 1 } },
+    ],
+    witnesses: options.witnesses ?? [
+      {
+        objectId: 2,
+        rootId: 1,
+        predecessorId: 1,
+        relation: { kind: 'arrayElement', index: 0 },
+      },
+      {
+        objectId: 3,
+        rootId: 1,
+        predecessorId: 2,
+        relation: { kind: 'arrayElement', index: 1 },
+      },
+    ],
+    omittedWitnesses: options.omittedWitnesses,
+  })
+}
+
+function okPlan(report: GcCollectionReport) {
+  const plan = buildReplayPlan(report)
+  if (plan.status !== 'ok') {
+    throw new Error(`expected an ok plan, got: ${plan.reason}`)
+  }
+  return plan
+}
+
+function stripDecorations(source: string): string {
+  return source
+    .split('\n')
+    .filter(
+      (line) => !line.startsWith('  linkStyle ') && !line.startsWith('  class ')
+    )
+    .map((line) => line.replace(/:::\w+$/, ''))
+    .join('\n')
+}
+
+describe('buildReplayPlan', () => {
+  it('replays a pure cycle: subtract, condemn, free', () => {
+    const plan = okPlan(cycleReport())
+    const captions = plan.steps.map((step) => step.caption)
+
+    expect(plan.steps).toHaveLength(8)
+    expect(plan.steps.map((step) => step.phase)).toEqual([
+      'Start',
+      'Trial deletion',
+      'Trial deletion',
+      'Trial deletion',
+      'Scan',
+      'Free cycles',
+      'Free cycles',
+      'Done',
+    ])
+
+    expect(captions[1]).toContain(
+      'Trial deletion subtracts the fields["next"] reference Instance(Node)#20 → Instance(Node)#21: RC 1 → 0.'
+    )
+    expect(captions[1]).toContain('becomes a Candidate')
+    expect(plan.steps[1].statuses.get(21)).toBe('candidate')
+    expect(plan.steps[1].statuses.get(20)).toBe('pending')
+    expect(plan.steps[1].boldEdgeIndices).toEqual([0])
+
+    expect(plan.steps[2].statuses.get(20)).toBe('candidate')
+    expect(plan.steps[2].dimmedEdgeIndices).toEqual([0])
+
+    expect(captions[3]).toContain('Trial deletion complete: 2 Candidates')
+    expect(captions[3]).toContain('no drawn object kept a positive RC')
+
+    expect(captions[4]).toContain('Scan rescues nothing')
+    expect(plan.steps[4].statuses.get(20)).toBe('garbage')
+    expect(plan.steps[4].counts.garbage).toBe(2)
+
+    expect(captions[5]).toContain('Free cycles frees Instance(Node)#20')
+    expect(plan.steps[5].statuses.get(20)).toBe('freed')
+    expect(plan.steps[5].statuses.get(21)).toBe('garbage')
+
+    expect(captions[7]).toContain('2 objects freed')
+    expect(plan.steps[7].counts).toEqual({
+      candidates: 0,
+      restored: 0,
+      garbage: 0,
+      freed: 2,
+    })
+  })
+
+  it('replays a rooted chain with parents-first witness restores', () => {
+    const plan = okPlan(rootedChainReport())
+    const captions = plan.steps.map((step) => step.caption)
+
+    expect(plan.steps).toHaveLength(9)
+    expect(captions[3]).toContain(
+      '2 Candidates at RC 0; 1 Trial survivor keeps a positive RC'
+    )
+    expect(captions[4]).toContain('Scan walks the Trial survivor')
+
+    // Array#2 (depth 1) restores before Array#3 (depth 2).
+    expect(captions[5]).toContain(
+      'Scan restores Array#2: the witness path from Trial survivor Array#1 reaches it directly via items[0]'
+    )
+    expect(captions[6]).toContain(
+      'Scan restores Array#3: the witness path from Trial survivor Array#1 reaches it through Array#2 via items[1]'
+    )
+    expect(plan.steps[6].boldEdgeIndices).toEqual([0, 1])
+
+    expect(captions[7]).toContain('the candidate list is empty')
+    expect(captions[8]).toContain('nothing was freed')
+    expect(plan.steps[8].counts).toEqual({
+      candidates: 0,
+      restored: 2,
+      garbage: 0,
+      freed: 0,
+    })
+  })
+
+  it('replays a survivor-only heap without a scan or free phase', () => {
+    const plan = okPlan(
+      makeReport({
+        objects: [
+          { id: 1, kind: 'array', label: 'Array#1' },
+          { id: 5, kind: 'instance', label: 'Instance(Node)#5' },
+        ],
+        decisions: [
+          survivor(1, 1),
+          {
+            objectId: 5,
+            refCountBefore: 2,
+            heapIncomingEdges: 1,
+            trialRefCount: 1,
+            decision: 'survivor',
+            final: 'retained',
+          },
+        ],
+        edges: [
+          { fromId: 1, toId: 5, relation: { kind: 'arrayElement', index: 0 } },
+        ],
+      })
+    )
+
+    expect(plan.steps.map((step) => step.phase)).toEqual([
+      'Start',
+      'Trial deletion',
+      'Trial deletion',
+      'Done',
+    ])
+    expect(plan.steps[1].caption).toContain('RC 2 → 1')
+    expect(plan.steps[1].caption).not.toContain('Candidate')
+    expect(plan.steps[2].caption).toContain('there are no Candidates')
+    expect(plan.steps[3].caption).toContain('nothing was freed')
+  })
+
+  it('emits identical node and edge statements for every frame', () => {
+    for (const report of [cycleReport(), rootedChainReport()]) {
+      const plan = okPlan(report)
+      const sources = plan.steps.map((step) =>
+        replayStepSource(plan.model, step)
+      )
+      const baseline = stripDecorations(sources[0])
+      for (const source of sources) {
+        expect(stripDecorations(source)).toBe(baseline)
+      }
+    }
+  })
+
+  it('styles frames through classes and linkStyle only', () => {
+    const plan = okPlan(cycleReport())
+
+    const firstTrial = replayStepSource(plan.model, plan.steps[1])
+    expect(firstTrial).toContain('o21["Instance(Node)#35;21"]:::candidate')
+    expect(firstTrial).toContain('  linkStyle 0 stroke-width:3.5px')
+    expect(firstTrial).toContain('  class o20,o21 active')
+
+    const secondTrial = replayStepSource(plan.model, plan.steps[2])
+    expect(secondTrial).toContain('  linkStyle 0 opacity:0.35')
+    expect(secondTrial).toContain('  linkStyle 1 stroke-width:3.5px')
+
+    const done = replayStepSource(plan.model, plan.steps[7])
+    expect(done).toContain('o20["Instance(Node)#35;20"]:::freed')
+    expect(done).toContain('o21["Instance(Node)#35;21"]:::freed')
+  })
+
+  it('is unavailable when the topology graph is unavailable', () => {
+    const plan = buildReplayPlan(cycleReport({ omittedEdgeDetails: 1 }))
+    expect(plan.status).toBe('unavailable')
+    if (plan.status === 'unavailable') {
+      expect(plan.reason).toMatch(/topology card above explains why/)
+    }
+  })
+
+  it('is unavailable when restoration witnesses were truncated', () => {
+    const plan = buildReplayPlan(rootedChainReport({ omittedWitnesses: 1 }))
+    expect(plan.status).toBe('unavailable')
+    if (plan.status === 'unavailable') {
+      expect(plan.reason).toMatch(/truncated restoration witnesses/)
+    }
+  })
+
+  it('is unavailable when a restored object has no witness', () => {
+    const plan = buildReplayPlan(rootedChainReport({ witnesses: [] }))
+    expect(plan.status).toBe('unavailable')
+    if (plan.status === 'unavailable') {
+      expect(plan.reason).toMatch(/step-by-step replay/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds a **Phase replay** card to the GC report view, right below the heap topology graph. It turns the collection report into an animated, steppable walkthrough of the three collector phases over the exact same drawing:

- **Trial deletion** — one step per visited edge (in the report's sorted order): the caption narrates the RC arithmetic (`RC 1 → 0`), the subtracted arrow is bolded, consumed arrows dim, and an object reaching RC 0 turns amber as a **Candidate** (explicitly "not yet known to be garbage").
- **Scan** — survivors turn green at the phase boundary, then one step per restoration witness (ordered parents-first along the predecessor chain): the witness arrow is highlighted and the object turns blue as **Restored**; unreachable candidates then turn red as garbage.
- **Free cycles** — one step per freed object; freed nodes fade out. A final step summarizes freed vs retained.

Controls: Play/Pause (auto-advance), Back/Next, a step slider, a step counter with the current phase, and an `aria-live` caption plus a Candidates/Restored/Garbage/Freed counts line — every transition is narrated as text, so color is never the only channel.

## Implementation notes

- **Layout stability**: every frame emits the identical mermaid node and edge statements (same labels, same order); frames differ only in `:::` status classes, a `class … active` list, and theme-neutral `linkStyle` emphasis (bold width / dimmed opacity). Mermaid therefore computes the same layout for all frames — no jumping between steps.
- **Shared generator**: `heapGraph.ts` is refactored into `buildHeapGraphModel` + `renderHeapGraphModel`; the static topology card and the replay render from one model. `buildHeapGraph` output is byte-identical (existing exact-line tests unchanged and passing).
- **Honest determinism**: the card states the replay is a deterministic reconstruction from the report's sorted edges and witness paths, not the collector's actual event order, and that the real collector ran all three phases atomically (plan §12/§21).
- **Degrade rather than lie** (plan §13): the replay refuses to build when the topology graph is unavailable, when restoration witnesses were truncated, or when the report details don't fold back into the reported per-object numbers (the builder re-derives every trial RC and cross-checks decisions, witnesses, and freed counts while folding).
- Pure logic lives in `phaseReplay.ts` (fully unit-testable); `PhaseReplayView.tsx` mirrors `HeapGraphView`'s mermaid lifecycle and keeps the previous frame on screen while the next renders to avoid flicker.

## Testing

- `pnpm --filter monkey-playground test` — 57 tests pass, including new plan-builder unit tests (cycle / rooted chain / survivor-only / truncation / inconsistency), a frame layout-stability regression test, component tests for stepping, slider, play toggle, and degrade copy, and a real-mermaid parse of **every** replay frame (validates the `linkStyle`/`class` syntax, no mock).
- `pnpm --filter monkey-playground lint` — clean (only the pre-existing `Header.tsx` `no-img-element` warning).
- `pnpm --filter monkey-playground build` — passes.
- No Rust/WASM changes; UI-only over the existing report contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)