### PR TITLE
feat(playground): showcase .mbc bytecode snapshots with inspector, download, and run

### DIFF
--- a/compiler/lib.rs
+++ b/compiler/lib.rs
@@ -8,6 +8,8 @@ mod frame;
 pub mod op_code;
 mod op_code_test;
 pub mod snapshot;
+pub mod snapshot_layout;
+mod snapshot_layout_test;
 mod snapshot_test;
 pub mod symbol_table;
 mod symbol_table_test;

--- a/compiler/snapshot.rs
+++ b/compiler/snapshot.rs
@@ -540,17 +540,23 @@ impl<'a> Reader<'a> {
         }
     }
 
+    /// Cursor offset from the start of the buffer, for byte-range annotation
+    /// (see `snapshot_layout`).
+    pub(crate) fn position(&self) -> usize {
+        self.pos
+    }
+
     fn remaining(&self) -> usize {
         self.buf.len() - self.pos
     }
 
-    fn read_u8(&mut self) -> Result<u8, SnapshotError> {
+    pub(crate) fn read_u8(&mut self) -> Result<u8, SnapshotError> {
         let byte = *self.buf.get(self.pos).ok_or(SnapshotError::UnexpectedEof)?;
         self.pos += 1;
         Ok(byte)
     }
 
-    fn read_exact(&mut self, len: usize) -> Result<&'a [u8], SnapshotError> {
+    pub(crate) fn read_exact(&mut self, len: usize) -> Result<&'a [u8], SnapshotError> {
         if len > self.remaining() {
             return Err(SnapshotError::UnexpectedEof);
         }
@@ -606,7 +612,7 @@ impl<'a> Reader<'a> {
     }
 
     /// ULEB128 checked into `usize` (they differ on wasm32).
-    fn read_usize(&mut self) -> Result<usize, SnapshotError> {
+    pub(crate) fn read_usize(&mut self) -> Result<usize, SnapshotError> {
         let value = self.read_uleb128()?;
         usize::try_from(value).map_err(|_| SnapshotError::IntegerOverflow)
     }

--- a/compiler/snapshot_layout.rs
+++ b/compiler/snapshot_layout.rs
@@ -1,0 +1,337 @@
+//! Byte-range annotations for `.mbc` snapshots (the playground inspector).
+//!
+//! [`describe_bytecode`] funnels the buffer through [`read_bytecode`] first —
+//! the full L1 validation — and only then re-walks it, recording one region
+//! per format field. Regions are emitted in file order, are never empty, and
+//! tile the buffer exactly: the first starts at offset 0, each next region
+//! starts where the previous one ends, and the last ends at `byte_length`.
+//! Consumers can therefore render a complete annotated hexdump without gap
+//! or overlap handling.
+
+use std::convert::TryInto;
+
+use serde::Serialize;
+
+use crate::op_code::{read_operands, Opcode, DEFINITIONS};
+use crate::snapshot::{
+    read_bytecode, Reader, SnapshotError, FLAG_HAS_DEBUG_INFO, TAG_FUNCTION, TAG_INTEGER,
+    TAG_STRING,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SnapshotSection {
+    Header,
+    Main,
+    Constants,
+    Debug,
+}
+
+/// One annotated byte range. `label` names the format field ("magic",
+/// "const[0] tag", "OpConst 1"); `detail` explains the decoded value.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotRegion {
+    pub offset: usize,
+    pub length: usize,
+    pub section: SnapshotSection,
+    pub label: String,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotLayout {
+    pub byte_length: usize,
+    pub format_version: u8,
+    /// Rendered as `0x{:08x}`: a JSON string keeps the u32 exact in JS.
+    pub abi_fingerprint: String,
+    pub has_debug_info: bool,
+    pub regions: Vec<SnapshotRegion>,
+}
+
+/// Annotate every byte of a validated `.mbc` buffer.
+///
+/// The buffer is untrusted input; it is validated with [`read_bytecode`]
+/// before the annotating walk, so any `Err` here carries the same
+/// [`SnapshotError`] the loader would report.
+pub fn describe_bytecode(buf: &[u8]) -> Result<SnapshotLayout, SnapshotError> {
+    read_bytecode(buf)?;
+    Walker {
+        buf,
+        reader: Reader::new(buf),
+        regions: Vec::new(),
+    }
+    .walk()
+}
+
+struct Walker<'a> {
+    buf: &'a [u8],
+    reader: Reader<'a>,
+    regions: Vec<SnapshotRegion>,
+}
+
+impl<'a> Walker<'a> {
+    fn walk(mut self) -> Result<SnapshotLayout, SnapshotError> {
+        use SnapshotSection::{Constants, Debug, Header, Main};
+
+        self.record(
+            Header,
+            "magic",
+            |r| r.read_exact(4),
+            |_| "file signature \"MBC\\0\"".to_string(),
+        )?;
+        let format_version = self.record(Header, "version", Reader::read_u8, |version| {
+            format!("container format version {}", version)
+        })?;
+        let fingerprint_bytes = self.record(
+            Header,
+            "abi fingerprint",
+            |r| r.read_exact(4),
+            |bytes| {
+                let value = u32::from_le_bytes(bytes[..4].try_into().expect("4-byte slice"));
+                format!(
+                    "0x{:08x} — FNV-1a over the opcode and builtin tables (little-endian)",
+                    value
+                )
+            },
+        )?;
+        let abi_fingerprint = format!(
+            "0x{:08x}",
+            u32::from_le_bytes(fingerprint_bytes[..4].try_into().expect("4-byte slice"))
+        );
+        let flags = self.record(Header, "flags", Reader::read_u8, |flags| {
+            if flags & FLAG_HAS_DEBUG_INFO != 0 {
+                format!("0b{:08b} — debug info present", flags)
+            } else {
+                format!("0b{:08b} — debug info stripped", flags)
+            }
+        })?;
+        let has_debug_info = flags & FLAG_HAS_DEBUG_INFO != 0;
+
+        let main_len = self.record(Main, "main length", Reader::read_usize, |len| {
+            format!("{} bytes of main instructions follow (ULEB128)", len)
+        })?;
+        self.record_instructions(Main, "main", main_len)?;
+
+        let constant_count =
+            self.record(Constants, "constant count", Reader::read_usize, |count| {
+                format!("{} constants (ULEB128)", count)
+            })?;
+        // Stream names for function constants, reused by the debug section.
+        let mut streams: Vec<String> = Vec::with_capacity(constant_count);
+        for index in 0..constant_count {
+            let tag_label = format!("const[{}] tag", index);
+            let tag = self.record(Constants, &tag_label, Reader::read_u8, |tag| match *tag {
+                TAG_INTEGER => "TAG_INTEGER (1) — SLEB128 value".to_string(),
+                TAG_STRING => "TAG_STRING (2) — length-prefixed UTF-8".to_string(),
+                TAG_FUNCTION => "TAG_FUNCTION (3) — name, locals, params, body".to_string(),
+                other => format!("unknown tag {}", other),
+            })?;
+            streams.push(format!("const[{}]", index));
+            match tag {
+                TAG_INTEGER => {
+                    self.record(
+                        Constants,
+                        format!("const[{}] value", index),
+                        Reader::read_sleb128,
+                        |value| format!("{} (SLEB128)", value),
+                    )?;
+                }
+                TAG_STRING => {
+                    self.record_str(Constants, &format!("const[{}] text", index))?;
+                }
+                TAG_FUNCTION => {
+                    let name = self.record_str(Constants, &format!("const[{}] name", index))?;
+                    self.record(
+                        Constants,
+                        format!("const[{}] locals", index),
+                        Reader::read_usize,
+                        |count| format!("{} local slots", count),
+                    )?;
+                    self.record(
+                        Constants,
+                        format!("const[{}] params", index),
+                        Reader::read_usize,
+                        |count| format!("{} parameters", count),
+                    )?;
+                    let body_len = self.record(
+                        Constants,
+                        format!("const[{}] body length", index),
+                        Reader::read_usize,
+                        |len| format!("{} bytes of function instructions follow (ULEB128)", len),
+                    )?;
+                    let stream = if name.is_empty() {
+                        format!("const[{}] fn", index)
+                    } else {
+                        format!("fn {}", name)
+                    };
+                    self.record_instructions(Constants, &stream, body_len)?;
+                    streams[index] = stream;
+                }
+                other => return Err(SnapshotError::BadTag(other)),
+            }
+        }
+
+        if has_debug_info {
+            self.record_debug_info("main")?;
+            let entry_count =
+                self.record(Debug, "debug fn count", Reader::read_usize, |count| {
+                    format!("{} function debug entries", count)
+                })?;
+            for _ in 0..entry_count {
+                let start = self.reader.position();
+                let constant_index = self.reader.read_usize()?;
+                let stream = streams
+                    .get(constant_index)
+                    .cloned()
+                    .unwrap_or_else(|| format!("const[{}]", constant_index));
+                self.push(
+                    start,
+                    Debug,
+                    "debug fn index".to_string(),
+                    format!("pc→span entries for {}", stream),
+                );
+                self.record_debug_info(&stream)?;
+            }
+        }
+
+        // read_bytecode already rejected trailing bytes; this guards the
+        // walker itself against drifting out of sync with the codec.
+        if self.reader.position() != self.buf.len() {
+            return Err(SnapshotError::TrailingBytes);
+        }
+        Ok(SnapshotLayout {
+            byte_length: self.buf.len(),
+            format_version,
+            abi_fingerprint,
+            has_debug_info,
+            regions: self.regions,
+        })
+    }
+
+    /// Read one field and record the byte range it occupied. Zero-length
+    /// fields (e.g. the bytes of an empty string) produce no region.
+    fn record<T>(
+        &mut self,
+        section: SnapshotSection,
+        label: impl Into<String>,
+        read: impl FnOnce(&mut Reader<'a>) -> Result<T, SnapshotError>,
+        detail: impl FnOnce(&T) -> String,
+    ) -> Result<T, SnapshotError> {
+        let start = self.reader.position();
+        let value = read(&mut self.reader)?;
+        let detail = detail(&value);
+        self.push(start, section, label.into(), detail);
+        Ok(value)
+    }
+
+    fn push(&mut self, start: usize, section: SnapshotSection, label: String, detail: String) {
+        let end = self.reader.position();
+        if end == start {
+            return;
+        }
+        self.regions.push(SnapshotRegion {
+            offset: start,
+            length: end - start,
+            section,
+            label,
+            detail,
+        });
+    }
+
+    /// Length prefix and UTF-8 bytes as two regions; returns the text.
+    fn record_str(
+        &mut self,
+        section: SnapshotSection,
+        label: &str,
+    ) -> Result<String, SnapshotError> {
+        let len = self.record(section, format!("{} length", label), Reader::read_usize, |len| {
+            format!("{} bytes (ULEB128)", len)
+        })?;
+        let start = self.reader.position();
+        let bytes = self.reader.read_exact(len)?;
+        let text = String::from_utf8(bytes.to_vec()).map_err(|_| SnapshotError::BadUtf8)?;
+        self.push(start, section, label.to_string(), format!("{:?}", text));
+        Ok(text)
+    }
+
+    /// One region per instruction, labelled with its disassembly. The stream
+    /// was already validated, but decode defensively anyway: the walker must
+    /// never panic (it runs behind the wasm boundary).
+    fn record_instructions(
+        &mut self,
+        section: SnapshotSection,
+        stream: &str,
+        len: usize,
+    ) -> Result<(), SnapshotError> {
+        let start = self.reader.position();
+        let bytes = self.reader.read_exact(len)?;
+        let mut pc = 0;
+        while pc < len {
+            let opcode = Opcode::from_repr(bytes[pc]).ok_or_else(|| {
+                SnapshotError::InvalidInstruction(format!(
+                    "unknown opcode 0x{:02x} (stream {}, offset {})",
+                    bytes[pc], stream, pc
+                ))
+            })?;
+            let definition = DEFINITIONS.get(&opcode).ok_or_else(|| {
+                SnapshotError::InvalidInstruction(format!(
+                    "missing definition for {:?} (stream {}, offset {})",
+                    opcode, stream, pc
+                ))
+            })?;
+            let operand_len: usize = definition
+                .operand_widths()
+                .iter()
+                .map(|w| *w as usize)
+                .sum();
+            if pc + 1 + operand_len > len {
+                return Err(SnapshotError::InvalidInstruction(format!(
+                    "truncated operands for {} (stream {}, offset {})",
+                    definition.name(),
+                    stream,
+                    pc
+                )));
+            }
+            let (operands, _) = read_operands(definition, &bytes[pc + 1..]);
+            let mut label = definition.name().to_string();
+            for operand in &operands {
+                label.push_str(&format!(" {}", operand));
+            }
+            let end = start + pc + 1 + operand_len;
+            self.regions.push(SnapshotRegion {
+                offset: start + pc,
+                length: end - (start + pc),
+                section,
+                label,
+                detail: format!("{} pc {:04}", stream, pc),
+            });
+            pc += 1 + operand_len;
+        }
+        Ok(())
+    }
+
+    /// Span count plus one region per `{pc, start, end}` triple.
+    fn record_debug_info(&mut self, stream: &str) -> Result<(), SnapshotError> {
+        let count = self.record(
+            SnapshotSection::Debug,
+            format!("{} span count", stream),
+            Reader::read_usize,
+            |count| format!("{} pc→span entries (ULEB128)", count),
+        )?;
+        for _ in 0..count {
+            let start = self.reader.position();
+            let pc = self.reader.read_usize()?;
+            let span_start = self.reader.read_usize()?;
+            let span_end = self.reader.read_usize()?;
+            self.push(
+                start,
+                SnapshotSection::Debug,
+                format!("{} pc {:04}", stream, pc),
+                format!("source {}..{}", span_start, span_end),
+            );
+        }
+        Ok(())
+    }
+}

--- a/compiler/snapshot_layout_test.rs
+++ b/compiler/snapshot_layout_test.rs
@@ -1,0 +1,136 @@
+#[cfg(test)]
+mod tests {
+    use parser::parse;
+
+    use crate::compiler::Compiler;
+    use crate::snapshot::{
+        bytecode_abi_fingerprint, write_bytecode, SnapshotError, FORMAT_VERSION,
+    };
+    use crate::snapshot_layout::{
+        describe_bytecode, SnapshotLayout, SnapshotRegion, SnapshotSection,
+    };
+
+    /// One function, one integer, and one string constant, so every tag shows up.
+    const SOURCE: &str = r#"let add = fn(a, b) { a + b }; add(1, "hi")"#;
+
+    fn snapshot_of(source: &str, strip_debug: bool) -> Vec<u8> {
+        let program = parse(source).expect("source parses");
+        let mut compiler = Compiler::new();
+        let bytecode = compiler.compile(&program).expect("source compiles");
+        write_bytecode(&bytecode, strip_debug).expect("bytecode serializes")
+    }
+
+    fn region<'a>(layout: &'a SnapshotLayout, label: &str) -> &'a SnapshotRegion {
+        layout
+            .regions
+            .iter()
+            .find(|region| region.label == label)
+            .unwrap_or_else(|| panic!("missing region {:?}", label))
+    }
+
+    #[test]
+    fn regions_tile_the_entire_buffer() {
+        for strip_debug in [false, true] {
+            let bytes = snapshot_of(SOURCE, strip_debug);
+            let layout = describe_bytecode(&bytes).expect("valid snapshot describes");
+            assert_eq!(layout.byte_length, bytes.len());
+
+            let mut cursor = 0;
+            for region in &layout.regions {
+                assert_eq!(region.offset, cursor, "gap or overlap at {:?}", region.label);
+                assert!(region.length >= 1, "empty region {:?}", region.label);
+                cursor = region.offset + region.length;
+            }
+            assert_eq!(cursor, layout.byte_length);
+        }
+    }
+
+    #[test]
+    fn header_regions_expose_format_facts() {
+        let layout = describe_bytecode(&snapshot_of(SOURCE, false)).unwrap();
+        assert_eq!(layout.format_version, FORMAT_VERSION);
+        assert_eq!(layout.abi_fingerprint, format!("0x{:08x}", bytecode_abi_fingerprint()));
+        assert!(layout.has_debug_info);
+
+        let labels: Vec<&str> = layout.regions[..4]
+            .iter()
+            .map(|region| region.label.as_str())
+            .collect();
+        assert_eq!(labels, ["magic", "version", "abi fingerprint", "flags"]);
+        assert!(layout.regions[..4]
+            .iter()
+            .all(|region| region.section == SnapshotSection::Header));
+        assert!(region(&layout, "abi fingerprint")
+            .detail
+            .contains(&layout.abi_fingerprint));
+        assert!(region(&layout, "flags")
+            .detail
+            .contains("debug info present"));
+
+        let stripped = describe_bytecode(&snapshot_of(SOURCE, true)).unwrap();
+        assert!(!stripped.has_debug_info);
+        assert!(region(&stripped, "flags")
+            .detail
+            .contains("debug info stripped"));
+    }
+
+    #[test]
+    fn instruction_regions_disassemble_both_streams() {
+        let layout = describe_bytecode(&snapshot_of(SOURCE, false)).unwrap();
+
+        let call = region(&layout, "OpCall 2");
+        assert_eq!(call.section, SnapshotSection::Main);
+        assert!(call.detail.starts_with("main pc "));
+
+        let add = region(&layout, "OpAdd");
+        assert_eq!(add.section, SnapshotSection::Constants);
+        assert!(add.detail.starts_with("fn add pc "));
+    }
+
+    #[test]
+    fn constant_regions_annotate_tags_and_values() {
+        let layout = describe_bytecode(&snapshot_of(SOURCE, false)).unwrap();
+
+        assert_eq!(region(&layout, "constant count").detail, "3 constants (ULEB128)");
+        assert!(region(&layout, "const[0] tag")
+            .detail
+            .contains("TAG_FUNCTION"));
+        assert_eq!(region(&layout, "const[0] name").detail, "\"add\"");
+        assert_eq!(region(&layout, "const[0] locals").detail, "2 local slots");
+        assert_eq!(region(&layout, "const[0] params").detail, "2 parameters");
+        assert!(region(&layout, "const[1] tag")
+            .detail
+            .contains("TAG_INTEGER"));
+        assert_eq!(region(&layout, "const[1] value").detail, "1 (SLEB128)");
+        assert!(region(&layout, "const[2] tag")
+            .detail
+            .contains("TAG_STRING"));
+        assert_eq!(region(&layout, "const[2] text").detail, "\"hi\"");
+    }
+
+    #[test]
+    fn debug_regions_map_pc_to_source_and_stripping_removes_them() {
+        let layout = describe_bytecode(&snapshot_of(SOURCE, false)).unwrap();
+        let main_spans = region(&layout, "main span count");
+        assert_eq!(main_spans.section, SnapshotSection::Debug);
+        assert!(layout.regions.iter().any(|region| {
+            region.section == SnapshotSection::Debug
+                && region.label.starts_with("main pc ")
+                && region.detail.starts_with("source ")
+        }));
+        assert!(region(&layout, "debug fn index").detail.contains("fn add"));
+
+        let stripped = describe_bytecode(&snapshot_of(SOURCE, true)).unwrap();
+        assert!(stripped
+            .regions
+            .iter()
+            .all(|region| region.section != SnapshotSection::Debug));
+    }
+
+    #[test]
+    fn describe_rejects_what_the_loader_rejects() {
+        let mut bytes = snapshot_of(SOURCE, false);
+        bytes[0] = b'X';
+        assert_eq!(describe_bytecode(&bytes), Err(SnapshotError::BadMagic));
+    }
+}

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -146,8 +146,14 @@ function App() {
   const [snapshotRun, setSnapshotRun] = useState<SnapshotRunState>({
     status: 'idle',
   })
+  const [snapshotStale, setSnapshotStale] = useState(false)
   const snapshotRunRequestId = useRef(0)
   const editorRef = useRef<EditorHandle>(null)
+  const latestCode = useRef(code)
+
+  useEffect(() => {
+    latestCode.current = code
+  }, [code])
 
   const astSelection = useMemo(
     () =>
@@ -160,10 +166,13 @@ function App() {
     [code, selection]
   )
 
+  // Keep the last build mounted and flag it stale instead of unmounting the
+  // panel: unmounting would reset the output scroll position and drop keyboard
+  // focus from the strip toggle on every rebuild.
   const invalidateSnapshot = useCallback(() => {
     snapshotRunRequestId.current += 1
     setSnapshotRun({ status: 'idle' })
-    setSnapshotBuild({ status: 'idle' })
+    setSnapshotStale(true)
   }, [])
 
   const compileCode = useCallback((source: string) => {
@@ -199,6 +208,7 @@ function App() {
           message: getErrorMessage(error),
         })
       }
+      setSnapshotStale(false)
     },
     []
   )
@@ -215,12 +225,19 @@ function App() {
 
   const editorOnChange = useCallback(
     (value: string) => {
+      // CodeMirror reports a document change even when the replacement text is
+      // identical (e.g. typing over a selection with the same character);
+      // setCode would bail on the equal string, so invalidating here would
+      // strand the snapshot as stale with no rebuild ever scheduled.
+      if (value === code) {
+        return
+      }
       setCode(value)
       gcRequestId.current += 1
       setGcState({ status: 'idle' })
       invalidateSnapshot()
     },
-    [invalidateSnapshot]
+    [code, invalidateSnapshot]
   )
 
   const handleStripDebugChange = useCallback(
@@ -245,13 +262,19 @@ function App() {
         parser: 'monkey',
         plugins: [monkeyPlugin.default as unknown as Plugin],
       })
-      setCode(formatted)
-      if (formatted !== code) {
-        invalidateSnapshot()
+      if (latestCode.current !== code) {
+        // The source was edited while prettier was loading; applying this
+        // result would silently revert those edits.
+        return
       }
+      if (formatted === code) {
+        return
+      }
+      setCode(formatted)
       setSelection(null)
       gcRequestId.current += 1
       setGcState({ status: 'idle' })
+      invalidateSnapshot()
       compileCode(formatted)
     } catch (error) {
       const message = getErrorMessage(error)
@@ -319,7 +342,7 @@ function App() {
   }, [code])
 
   const runSnapshotBytes = useCallback(async () => {
-    if (snapshotBuild.status !== 'ok') {
+    if (snapshotBuild.status !== 'ok' || snapshotStale) {
       return
     }
     const requestId = snapshotRunRequestId.current + 1
@@ -339,7 +362,7 @@ function App() {
         })
       }
     }
-  }, [snapshotBuild])
+  }, [snapshotBuild, snapshotStale])
 
   const highlightSourceSpan = useCallback(
     (span: SourceSpan) => {
@@ -490,7 +513,7 @@ function App() {
             <Button
               size="2"
               onClick={runSnapshotBytes}
-              disabled={snapshotBuild.status !== 'ok'}
+              disabled={snapshotBuild.status !== 'ok' || snapshotStale}
               loading={snapshotRun.status === 'running'}
             >
               Run snapshot
@@ -520,6 +543,7 @@ function App() {
               <SnapshotView
                 build={snapshotBuild}
                 run={snapshotRun}
+                stale={snapshotStale}
                 stripDebug={stripDebug}
                 onStripDebugChange={handleStripDebugChange}
                 onErrorSpanSelect={handleErrorSpanSelect}

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -14,6 +14,12 @@ import { Editor, type EditorHandle } from './Editor'
 import { GcReportView, type GcPanelState } from './GcReportView'
 import type { SourceSpan } from './gcReport'
 import { runGc } from './gcRunner'
+import {
+  SnapshotView,
+  type SnapshotBuildState,
+  type SnapshotRunState,
+} from './SnapshotView'
+import { buildSnapshot, runSnapshot } from './snapshotRunner'
 
 interface Snippet {
   label: string
@@ -94,7 +100,7 @@ makeCycle();
   },
 ]
 
-type OutputView = 'ast' | 'bytecode' | 'gc'
+type OutputView = 'ast' | 'bytecode' | 'gc' | 'snapshot'
 
 const panelClass =
   'flex min-h-0 min-w-0 h-full flex-col overflow-hidden bg-(--color-background)'
@@ -128,30 +134,52 @@ function App() {
   const [isFormatting, setIsFormatting] = useState(false)
   const [gcState, setGcState] = useState<GcPanelState>({ status: 'idle' })
   const gcRequestId = useRef(0)
+  const [stripDebug, setStripDebug] = useState(false)
+  const [snapshotBuild, setSnapshotBuild] = useState<SnapshotBuildState>({
+    status: 'idle',
+  })
+  const [snapshotRun, setSnapshotRun] = useState<SnapshotRunState>({
+    status: 'idle',
+  })
+  const snapshotRunRequestId = useRef(0)
   const editorRef = useRef<EditorHandle>(null)
 
-  const compileCode = useCallback((source: string) => {
-    try {
-      const astJson = parse(source)
-      const ast = JSON.parse(astJson) as unknown
-      setAstData(ast)
-      setAstOutput(JSON.stringify(ast, null, 2))
-    } catch (error) {
-      const message = getErrorMessage(error)
-      setAstData(null)
-      setAstOutput(message)
-    }
+  const compileCode = useCallback(
+    (source: string) => {
+      try {
+        const astJson = parse(source)
+        const ast = JSON.parse(astJson) as unknown
+        setAstData(ast)
+        setAstOutput(JSON.stringify(ast, null, 2))
+      } catch (error) {
+        const message = getErrorMessage(error)
+        setAstData(null)
+        setAstOutput(message)
+      }
 
-    try {
-      const debugJson = compile_with_debug(source)
-      const view = JSON.parse(debugJson) as BytecodeDebugView
-      setBytecodeDebugView(view)
-      setCompilerOutput(view.detail)
-    } catch (error) {
-      setBytecodeDebugView(null)
-      setCompilerOutput(getErrorMessage(error))
-    }
-  }, [])
+      try {
+        const debugJson = compile_with_debug(source)
+        const view = JSON.parse(debugJson) as BytecodeDebugView
+        setBytecodeDebugView(view)
+        setCompilerOutput(view.detail)
+      } catch (error) {
+        setBytecodeDebugView(null)
+        setCompilerOutput(getErrorMessage(error))
+      }
+
+      snapshotRunRequestId.current += 1
+      setSnapshotRun({ status: 'idle' })
+      try {
+        setSnapshotBuild(buildSnapshot(source, stripDebug))
+      } catch (error) {
+        setSnapshotBuild({
+          status: 'invalid',
+          message: getErrorMessage(error),
+        })
+      }
+    },
+    [stripDebug]
+  )
 
   const debouncedCompile = useMemo(
     () => debounce(compileCode, 200),
@@ -162,6 +190,8 @@ function App() {
     setCode(value)
     gcRequestId.current += 1
     setGcState({ status: 'idle' })
+    snapshotRunRequestId.current += 1
+    setSnapshotRun({ status: 'idle' })
   }, [])
 
   const formatCode = useCallback(async () => {
@@ -234,11 +264,34 @@ function App() {
     }
   }, [code])
 
+  const runSnapshotBytes = useCallback(async () => {
+    if (snapshotBuild.status !== 'ok') {
+      return
+    }
+    const requestId = snapshotRunRequestId.current + 1
+    snapshotRunRequestId.current = requestId
+    setSnapshotRun({ status: 'running' })
+
+    try {
+      const result = await runSnapshot(snapshotBuild.bytes)
+      if (snapshotRunRequestId.current === requestId) {
+        setSnapshotRun(result)
+      }
+    } catch (error) {
+      if (snapshotRunRequestId.current === requestId) {
+        setSnapshotRun({
+          status: 'invalid',
+          message: getErrorMessage(error),
+        })
+      }
+    }
+  }, [snapshotBuild])
+
   const handleNodeSelect = useCallback((start: number, end: number) => {
     editorRef.current?.highlightRange(start, end)
   }, [])
 
-  const handleGcErrorSpanSelect = useCallback((span: SourceSpan) => {
+  const handleErrorSpanSelect = useCallback((span: SourceSpan) => {
     editorRef.current?.highlightRange(span.start, span.end)
   }, [])
 
@@ -281,6 +334,22 @@ function App() {
       editor?.clearHighlight()
     }
   }, [gcState, outputView])
+
+  useEffect(() => {
+    if (
+      outputView !== 'snapshot' ||
+      snapshotRun.status !== 'error' ||
+      snapshotRun.span === null
+    ) {
+      return
+    }
+    const { span } = snapshotRun
+    const editor = editorRef.current
+    editor?.highlightRange(span.start, span.end)
+    return () => {
+      editor?.clearHighlight()
+    }
+  }, [snapshotRun, outputView])
 
   return (
     <div className="grid min-h-0 flex-1 grid-cols-2 overflow-hidden max-[780px]:grid-cols-1 max-[780px]:grid-rows-2">
@@ -340,6 +409,9 @@ function App() {
               Bytecode
             </SegmentedControl.Item>
             <SegmentedControl.Item value="gc">GC</SegmentedControl.Item>
+            <SegmentedControl.Item value="snapshot">
+              Snapshot
+            </SegmentedControl.Item>
           </SegmentedControl.Root>
           {outputView === 'gc' ? (
             <Button
@@ -348,6 +420,16 @@ function App() {
               loading={gcState.status === 'running'}
             >
               Run GC
+            </Button>
+          ) : null}
+          {outputView === 'snapshot' ? (
+            <Button
+              size="2"
+              onClick={runSnapshotBytes}
+              disabled={snapshotBuild.status !== 'ok'}
+              loading={snapshotRun.status === 'running'}
+            >
+              Run snapshot
             </Button>
           ) : null}
         </div>
@@ -365,7 +447,18 @@ function App() {
             <div className="min-h-0 flex-1 overflow-auto bg-(--gray-1) bg-[image:radial-gradient(circle_at_top_right,var(--accent-a3),transparent_34%)] p-4.5">
               <GcReportView
                 state={gcState}
-                onErrorSpanSelect={handleGcErrorSpanSelect}
+                onErrorSpanSelect={handleErrorSpanSelect}
+              />
+            </div>
+          ) : null}
+          {outputView === 'snapshot' ? (
+            <div className="min-h-0 flex-1 overflow-auto bg-(--gray-1) p-4.5">
+              <SnapshotView
+                build={snapshotBuild}
+                run={snapshotRun}
+                stripDebug={stripDebug}
+                onStripDebugChange={setStripDebug}
+                onErrorSpanSelect={handleErrorSpanSelect}
               />
             </div>
           ) : null}

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -14,6 +14,7 @@ import { Editor, type EditorHandle } from './Editor'
 import { GcReportView, type GcPanelState } from './GcReportView'
 import type { SourceSpan } from './gcReport'
 import { runGc } from './gcRunner'
+import { utf16OffsetToUtf8Byte, utf8ByteSpanToUtf16 } from './sourceSpan'
 import {
   SnapshotView,
   type SnapshotBuildState,
@@ -106,7 +107,11 @@ const panelClass =
   'flex min-h-0 min-w-0 h-full flex-col overflow-hidden bg-(--color-background)'
 
 const toolbarClass =
-  'flex shrink-0 items-center justify-between gap-3 border-b border-(--gray-a5) bg-(--color-background) px-3 py-2'
+  'flex shrink-0 items-center gap-3 border-b border-(--gray-a5) bg-(--color-background) px-3 py-2'
+
+const editorToolbarClass = `${toolbarClass} justify-between`
+
+const outputToolbarClass = `${toolbarClass} flex-wrap`
 
 const editorFrameClass =
   'flex min-h-0 flex-1 flex-col overflow-hidden bg-(--color-background)'
@@ -144,33 +149,50 @@ function App() {
   const snapshotRunRequestId = useRef(0)
   const editorRef = useRef<EditorHandle>(null)
 
-  const compileCode = useCallback(
-    (source: string) => {
-      try {
-        const astJson = parse(source)
-        const ast = JSON.parse(astJson) as unknown
-        setAstData(ast)
-        setAstOutput(JSON.stringify(ast, null, 2))
-      } catch (error) {
-        const message = getErrorMessage(error)
-        setAstData(null)
-        setAstOutput(message)
-      }
+  const astSelection = useMemo(
+    () =>
+      selection === null
+        ? null
+        : {
+            from: utf16OffsetToUtf8Byte(code, selection.from),
+            to: utf16OffsetToUtf8Byte(code, selection.to),
+          },
+    [code, selection]
+  )
 
-      try {
-        const debugJson = compile_with_debug(source)
-        const view = JSON.parse(debugJson) as BytecodeDebugView
-        setBytecodeDebugView(view)
-        setCompilerOutput(view.detail)
-      } catch (error) {
-        setBytecodeDebugView(null)
-        setCompilerOutput(getErrorMessage(error))
-      }
+  const invalidateSnapshot = useCallback(() => {
+    snapshotRunRequestId.current += 1
+    setSnapshotRun({ status: 'idle' })
+    setSnapshotBuild({ status: 'idle' })
+  }, [])
 
-      snapshotRunRequestId.current += 1
-      setSnapshotRun({ status: 'idle' })
+  const compileCode = useCallback((source: string) => {
+    try {
+      const astJson = parse(source)
+      const ast = JSON.parse(astJson) as unknown
+      setAstData(ast)
+      setAstOutput(JSON.stringify(ast, null, 2))
+    } catch (error) {
+      const message = getErrorMessage(error)
+      setAstData(null)
+      setAstOutput(message)
+    }
+
+    try {
+      const debugJson = compile_with_debug(source)
+      const view = JSON.parse(debugJson) as BytecodeDebugView
+      setBytecodeDebugView(view)
+      setCompilerOutput(view.detail)
+    } catch (error) {
+      setBytecodeDebugView(null)
+      setCompilerOutput(getErrorMessage(error))
+    }
+  }, [])
+
+  const compileSnapshot = useCallback(
+    (source: string, shouldStripDebug: boolean) => {
       try {
-        setSnapshotBuild(buildSnapshot(source, stripDebug))
+        setSnapshotBuild(buildSnapshot(source, shouldStripDebug))
       } catch (error) {
         setSnapshotBuild({
           status: 'invalid',
@@ -178,7 +200,7 @@ function App() {
         })
       }
     },
-    [stripDebug]
+    []
   )
 
   const debouncedCompile = useMemo(
@@ -186,13 +208,31 @@ function App() {
     [compileCode]
   )
 
-  const editorOnChange = useCallback((value: string) => {
-    setCode(value)
-    gcRequestId.current += 1
-    setGcState({ status: 'idle' })
-    snapshotRunRequestId.current += 1
-    setSnapshotRun({ status: 'idle' })
-  }, [])
+  const debouncedSnapshotCompile = useMemo(
+    () => debounce(compileSnapshot, 200),
+    [compileSnapshot]
+  )
+
+  const editorOnChange = useCallback(
+    (value: string) => {
+      setCode(value)
+      gcRequestId.current += 1
+      setGcState({ status: 'idle' })
+      invalidateSnapshot()
+    },
+    [invalidateSnapshot]
+  )
+
+  const handleStripDebugChange = useCallback(
+    (nextStripDebug: boolean) => {
+      if (nextStripDebug === stripDebug) {
+        return
+      }
+      invalidateSnapshot()
+      setStripDebug(nextStripDebug)
+    },
+    [invalidateSnapshot, stripDebug]
+  )
 
   const formatCode = useCallback(async () => {
     setIsFormatting(true)
@@ -206,6 +246,9 @@ function App() {
         plugins: [monkeyPlugin.default as unknown as Plugin],
       })
       setCode(formatted)
+      if (formatted !== code) {
+        invalidateSnapshot()
+      }
       setSelection(null)
       gcRequestId.current += 1
       setGcState({ status: 'idle' })
@@ -218,13 +261,23 @@ function App() {
     } finally {
       setIsFormatting(false)
     }
-  }, [code, compileCode])
+  }, [code, compileCode, invalidateSnapshot])
 
   useEffect(() => {
     debouncedCompile(code)
   }, [code, debouncedCompile])
 
   useEffect(() => () => debouncedCompile.cancel(), [debouncedCompile])
+
+  useEffect(() => {
+    if (outputView !== 'snapshot') {
+      debouncedSnapshotCompile.cancel()
+      return
+    }
+
+    debouncedSnapshotCompile(code, stripDebug)
+    return () => debouncedSnapshotCompile.cancel()
+  }, [code, debouncedSnapshotCompile, outputView, stripDebug])
 
   useEffect(() => {
     const index = Math.min(Math.max(snippetIndex, 0), snippets.length - 1)
@@ -234,8 +287,9 @@ function App() {
     setSelection(null)
     gcRequestId.current += 1
     setGcState({ status: 'idle' })
+    invalidateSnapshot()
     setCode(snippets[index].code)
-  }, [snippetIndex, setSnippetIndex])
+  }, [invalidateSnapshot, snippetIndex, setSnippetIndex])
 
   useEffect(
     () => () => {
@@ -287,13 +341,22 @@ function App() {
     }
   }, [snapshotBuild])
 
-  const handleNodeSelect = useCallback((start: number, end: number) => {
-    editorRef.current?.highlightRange(start, end)
-  }, [])
+  const highlightSourceSpan = useCallback(
+    (span: SourceSpan) => {
+      const converted = utf8ByteSpanToUtf16(code, span)
+      editorRef.current?.highlightRange(converted.start, converted.end)
+    },
+    [code]
+  )
 
-  const handleErrorSpanSelect = useCallback((span: SourceSpan) => {
-    editorRef.current?.highlightRange(span.start, span.end)
-  }, [])
+  const handleNodeSelect = useCallback(
+    (start: number, end: number) => {
+      highlightSourceSpan({ start, end })
+    },
+    [highlightSourceSpan]
+  )
+
+  const handleErrorSpanSelect = highlightSourceSpan
 
   const handleBytecodeSelection = useCallback(
     (selection: { from: number; to: number }) => {
@@ -308,9 +371,9 @@ function App() {
         return
       }
 
-      editorRef.current?.highlightRange(span.start, span.end)
+      highlightSourceSpan(span)
     },
-    [bytecodeDebugView]
+    [bytecodeDebugView, highlightSourceSpan]
   )
 
   useEffect(() => {
@@ -329,11 +392,11 @@ function App() {
     }
     const { span } = gcState
     const editor = editorRef.current
-    editor?.highlightRange(span.start, span.end)
+    highlightSourceSpan(span)
     return () => {
       editor?.clearHighlight()
     }
-  }, [gcState, outputView])
+  }, [gcState, highlightSourceSpan, outputView])
 
   useEffect(() => {
     if (
@@ -345,18 +408,18 @@ function App() {
     }
     const { span } = snapshotRun
     const editor = editorRef.current
-    editor?.highlightRange(span.start, span.end)
+    highlightSourceSpan(span)
     return () => {
       editor?.clearHighlight()
     }
-  }, [snapshotRun, outputView])
+  }, [highlightSourceSpan, snapshotRun, outputView])
 
   return (
     <div className="grid min-h-0 flex-1 grid-cols-2 overflow-hidden max-[780px]:grid-cols-1 max-[780px]:grid-rows-2">
       <div
         className={`${panelClass} border-r border-(--gray-a5) max-[780px]:border-r-0 max-[780px]:border-b`}
       >
-        <div className={toolbarClass}>
+        <div className={editorToolbarClass}>
           <div className="flex items-center gap-3">
             <Button size="2" onClick={formatCode} loading={isFormatting}>
               Format
@@ -398,8 +461,9 @@ function App() {
       </div>
 
       <div className={panelClass}>
-        <div className={toolbarClass}>
+        <div className={outputToolbarClass}>
           <SegmentedControl.Root
+            className="max-w-full min-w-0!"
             size="2"
             value={outputView}
             onValueChange={(value) => setOutputView(value as OutputView)}
@@ -438,7 +502,7 @@ function App() {
             <div className="min-h-0 flex-1 overflow-auto bg-(--color-background) px-2.5 pt-2 pb-4">
               <AstTreeView
                 data={astData}
-                selection={selection}
+                selection={astSelection}
                 onNodeSelect={handleNodeSelect}
               />
             </div>
@@ -457,7 +521,7 @@ function App() {
                 build={snapshotBuild}
                 run={snapshotRun}
                 stripDebug={stripDebug}
-                onStripDebugChange={setStripDebug}
+                onStripDebugChange={handleStripDebugChange}
                 onErrorSpanSelect={handleErrorSpanSelect}
               />
             </div>

--- a/packages/playground/src/SnapshotView.tsx
+++ b/packages/playground/src/SnapshotView.tsx
@@ -29,6 +29,7 @@ export type SnapshotRunState =
 interface SnapshotViewProps {
   build: SnapshotBuildState
   run: SnapshotRunState
+  stale: boolean
   stripDebug: boolean
   onStripDebugChange: (stripDebug: boolean) => void
   onErrorSpanSelect?: (span: SourceSpan) => void
@@ -75,10 +76,12 @@ function downloadSnapshot(bytes: Uint8Array<ArrayBuffer>) {
 
 function SnapshotSummary({
   build,
+  stale,
   stripDebug,
   onStripDebugChange,
 }: {
   build: SnapshotBuildSuccess
+  stale: boolean
   stripDebug: boolean
   onStripDebugChange: (stripDebug: boolean) => void
 }) {
@@ -126,7 +129,7 @@ function SnapshotSummary({
             Stripped
           </SegmentedControl.Item>
         </SegmentedControl.Root>
-        <Button size="1" variant="soft" onClick={handleDownload}>
+        <Button size="1" variant="soft" onClick={handleDownload} disabled={stale}>
           Download .mbc
         </Button>
       </div>
@@ -257,37 +260,54 @@ function SnapshotRunResult({
 export function SnapshotView({
   build,
   run,
+  stale,
   stripDebug,
   onStripDebugChange,
   onErrorSpanSelect,
 }: SnapshotViewProps) {
   if (build.status === 'idle') {
-    return <p className={`${mutedClass} m-0`}>Compiling snapshot…</p>
+    return (
+      <output className={`${mutedClass} block`}>Compiling snapshot…</output>
+    )
   }
+
+  // The previous result stays mounted while a rebuild is pending so scroll
+  // position and focus survive; the live region announces the swap for
+  // assistive tech, mirroring the alert roles on the error branches.
+  const staleNotice = stale ? (
+    <output className={`${mutedClass} block`}>Rebuilding snapshot…</output>
+  ) : null
 
   if (build.status === 'error' || build.status === 'invalid') {
     const heading =
       build.status === 'error' ? `${build.stage} error` : 'unexpected response'
     return (
-      <p role="alert" className={alertClass}>
-        {heading}: {build.message}
-      </p>
+      <div className="grid gap-4">
+        {staleNotice}
+        <p role="alert" className={alertClass}>
+          {heading}: {build.message}
+        </p>
+      </div>
     )
   }
 
   return (
     <div className="grid gap-4">
-      <SnapshotSummary
-        build={build}
-        stripDebug={stripDebug}
-        onStripDebugChange={onStripDebugChange}
-      />
-      <SnapshotRunResult
-        build={build}
-        run={run}
-        onErrorSpanSelect={onErrorSpanSelect}
-      />
-      <SnapshotHexdump build={build} />
+      {staleNotice}
+      <div className={`grid gap-4 ${stale ? 'opacity-60' : ''}`}>
+        <SnapshotSummary
+          build={build}
+          stale={stale}
+          stripDebug={stripDebug}
+          onStripDebugChange={onStripDebugChange}
+        />
+        <SnapshotRunResult
+          build={build}
+          run={run}
+          onErrorSpanSelect={onErrorSpanSelect}
+        />
+        <SnapshotHexdump build={build} />
+      </div>
     </div>
   )
 }

--- a/packages/playground/src/SnapshotView.tsx
+++ b/packages/playground/src/SnapshotView.tsx
@@ -1,0 +1,293 @@
+'use client'
+
+import { Button, SegmentedControl } from '@radix-ui/themes'
+import { useCallback } from 'react'
+
+import type { SourceSpan } from './gcReport'
+import {
+  formatByteOffset,
+  groupRegionsBySection,
+  regionHex,
+  snapshotSectionTitles,
+  type SnapshotBuildEnvelope,
+  type SnapshotBuildSuccess,
+  type SnapshotRunEnvelope,
+  type SnapshotSection,
+} from './snapshot'
+
+export type SnapshotBuildState =
+  | { status: 'idle' }
+  | SnapshotBuildEnvelope
+  | { status: 'invalid'; message: string }
+
+export type SnapshotRunState =
+  | { status: 'idle' }
+  | { status: 'running' }
+  | SnapshotRunEnvelope
+  | { status: 'invalid'; message: string }
+
+interface SnapshotViewProps {
+  build: SnapshotBuildState
+  run: SnapshotRunState
+  stripDebug: boolean
+  onStripDebugChange: (stripDebug: boolean) => void
+  onErrorSpanSelect?: (span: SourceSpan) => void
+}
+
+const cardClass =
+  'rounded-[10px] border border-(--gray-a5) bg-(--color-panel-solid) p-4 shadow-[0_1px_2px_var(--black-a3)]'
+
+const mutedClass = 'text-xs text-(--gray-10)'
+
+const sectionHeadingClass = 'm-0 mb-3 text-base text-(--gray-12)'
+
+const alertClass =
+  'm-0 rounded-md border border-(--red-a6) bg-(--red-a3) px-3 py-2 text-sm text-(--red-11)'
+
+const dlTextClass =
+  '[&_dt]:text-[11px] [&_dt]:text-(--gray-10) [&_dd]:m-0 [&_dd]:mt-0.5 [&_dd]:font-mono [&_dd]:font-bold [&_dd]:text-(--gray-12)'
+
+const summaryListClass = `m-0 mb-3 grid grid-cols-4 gap-2 max-[900px]:grid-cols-2 [&>div]:min-w-0 [&>div]:rounded-md [&>div]:bg-(--gray-a3) [&>div]:p-2 ${dlTextClass}`
+
+const sectionDotTones: Record<SnapshotSection, string> = {
+  header: 'bg-(--blue-9)',
+  main: 'bg-(--green-9)',
+  constants: 'bg-(--amber-9)',
+  debug: 'bg-(--violet-9)',
+}
+
+const sectionHelp: Record<SnapshotSection, string> = {
+  header: 'Fixed 10 bytes: magic, version, ABI fingerprint, flags.',
+  main: 'Length-prefixed top-level instruction stream.',
+  constants: 'Tagged constant pool: integers, strings, functions.',
+  debug: 'Optional pc→source-span tables; gone with --strip.',
+}
+
+function downloadSnapshot(bytes: Uint8Array<ArrayBuffer>) {
+  const blob = new Blob([bytes], { type: 'application/octet-stream' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = 'program.mbc'
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+function SnapshotSummary({
+  build,
+  stripDebug,
+  onStripDebugChange,
+}: {
+  build: SnapshotBuildSuccess
+  stripDebug: boolean
+  onStripDebugChange: (stripDebug: boolean) => void
+}) {
+  const handleDownload = useCallback(() => {
+    downloadSnapshot(build.bytes)
+  }, [build.bytes])
+
+  return (
+    <section className={cardClass}>
+      <h2 className={sectionHeadingClass}>Snapshot (.mbc)</h2>
+      <dl className={summaryListClass}>
+        <div>
+          <dt>Size</dt>
+          <dd aria-label="Snapshot size">{build.layout.byteLength} bytes</dd>
+        </div>
+        <div>
+          <dt>Format version</dt>
+          <dd aria-label="Snapshot format version">
+            {build.layout.formatVersion}
+          </dd>
+        </div>
+        <div>
+          <dt>ABI fingerprint</dt>
+          <dd aria-label="Snapshot ABI fingerprint">
+            {build.layout.abiFingerprint}
+          </dd>
+        </div>
+        <div>
+          <dt>Debug info</dt>
+          <dd aria-label="Snapshot debug info">
+            {build.layout.hasDebugInfo ? 'included' : 'stripped'}
+          </dd>
+        </div>
+      </dl>
+      <div className="flex flex-wrap items-center gap-3">
+        <SegmentedControl.Root
+          size="1"
+          value={stripDebug ? 'stripped' : 'debug'}
+          onValueChange={(value) => onStripDebugChange(value === 'stripped')}
+        >
+          <SegmentedControl.Item value="debug">
+            Keep debug info
+          </SegmentedControl.Item>
+          <SegmentedControl.Item value="stripped">
+            Stripped
+          </SegmentedControl.Item>
+        </SegmentedControl.Root>
+        <Button size="1" variant="soft" onClick={handleDownload}>
+          Download .mbc
+        </Button>
+      </div>
+      <p className={`${mutedClass} mx-0 mt-3 mb-0`}>
+        These are the exact bytes <code>monkey-gc compile</code> writes.
+        Download the file and run <code>monkey-gc run program.mbc</code>{' '}
+        locally — no parser or compiler involved.
+      </p>
+    </section>
+  )
+}
+
+function SnapshotHexdump({ build }: { build: SnapshotBuildSuccess }) {
+  const groups = groupRegionsBySection(build.layout.regions)
+
+  return (
+    <section className={cardClass} aria-label="Annotated snapshot bytes">
+      <h2 className={sectionHeadingClass}>Byte layout</h2>
+      {groups.map((group, groupIndex) => (
+        <div key={`${group.section}-${groupIndex}`} className="mb-4 last:mb-0">
+          <h3 className="m-0 mb-0.5 flex items-center gap-2 text-sm text-(--gray-12)">
+            <span
+              aria-hidden
+              className={`inline-block size-2 rounded-full ${sectionDotTones[group.section]}`}
+            />
+            {snapshotSectionTitles[group.section]}
+          </h3>
+          <p className={`${mutedClass} mx-0 mt-0 mb-2`}>
+            {sectionHelp[group.section]}
+          </p>
+          <div className="font-mono text-xs leading-relaxed">
+            {group.regions.map((region) => (
+              <div
+                key={region.offset}
+                className="grid grid-cols-[3.25rem_minmax(6rem,11rem)_1fr] items-baseline gap-x-3 border-t border-(--gray-a3) py-1 first:border-t-0"
+              >
+                <span className="text-(--gray-9)">
+                  {formatByteOffset(region.offset)}
+                </span>
+                <span className="break-words text-(--gray-11)">
+                  {regionHex(build.bytes, region)}
+                </span>
+                <span className="font-sans">
+                  <span className="font-semibold text-(--gray-12)">
+                    {region.label}
+                  </span>{' '}
+                  <span className={mutedClass}>{region.detail}</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  )
+}
+
+function SnapshotRunResult({
+  build,
+  run,
+  onErrorSpanSelect,
+}: {
+  build: SnapshotBuildSuccess
+  run: SnapshotRunState
+  onErrorSpanSelect?: (span: SourceSpan) => void
+}) {
+  return (
+    <section className={cardClass}>
+      <h2 className={sectionHeadingClass}>Run from snapshot</h2>
+      {run.status === 'idle' ? (
+        <p className={`${mutedClass} m-0`}>
+          Run snapshot executes the bytes above on the GC VM — the same path
+          as <code>monkey-gc run program.mbc</code>. The source editor is not
+          consulted.
+        </p>
+      ) : null}
+      {run.status === 'running' ? (
+        <p className={`${mutedClass} m-0`}>Running…</p>
+      ) : null}
+      {run.status === 'ok' ? (
+        <output
+          aria-label="Snapshot run result"
+          className="block rounded-md bg-(--gray-a3) p-2 font-mono text-sm text-(--gray-12)"
+        >
+          {run.result}
+        </output>
+      ) : null}
+      {run.status === 'error' ? (
+        <div>
+          <p role="alert" className={alertClass}>
+            {run.stage === 'snapshot' ? 'snapshot rejected' : 'runtime error'}:{' '}
+            {run.message}
+          </p>
+          {run.span !== null ? (
+            <Button
+              size="1"
+              variant="soft"
+              className="mt-2"
+              onClick={() => {
+                const { span } = run
+                if (span !== null) {
+                  onErrorSpanSelect?.(span)
+                }
+              }}
+            >
+              Show in editor ({run.span.start}–{run.span.end})
+            </Button>
+          ) : null}
+          {run.stage === 'runtime' &&
+          run.span === null &&
+          !build.layout.hasDebugInfo ? (
+            <p className={`${mutedClass} mx-0 mt-2 mb-0`}>
+              Stripped snapshots drop the pc→span table, so this error has no
+              source location. Switch to “Keep debug info” to get one.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+      {run.status === 'invalid' ? (
+        <p role="alert" className={alertClass}>
+          {run.message}
+        </p>
+      ) : null}
+    </section>
+  )
+}
+
+export function SnapshotView({
+  build,
+  run,
+  stripDebug,
+  onStripDebugChange,
+  onErrorSpanSelect,
+}: SnapshotViewProps) {
+  if (build.status === 'idle') {
+    return <p className={`${mutedClass} m-0`}>Compiling snapshot…</p>
+  }
+
+  if (build.status === 'error' || build.status === 'invalid') {
+    const heading =
+      build.status === 'error' ? `${build.stage} error` : 'unexpected response'
+    return (
+      <p role="alert" className={alertClass}>
+        {heading}: {build.message}
+      </p>
+    )
+  }
+
+  return (
+    <div className="grid gap-4">
+      <SnapshotSummary
+        build={build}
+        stripDebug={stripDebug}
+        onStripDebugChange={onStripDebugChange}
+      />
+      <SnapshotRunResult
+        build={build}
+        run={run}
+        onErrorSpanSelect={onErrorSpanSelect}
+      />
+      <SnapshotHexdump build={build} />
+    </div>
+  )
+}

--- a/packages/playground/src/snapshot.ts
+++ b/packages/playground/src/snapshot.ts
@@ -1,0 +1,308 @@
+import type { SourceSpan } from './gcReport'
+
+export const snapshotSections = [
+  'header',
+  'main',
+  'constants',
+  'debug',
+] as const
+
+export type SnapshotSection = (typeof snapshotSections)[number]
+
+export const snapshotSectionTitles: Record<SnapshotSection, string> = {
+  header: 'Header',
+  main: 'Main program',
+  constants: 'Constant pool',
+  debug: 'Debug info',
+}
+
+/**
+ * One annotated byte range of a `.mbc` file. Regions arrive in file order
+ * and tile the buffer exactly (no gaps, no overlaps) — `parseSnapshotBuildEnvelope`
+ * re-checks that invariant so the hexdump can rely on it.
+ */
+export interface SnapshotRegion {
+  offset: number
+  length: number
+  section: SnapshotSection
+  label: string
+  detail: string
+}
+
+export interface SnapshotLayout {
+  byteLength: number
+  formatVersion: number
+  abiFingerprint: string
+  hasDebugInfo: boolean
+  regions: SnapshotRegion[]
+}
+
+export interface SnapshotBuildSuccess {
+  status: 'ok'
+  bytes: Uint8Array<ArrayBuffer>
+  layout: SnapshotLayout
+}
+
+export type SnapshotBuildStage = 'parse' | 'compile' | 'snapshot'
+
+export interface SnapshotBuildError {
+  status: 'error'
+  stage: SnapshotBuildStage
+  message: string
+}
+
+export type SnapshotBuildEnvelope = SnapshotBuildSuccess | SnapshotBuildError
+
+export interface SnapshotRunSuccess {
+  status: 'ok'
+  result: string
+}
+
+export type SnapshotRunStage = 'snapshot' | 'runtime'
+
+export interface SnapshotRunError {
+  status: 'error'
+  stage: SnapshotRunStage
+  message: string
+  span: SourceSpan | null
+}
+
+export type SnapshotRunEnvelope = SnapshotRunSuccess | SnapshotRunError
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function readNumber(
+  record: Record<string, unknown>,
+  key: string,
+  path: string
+): number {
+  const value = record[key]
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${path}.${key} must be a non-negative safe integer`)
+  }
+  return value
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string,
+  path: string
+): string {
+  const value = record[key]
+  if (typeof value !== 'string') {
+    throw new Error(`${path}.${key} must be a string`)
+  }
+  return value
+}
+
+function parseEnvelope(serialized: string, what: string): unknown {
+  let value: unknown
+  try {
+    value = JSON.parse(serialized) as unknown
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`${what} is not valid JSON: ${message}`)
+  }
+  if (!isRecord(value)) {
+    throw new Error(`${what} must be an object`)
+  }
+  return value
+}
+
+export function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  if (!/^([0-9a-f]{2})*$/.test(hex)) {
+    throw new Error('bytesHex must be lowercase hex byte pairs')
+  }
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16)
+  }
+  return bytes
+}
+
+function readRegions(value: unknown, byteLength: number): SnapshotRegion[] {
+  if (!Array.isArray(value)) {
+    throw new Error('layout.regions must be an array')
+  }
+
+  let cursor = 0
+  const regions = value.map((entry, index) => {
+    const path = `layout.regions[${index}]`
+    if (!isRecord(entry)) {
+      throw new Error(`${path} must be an object`)
+    }
+    const offset = readNumber(entry, 'offset', path)
+    const length = readNumber(entry, 'length', path)
+    if (length < 1) {
+      throw new Error(`${path}.length must be at least 1`)
+    }
+    if (offset !== cursor) {
+      throw new Error(
+        `${path} must start at byte ${cursor}, the end of the previous region`
+      )
+    }
+    cursor = offset + length
+    const section = entry.section
+    if (
+      typeof section !== 'string' ||
+      !snapshotSections.includes(section as SnapshotSection)
+    ) {
+      throw new Error(`${path}.section must be a known snapshot section`)
+    }
+    return {
+      offset,
+      length,
+      section: section as SnapshotSection,
+      label: readString(entry, 'label', path),
+      detail: readString(entry, 'detail', path),
+    }
+  })
+  if (cursor !== byteLength) {
+    throw new Error('layout.regions must tile the buffer up to byteLength')
+  }
+  return regions
+}
+
+function readLayout(value: unknown): SnapshotLayout {
+  if (!isRecord(value)) {
+    throw new Error('layout must be an object')
+  }
+
+  const byteLength = readNumber(value, 'byteLength', 'layout')
+  const abiFingerprint = readString(value, 'abiFingerprint', 'layout')
+  if (!/^0x[0-9a-f]{8}$/.test(abiFingerprint)) {
+    throw new Error('layout.abiFingerprint must be a 0x-prefixed u32 hex string')
+  }
+  if (typeof value.hasDebugInfo !== 'boolean') {
+    throw new Error('layout.hasDebugInfo must be a boolean')
+  }
+  const regions = readRegions(value.regions, byteLength)
+  if (
+    !value.hasDebugInfo &&
+    regions.some((region) => region.section === 'debug')
+  ) {
+    throw new Error('layout without debug info must not contain debug regions')
+  }
+
+  return {
+    byteLength,
+    formatVersion: readNumber(value, 'formatVersion', 'layout'),
+    abiFingerprint,
+    hasDebugInfo: value.hasDebugInfo,
+    regions,
+  }
+}
+
+export function parseSnapshotBuildEnvelope(
+  serialized: string
+): SnapshotBuildEnvelope {
+  const value = parseEnvelope(serialized, 'Snapshot response') as Record<
+    string,
+    unknown
+  >
+
+  if (value.status === 'ok') {
+    const layout = readLayout(value.layout)
+    const bytes = hexToBytes(readString(value, 'bytesHex', 'envelope'))
+    if (bytes.length !== layout.byteLength) {
+      throw new Error('bytesHex length must match layout.byteLength')
+    }
+    return { status: 'ok', bytes, layout }
+  }
+
+  if (value.status === 'error') {
+    const stage = value.stage
+    if (stage !== 'parse' && stage !== 'compile' && stage !== 'snapshot') {
+      throw new Error('stage must be parse, compile, or snapshot')
+    }
+    return {
+      status: 'error',
+      stage,
+      message: readString(value, 'message', 'envelope'),
+    }
+  }
+
+  throw new Error('Snapshot response status must be ok or error')
+}
+
+function readSpan(value: unknown): SourceSpan | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+  if (!isRecord(value)) {
+    throw new Error('span must be an object or null')
+  }
+  return {
+    start: readNumber(value, 'start', 'span'),
+    end: readNumber(value, 'end', 'span'),
+  }
+}
+
+export function parseSnapshotRunEnvelope(
+  serialized: string
+): SnapshotRunEnvelope {
+  const value = parseEnvelope(serialized, 'Snapshot run response') as Record<
+    string,
+    unknown
+  >
+
+  if (value.status === 'ok') {
+    return { status: 'ok', result: readString(value, 'result', 'envelope') }
+  }
+
+  if (value.status === 'error') {
+    const stage = value.stage
+    if (stage !== 'snapshot' && stage !== 'runtime') {
+      throw new Error('stage must be snapshot or runtime')
+    }
+    return {
+      status: 'error',
+      stage,
+      message: readString(value, 'message', 'envelope'),
+      span: readSpan(value.span),
+    }
+  }
+
+  throw new Error('Snapshot run response status must be ok or error')
+}
+
+/** Hexdump-style offset: `0x2a` → `002a`. */
+export function formatByteOffset(offset: number): string {
+  return offset.toString(16).padStart(4, '0')
+}
+
+/** The bytes a region covers, as space-separated hex pairs: `4d 42 43 00`. */
+export function regionHex(bytes: Uint8Array, region: SnapshotRegion): string {
+  const parts: string[] = []
+  for (let index = 0; index < region.length; index += 1) {
+    parts.push(bytes[region.offset + index].toString(16).padStart(2, '0'))
+  }
+  return parts.join(' ')
+}
+
+export interface SnapshotSectionGroup {
+  section: SnapshotSection
+  regions: SnapshotRegion[]
+}
+
+/**
+ * Group consecutive same-section regions for display. Sections appear in
+ * file order (header, main, constants, debug), so this yields one group per
+ * section that is present.
+ */
+export function groupRegionsBySection(
+  regions: readonly SnapshotRegion[]
+): SnapshotSectionGroup[] {
+  const groups: SnapshotSectionGroup[] = []
+  for (const region of regions) {
+    const last = groups[groups.length - 1]
+    if (last && last.section === region.section) {
+      last.regions.push(region)
+    } else {
+      groups.push({ section: region.section, regions: [region] })
+    }
+  }
+  return groups
+}

--- a/packages/playground/src/snapshotRunner.ts
+++ b/packages/playground/src/snapshotRunner.ts
@@ -1,0 +1,32 @@
+import { compile_to_snapshot, run_snapshot } from '@gengjiawen/monkey-wasm'
+
+import {
+  parseSnapshotBuildEnvelope,
+  parseSnapshotRunEnvelope,
+  type SnapshotBuildEnvelope,
+  type SnapshotRunEnvelope,
+} from './snapshot'
+
+/**
+ * Compile source into a `.mbc` snapshot plus its annotated layout.
+ * Synchronous like `compile_with_debug`, so it can run in the debounced
+ * compile pass. Parse/compile failures come back as envelope data.
+ */
+export function buildSnapshot(
+  source: string,
+  stripDebug: boolean
+): SnapshotBuildEnvelope {
+  return parseSnapshotBuildEnvelope(compile_to_snapshot(source, stripDebug))
+}
+
+/**
+ * Execute `.mbc` bytes on the GC VM — the browser twin of
+ * `monkey-gc run foo.mbc`. The bytes go through the validating snapshot
+ * reader, not the parser or compiler.
+ */
+export async function runSnapshot(
+  bytes: Uint8Array
+): Promise<SnapshotRunEnvelope> {
+  await Promise.resolve()
+  return parseSnapshotRunEnvelope(run_snapshot(bytes))
+}

--- a/packages/playground/src/sourceSpan.ts
+++ b/packages/playground/src/sourceSpan.ts
@@ -82,13 +82,3 @@ export function utf16OffsetToUtf8Byte(
 
   return bytes
 }
-
-export function utf16SpanToUtf8Byte(
-  source: string,
-  span: SourceSpanLike
-): SourceSpanLike {
-  return {
-    start: utf16OffsetToUtf8Byte(source, span.start),
-    end: utf16OffsetToUtf8Byte(source, span.end),
-  }
-}

--- a/packages/playground/src/sourceSpan.ts
+++ b/packages/playground/src/sourceSpan.ts
@@ -1,0 +1,94 @@
+export interface SourceSpanLike {
+  start: number
+  end: number
+}
+
+function utf8Width(character: string): number {
+  const codePoint = character.codePointAt(0) ?? 0
+  if (codePoint <= 0x7f) return 1
+  if (codePoint <= 0x7ff) return 2
+  if (codePoint <= 0xffff) return 3
+  return 4
+}
+
+/**
+ * Rust lexer spans count UTF-8 bytes, while CodeMirror positions count UTF-16
+ * code units. Map a byte boundary back into the browser string, clamping
+ * malformed or out-of-range offsets to a safe document position.
+ */
+export function utf8ByteOffsetToUtf16(
+  source: string,
+  byteOffset: number
+): number {
+  if (Number.isNaN(byteOffset) || byteOffset <= 0) {
+    return 0
+  }
+
+  const target = Math.floor(byteOffset)
+  let bytes = 0
+  let utf16 = 0
+
+  for (const character of source) {
+    const width = utf8Width(character)
+
+    if (bytes + width > target) {
+      return utf16
+    }
+
+    bytes += width
+    utf16 += character.length
+    if (bytes === target) {
+      return utf16
+    }
+  }
+
+  return source.length
+}
+
+export function utf8ByteSpanToUtf16(
+  source: string,
+  span: SourceSpanLike
+): SourceSpanLike {
+  return {
+    start: utf8ByteOffsetToUtf16(source, span.start),
+    end: utf8ByteOffsetToUtf16(source, span.end),
+  }
+}
+
+/** Map a CodeMirror UTF-16 position back to a Rust UTF-8 byte boundary. */
+export function utf16OffsetToUtf8Byte(
+  source: string,
+  utf16Offset: number
+): number {
+  if (Number.isNaN(utf16Offset) || utf16Offset <= 0) {
+    return 0
+  }
+
+  const target = Math.floor(utf16Offset)
+  let bytes = 0
+  let utf16 = 0
+
+  for (const character of source) {
+    if (utf16 + character.length > target) {
+      return bytes
+    }
+
+    utf16 += character.length
+    bytes += utf8Width(character)
+    if (utf16 === target) {
+      return bytes
+    }
+  }
+
+  return bytes
+}
+
+export function utf16SpanToUtf8Byte(
+  source: string,
+  span: SourceSpanLike
+): SourceSpanLike {
+  return {
+    start: utf16OffsetToUtf8Byte(source, span.start),
+    end: utf16OffsetToUtf8Byte(source, span.end),
+  }
+}

--- a/packages/playground/src/test/App.test.tsx
+++ b/packages/playground/src/test/App.test.tsx
@@ -8,6 +8,7 @@ import {
   within,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Provider } from 'jotai'
 import {
   forwardRef,
   useImperativeHandle,
@@ -27,9 +28,11 @@ const {
   runSnapshotMock,
   highlightRangeMock,
   clearHighlightMock,
+  formatMock,
+  sourceEditorHooks,
 } = vi.hoisted(() => ({
   runGcMock: vi.fn(),
-  parseMock: vi.fn(() => '{"Program":{"type":"Program","body":[]}}'),
+  parseMock: vi.fn(),
   compileMock: vi.fn(() =>
     JSON.stringify({
       detail: '',
@@ -42,7 +45,17 @@ const {
   runSnapshotMock: vi.fn(),
   highlightRangeMock: vi.fn(),
   clearHighlightMock: vi.fn(),
+  formatMock: vi.fn(),
+  // The mock editor below is a plain <textarea>, which cannot reproduce every
+  // CodeMirror callback: change events whose text equals the current document,
+  // or cursor movements. Tests drive those callbacks through these hooks.
+  sourceEditorHooks: {} as {
+    onChange?: (value: string) => void
+    onSelectionChange?: (selection: { from: number; to: number }) => void
+  },
 }))
+
+const defaultAstJson = '{"Program":{"type":"Program","body":[]}}'
 
 vi.mock('@gengjiawen/monkey-wasm', () => ({
   parse: parseMock,
@@ -58,21 +71,35 @@ vi.mock('../snapshotRunner', () => ({
   runSnapshot: runSnapshotMock,
 }))
 
+vi.mock('prettier/standalone', () => ({
+  format: formatMock,
+}))
+
+vi.mock('../../../prettier-plugin-monkey/src/index', () => ({
+  default: {},
+}))
+
 interface MockEditorProps {
   code?: string
   onChange?: (value: string) => void
+  onSelectionChange?: (selection: { from: number; to: number }) => void
   extra?: { readOnly?: boolean }
 }
 
 vi.mock('../Editor', () => ({
   Editor: forwardRef(function MockEditor(
-    { code = '', onChange, extra }: MockEditorProps,
+    { code = '', onChange, onSelectionChange, extra }: MockEditorProps,
     ref: Ref<{ highlightRange(): void; clearHighlight(): void }>
   ) {
     useImperativeHandle(ref, () => ({
       highlightRange: highlightRangeMock,
       clearHighlight: clearHighlightMock,
     }))
+
+    if (!extra?.readOnly) {
+      sourceEditorHooks.onChange = onChange
+      sourceEditorHooks.onSelectionChange = onSelectionChange
+    }
 
     const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
       onChange?.(event.target.value)
@@ -305,10 +332,14 @@ function snapshotEnvelope(): SnapshotBuildSuccess {
 }
 
 function renderApp() {
+  // A fresh jotai Provider per render keeps atom state (the persisted snippet
+  // index) from leaking between tests through the module-level default store.
   return render(
-    <Theme>
-      <App />
-    </Theme>
+    <Provider>
+      <Theme>
+        <App />
+      </Theme>
+    </Provider>
   )
 }
 
@@ -327,13 +358,18 @@ afterEach(cleanup)
 beforeEach(() => {
   localStorage.clear()
   runGcMock.mockReset()
-  parseMock.mockClear()
+  parseMock.mockReset()
+  parseMock.mockImplementation(() => defaultAstJson)
   compileMock.mockClear()
   buildSnapshotMock.mockReset()
   buildSnapshotMock.mockImplementation(() => snapshotEnvelope())
   runSnapshotMock.mockReset()
+  formatMock.mockReset()
+  formatMock.mockImplementation(async (source: string) => source)
   highlightRangeMock.mockClear()
   clearHighlightMock.mockClear()
+  sourceEditorHooks.onChange = undefined
+  sourceEditorHooks.onSelectionChange = undefined
 })
 
 describe('GC playground', () => {
@@ -514,6 +550,35 @@ describe('GC playground', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
+  it('converts UTF-8 GC error spans before highlighting Unicode source', async () => {
+    const user = userEvent.setup()
+    // 中 is three UTF-8 bytes but one UTF-16 unit, so the byte span {7, 11}
+    // reported by the lexer lands on UTF-16 positions {5, 9}.
+    runGcMock.mockResolvedValue({
+      status: 'error',
+      stage: 'runtime',
+      message: 'identifier not found: boom',
+      span: { start: 7, end: 11 },
+    } satisfies GcRunEnvelope)
+    renderApp()
+
+    const sourceEditor = screen.getByLabelText('Source editor')
+    await user.clear(sourceEditor)
+    await user.type(sourceEditor, '"中"; boom;')
+
+    highlightRangeMock.mockClear()
+    await user.click(await openGcTab(user))
+
+    await screen.findByRole('alert')
+    expect(highlightRangeMock).toHaveBeenCalledWith(5, 9)
+
+    highlightRangeMock.mockClear()
+    await user.click(
+      screen.getByRole('button', { name: 'Show in editor (7–11)' })
+    )
+    expect(highlightRangeMock).toHaveBeenCalledWith(5, 9)
+  })
+
   it('ignores a stale run after the source changes and a newer run finishes', async () => {
     const user = userEvent.setup()
     const firstRun = deferred<GcRunEnvelope>()
@@ -601,22 +666,81 @@ describe('Snapshot playground', () => {
     const runButton = await openSnapshotTab(user)
     await screen.findByLabelText('Snapshot size')
     expect(runButton).toBeEnabled()
-    expect(screen.getByRole('button', { name: 'Download .mbc' })).toBeEnabled()
+    const downloadButton = screen.getByRole('button', {
+      name: 'Download .mbc',
+    })
+    expect(downloadButton).toBeEnabled()
     const buildCount = buildSnapshotMock.mock.calls.length
 
     await user.type(screen.getByLabelText('Source editor'), 'x')
 
-    expect(screen.getByText('Compiling snapshot…')).toBeInTheDocument()
+    // The previous build stays mounted while the rebuild is announced; only
+    // the actions that would hand out stale bytes lock up.
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Rebuilding snapshot…'
+    )
+    expect(screen.getByLabelText('Snapshot size')).toBeInTheDocument()
     expect(runButton).toBeDisabled()
-    expect(
-      screen.queryByRole('button', { name: 'Download .mbc' })
-    ).not.toBeInTheDocument()
+    expect(downloadButton).toBeDisabled()
     expect(buildSnapshotMock).toHaveBeenCalledTimes(buildCount)
 
-    expect(await screen.findByLabelText('Snapshot size')).toHaveTextContent(
-      '4 bytes'
-    )
+    await waitFor(() => expect(runButton).toBeEnabled())
+    expect(screen.queryByText('Rebuilding snapshot…')).not.toBeInTheDocument()
+    expect(downloadButton).toBeEnabled()
+    expect(buildSnapshotMock).toHaveBeenCalledTimes(buildCount + 1)
+  })
+
+  it('keeps a fresh build when an edit reports identical text', async () => {
+    const user = userEvent.setup()
+    renderApp()
+
+    const runButton = await openSnapshotTab(user)
+    await screen.findByLabelText('Snapshot size')
     expect(runButton).toBeEnabled()
+    const buildCount = buildSnapshotMock.mock.calls.length
+    const sourceEditor =
+      screen.getByLabelText<HTMLTextAreaElement>('Source editor')
+
+    // CodeMirror reports a document change even when the replacement text is
+    // identical, e.g. typing over a selection with the same character.
+    act(() => {
+      sourceEditorHooks.onChange?.(sourceEditor.value)
+    })
+
+    expect(screen.queryByText('Rebuilding snapshot…')).not.toBeInTheDocument()
+    expect(runButton).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Download .mbc' })).toBeEnabled()
+    expect(buildSnapshotMock).toHaveBeenCalledTimes(buildCount)
+  })
+
+  it('invalidates and rebuilds the snapshot when switching snippets', async () => {
+    const user = userEvent.setup()
+    renderApp()
+
+    const runButton = await openSnapshotTab(user)
+    await screen.findByLabelText('Snapshot size')
+    expect(runButton).toBeEnabled()
+    const buildCount = buildSnapshotMock.mock.calls.length
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(await screen.findByRole('option', { name: 'Functions' }))
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Rebuilding snapshot…'
+    )
+    expect(runButton).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Download .mbc' })
+    ).toBeDisabled()
+
+    await waitFor(() => {
+      expect(buildSnapshotMock).toHaveBeenCalledTimes(buildCount + 1)
+    })
+    expect(buildSnapshotMock).toHaveBeenLastCalledWith(
+      expect.stringContaining('let add = fn(a, b) { a + b };'),
+      false
+    )
+    await waitFor(() => expect(runButton).toBeEnabled())
   })
 
   it('highlights the span for snapshot runtime errors until the source changes', async () => {
@@ -698,13 +822,16 @@ describe('Snapshot playground', () => {
     const runButton = screen.getByRole('button', { name: 'Run snapshot' })
     const buildCount = buildSnapshotMock.mock.calls.length
 
-    await user.click(screen.getByRole('radio', { name: 'Stripped' }))
+    const strippedToggle = screen.getByRole('radio', { name: 'Stripped' })
+    await user.click(strippedToggle)
 
-    expect(screen.getByText('Compiling snapshot…')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Rebuilding snapshot…'
+    )
     expect(runButton).toBeDisabled()
-    expect(
-      screen.queryByRole('button', { name: 'Download .mbc' })
-    ).not.toBeInTheDocument()
+    // The toggle survives the rebuild without losing keyboard focus because
+    // the panel is never unmounted.
+    expect(strippedToggle).toHaveFocus()
     expect(buildSnapshotMock).toHaveBeenCalledTimes(buildCount)
 
     await waitFor(() => {
@@ -718,6 +845,7 @@ describe('Snapshot playground', () => {
         'stripped'
       )
     })
+    expect(strippedToggle).toHaveFocus()
   })
 
   it('ignores a snapshot run that resolves after the source changes', async () => {
@@ -739,11 +867,159 @@ describe('Snapshot playground', () => {
     })
 
     expect(screen.queryByText('stale')).not.toBeInTheDocument()
-    expect(screen.getByText('Compiling snapshot…')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Rebuilding snapshot…'
+    )
 
-    await screen.findByLabelText('Snapshot size')
+    await waitFor(() => expect(runButton).toBeEnabled())
     expect(
       screen.getByText(/executes the bytes above on the GC VM/)
     ).toBeInTheDocument()
+    expect(screen.queryByText('stale')).not.toBeInTheDocument()
+  })
+})
+
+describe('Format', () => {
+  it('keeps the GC report when formatting is a no-op', async () => {
+    const user = userEvent.setup()
+    runGcMock.mockResolvedValue(successEnvelope())
+    renderApp()
+
+    await user.click(await openGcTab(user))
+    await screen.findByLabelText(
+      'Heap object count before and after collection'
+    )
+
+    const formatButton = screen.getByRole('button', { name: 'Format' })
+    await user.click(formatButton)
+    await waitFor(() => expect(formatButton).toBeEnabled())
+
+    expect(
+      screen.getByLabelText('Heap object count before and after collection')
+    ).toHaveTextContent('20 → 18')
+  })
+
+  it('keeps the snapshot when formatting is a no-op', async () => {
+    const user = userEvent.setup()
+    renderApp()
+
+    const runButton = await openSnapshotTab(user)
+    await screen.findByLabelText('Snapshot size')
+    expect(runButton).toBeEnabled()
+    const buildCount = buildSnapshotMock.mock.calls.length
+
+    const formatButton = screen.getByRole('button', { name: 'Format' })
+    await user.click(formatButton)
+    await waitFor(() => expect(formatButton).toBeEnabled())
+
+    expect(screen.queryByText('Rebuilding snapshot…')).not.toBeInTheDocument()
+    expect(runButton).toBeEnabled()
+    expect(buildSnapshotMock).toHaveBeenCalledTimes(buildCount)
+  })
+
+  it('rebuilds the snapshot after formatting changes the source', async () => {
+    const user = userEvent.setup()
+    formatMock.mockResolvedValue('let formatted = 1;\n')
+    renderApp()
+
+    const runButton = await openSnapshotTab(user)
+    await screen.findByLabelText('Snapshot size')
+    const sourceEditor = screen.getByLabelText('Source editor')
+
+    await user.click(screen.getByRole('button', { name: 'Format' }))
+
+    await waitFor(() =>
+      expect(sourceEditor).toHaveValue('let formatted = 1;\n')
+    )
+    await waitFor(() => {
+      expect(buildSnapshotMock).toHaveBeenLastCalledWith(
+        'let formatted = 1;\n',
+        false
+      )
+    })
+    await waitFor(() => expect(runButton).toBeEnabled())
+  })
+
+  it('discards a format result that resolves after further edits', async () => {
+    const user = userEvent.setup()
+    const pendingFormat = deferred<string>()
+    formatMock.mockReturnValueOnce(pendingFormat.promise)
+    renderApp()
+
+    const sourceEditor =
+      screen.getByLabelText<HTMLTextAreaElement>('Source editor')
+    const formatButton = screen.getByRole('button', { name: 'Format' })
+    await user.click(formatButton)
+    await waitFor(() => expect(formatMock).toHaveBeenCalledTimes(1))
+
+    await user.type(sourceEditor, 'x')
+    const edited = sourceEditor.value
+    expect(edited).toContain('x')
+
+    await act(async () => {
+      pendingFormat.resolve('let clobbered = 1;')
+      await pendingFormat.promise
+    })
+    await waitFor(() => expect(formatButton).toBeEnabled())
+
+    // Applying the late result would silently revert the edit.
+    expect(sourceEditor).toHaveValue(edited)
+  })
+})
+
+describe('AST selection sync', () => {
+  it('maps editor selections to AST nodes across multi-byte characters', async () => {
+    const user = userEvent.setup()
+    const unicodeSource = '"中"; boom;'
+    // boom occupies bytes {7, 11} but UTF-16 positions {5, 9}.
+    const unicodeAst = JSON.stringify({
+      Program: {
+        type: 'Program',
+        span: { start: 0, end: 12 },
+        body: [
+          {
+            type: 'ExpressionStatement',
+            span: { start: 0, end: 6 },
+            expression: {
+              type: 'StringLiteral',
+              span: { start: 0, end: 5 },
+              value: '中',
+            },
+          },
+          {
+            type: 'ExpressionStatement',
+            span: { start: 7, end: 12 },
+            expression: {
+              type: 'Identifier',
+              span: { start: 7, end: 11 },
+              name: 'boom',
+            },
+          },
+        ],
+      },
+    })
+    parseMock.mockImplementation((source: string) =>
+      source === unicodeSource ? unicodeAst : defaultAstJson
+    )
+    renderApp()
+
+    const sourceEditor = screen.getByLabelText('Source editor')
+    await user.clear(sourceEditor)
+    await user.type(sourceEditor, unicodeSource)
+    await screen.findByText('Identifier')
+
+    act(() => {
+      sourceEditorHooks.onSelectionChange?.({ from: 5, to: 9 })
+    })
+
+    const identifierSummary = screen.getByText('Identifier').closest('summary')
+    expect(identifierSummary).not.toBeNull()
+    expect(identifierSummary).toHaveClass(
+      'shadow-[inset_2px_0_0_var(--accent-9)]'
+    )
+
+    highlightRangeMock.mockClear()
+    await user.click(identifierSummary!)
+    expect(highlightRangeMock).toHaveBeenCalledWith(5, 9)
   })
 })

--- a/packages/playground/src/test/App.test.tsx
+++ b/packages/playground/src/test/App.test.tsx
@@ -17,11 +17,14 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { GcRunEnvelope, ValueKindCounts } from '../gcReport'
+import type { SnapshotBuildSuccess, SnapshotRunEnvelope } from '../snapshot'
 
 const {
   runGcMock,
   parseMock,
   compileMock,
+  buildSnapshotMock,
+  runSnapshotMock,
   highlightRangeMock,
   clearHighlightMock,
 } = vi.hoisted(() => ({
@@ -35,6 +38,8 @@ const {
       instructionLines: [],
     })
   ),
+  buildSnapshotMock: vi.fn(),
+  runSnapshotMock: vi.fn(),
   highlightRangeMock: vi.fn(),
   clearHighlightMock: vi.fn(),
 }))
@@ -46,6 +51,11 @@ vi.mock('@gengjiawen/monkey-wasm', () => ({
 
 vi.mock('../gcRunner', () => ({
   runGc: runGcMock,
+}))
+
+vi.mock('../snapshotRunner', () => ({
+  buildSnapshot: buildSnapshotMock,
+  runSnapshot: runSnapshotMock,
 }))
 
 interface MockEditorProps {
@@ -272,6 +282,28 @@ function deferred<T>() {
   return { promise, resolve }
 }
 
+function snapshotEnvelope(): SnapshotBuildSuccess {
+  return {
+    status: 'ok',
+    bytes: new Uint8Array([0x4d, 0x42, 0x43, 0x00]),
+    layout: {
+      byteLength: 4,
+      formatVersion: 1,
+      abiFingerprint: '0x0000002a',
+      hasDebugInfo: true,
+      regions: [
+        {
+          offset: 0,
+          length: 4,
+          section: 'header',
+          label: 'magic',
+          detail: 'file signature "MBC\\0"',
+        },
+      ],
+    },
+  }
+}
+
 function renderApp() {
   return render(
     <Theme>
@@ -285,18 +317,26 @@ async function openGcTab(user: ReturnType<typeof userEvent.setup>) {
   return screen.getByRole('button', { name: 'Run GC' })
 }
 
+async function openSnapshotTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('radio', { name: 'Snapshot' }))
+  return screen.getByRole('button', { name: 'Run snapshot' })
+}
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  localStorage.clear()
+  runGcMock.mockReset()
+  parseMock.mockClear()
+  compileMock.mockClear()
+  buildSnapshotMock.mockReset()
+  buildSnapshotMock.mockImplementation(() => snapshotEnvelope())
+  runSnapshotMock.mockReset()
+  highlightRangeMock.mockClear()
+  clearHighlightMock.mockClear()
+})
+
 describe('GC playground', () => {
-  afterEach(cleanup)
-
-  beforeEach(() => {
-    localStorage.clear()
-    runGcMock.mockReset()
-    parseMock.mockClear()
-    compileMock.mockClear()
-    highlightRangeMock.mockClear()
-    clearHighlightMock.mockClear()
-  })
-
   it('runs only on demand and renders the collection report', async () => {
     const user = userEvent.setup()
     runGcMock.mockResolvedValue(successEnvelope())
@@ -509,5 +549,125 @@ describe('GC playground', () => {
     })
     expect(screen.getByText('new')).toBeInTheDocument()
     expect(runGcMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('Snapshot playground', () => {
+  it('builds the snapshot automatically and runs the bytes on demand', async () => {
+    const user = userEvent.setup()
+    runSnapshotMock.mockResolvedValue({
+      status: 'ok',
+      result: '3',
+    } satisfies SnapshotRunEnvelope)
+    renderApp()
+
+    const runButton = await openSnapshotTab(user)
+
+    expect(await screen.findByLabelText('Snapshot size')).toHaveTextContent(
+      '4 bytes'
+    )
+    expect(screen.getByText('magic')).toBeInTheDocument()
+    expect(screen.getByText('4d 42 43 00')).toBeInTheDocument()
+    expect(buildSnapshotMock).toHaveBeenLastCalledWith(
+      expect.any(String),
+      false
+    )
+    expect(runSnapshotMock).not.toHaveBeenCalled()
+
+    await user.click(runButton)
+
+    expect(
+      await screen.findByLabelText('Snapshot run result')
+    ).toHaveTextContent('3')
+    expect(runSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(Array.from(runSnapshotMock.mock.calls[0][0] as Uint8Array)).toEqual([
+      0x4d, 0x42, 0x43, 0x00,
+    ])
+  })
+
+  it('highlights the span for snapshot runtime errors until the source changes', async () => {
+    const user = userEvent.setup()
+    runSnapshotMock.mockResolvedValue({
+      status: 'error',
+      stage: 'runtime',
+      message: 'not a function: Integer',
+      span: { start: 22, end: 36 },
+    } satisfies SnapshotRunEnvelope)
+    renderApp()
+
+    const runButton = await openSnapshotTab(user)
+    await screen.findByLabelText('Snapshot size')
+    await user.click(runButton)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('runtime error')
+    expect(alert).toHaveTextContent('not a function: Integer')
+    expect(highlightRangeMock).toHaveBeenCalledWith(22, 36)
+
+    clearHighlightMock.mockClear()
+    await user.type(screen.getByLabelText('Source editor'), 'x')
+    expect(clearHighlightMock).toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('rebuilds the snapshot when the strip toggle changes', async () => {
+    const user = userEvent.setup()
+    buildSnapshotMock.mockImplementation(
+      (_source: string, stripDebug: boolean) => {
+        const envelope = snapshotEnvelope()
+        return {
+          ...envelope,
+          layout: { ...envelope.layout, hasDebugInfo: !stripDebug },
+        }
+      }
+    )
+    renderApp()
+
+    await openSnapshotTab(user)
+    expect(
+      await screen.findByLabelText('Snapshot debug info')
+    ).toHaveTextContent('included')
+    expect(buildSnapshotMock).toHaveBeenLastCalledWith(
+      expect.any(String),
+      false
+    )
+
+    await user.click(screen.getByRole('radio', { name: 'Stripped' }))
+
+    await waitFor(() => {
+      expect(buildSnapshotMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        true
+      )
+    })
+    await waitFor(() => {
+      expect(screen.getByLabelText('Snapshot debug info')).toHaveTextContent(
+        'stripped'
+      )
+    })
+  })
+
+  it('ignores a snapshot run that resolves after the source changes', async () => {
+    const user = userEvent.setup()
+    const staleRun = deferred<SnapshotRunEnvelope>()
+    runSnapshotMock.mockReturnValueOnce(staleRun.promise)
+    renderApp()
+
+    const runButton = await openSnapshotTab(user)
+    await screen.findByLabelText('Snapshot size')
+    await user.click(runButton)
+    expect(runSnapshotMock).toHaveBeenCalledTimes(1)
+
+    await user.type(screen.getByLabelText('Source editor'), 'x')
+
+    await act(async () => {
+      staleRun.resolve({ status: 'ok', result: 'stale' })
+      await staleRun.promise
+    })
+
+    expect(screen.queryByText('stale')).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/executes the bytes above on the GC VM/)
+    ).toBeInTheDocument()
   })
 })

--- a/packages/playground/src/test/App.test.tsx
+++ b/packages/playground/src/test/App.test.tsx
@@ -491,7 +491,7 @@ describe('GC playground', () => {
       status: 'error',
       stage: 'runtime',
       message: "property 'next' does not exist on Node",
-      span: { start: 120, end: 126 },
+      span: { start: 0, end: 5 },
     } satisfies GcRunEnvelope)
     renderApp()
 
@@ -500,13 +500,13 @@ describe('GC playground', () => {
     const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent('runtime error')
     expect(alert).toHaveTextContent("property 'next' does not exist on Node")
-    expect(highlightRangeMock).toHaveBeenCalledWith(120, 126)
+    expect(highlightRangeMock).toHaveBeenCalledWith(0, 5)
 
     highlightRangeMock.mockClear()
     await user.click(
-      screen.getByRole('button', { name: 'Show in editor (120–126)' })
+      screen.getByRole('button', { name: 'Show in editor (0–5)' })
     )
-    expect(highlightRangeMock).toHaveBeenCalledWith(120, 126)
+    expect(highlightRangeMock).toHaveBeenCalledWith(0, 5)
 
     clearHighlightMock.mockClear()
     await user.type(screen.getByLabelText('Source editor'), 'x')
@@ -553,6 +553,15 @@ describe('GC playground', () => {
 })
 
 describe('Snapshot playground', () => {
+  it('does not compile snapshots while the snapshot tab is hidden', async () => {
+    renderApp()
+
+    await waitFor(() => {
+      expect(parseMock).toHaveBeenCalled()
+    })
+    expect(buildSnapshotMock).not.toHaveBeenCalled()
+  })
+
   it('builds the snapshot automatically and runs the bytes on demand', async () => {
     const user = userEvent.setup()
     runSnapshotMock.mockResolvedValue({
@@ -585,6 +594,31 @@ describe('Snapshot playground', () => {
     ])
   })
 
+  it('immediately invalidates stale bytes when the source changes', async () => {
+    const user = userEvent.setup()
+    renderApp()
+
+    const runButton = await openSnapshotTab(user)
+    await screen.findByLabelText('Snapshot size')
+    expect(runButton).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Download .mbc' })).toBeEnabled()
+    const buildCount = buildSnapshotMock.mock.calls.length
+
+    await user.type(screen.getByLabelText('Source editor'), 'x')
+
+    expect(screen.getByText('Compiling snapshot…')).toBeInTheDocument()
+    expect(runButton).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Download .mbc' })
+    ).not.toBeInTheDocument()
+    expect(buildSnapshotMock).toHaveBeenCalledTimes(buildCount)
+
+    expect(await screen.findByLabelText('Snapshot size')).toHaveTextContent(
+      '4 bytes'
+    )
+    expect(runButton).toBeEnabled()
+  })
+
   it('highlights the span for snapshot runtime errors until the source changes', async () => {
     const user = userEvent.setup()
     runSnapshotMock.mockResolvedValue({
@@ -610,6 +644,36 @@ describe('Snapshot playground', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
+  it('converts UTF-8 runtime spans before highlighting Unicode source', async () => {
+    const user = userEvent.setup()
+    const source = '"é"; let not_callable = 5; not_callable()'
+    runSnapshotMock.mockResolvedValue({
+      status: 'error',
+      stage: 'runtime',
+      message: 'not a function: Integer',
+      span: { start: 28, end: 42 },
+    } satisfies SnapshotRunEnvelope)
+    renderApp()
+
+    const sourceEditor = screen.getByLabelText('Source editor')
+    await user.clear(sourceEditor)
+    await user.type(sourceEditor, source)
+
+    const runButton = await openSnapshotTab(user)
+    await screen.findByLabelText('Snapshot size')
+    highlightRangeMock.mockClear()
+    await user.click(runButton)
+
+    await screen.findByRole('alert')
+    expect(highlightRangeMock).toHaveBeenCalledWith(27, 41)
+
+    highlightRangeMock.mockClear()
+    await user.click(
+      screen.getByRole('button', { name: 'Show in editor (28–42)' })
+    )
+    expect(highlightRangeMock).toHaveBeenCalledWith(27, 41)
+  })
+
   it('rebuilds the snapshot when the strip toggle changes', async () => {
     const user = userEvent.setup()
     buildSnapshotMock.mockImplementation(
@@ -631,8 +695,17 @@ describe('Snapshot playground', () => {
       expect.any(String),
       false
     )
+    const runButton = screen.getByRole('button', { name: 'Run snapshot' })
+    const buildCount = buildSnapshotMock.mock.calls.length
 
     await user.click(screen.getByRole('radio', { name: 'Stripped' }))
+
+    expect(screen.getByText('Compiling snapshot…')).toBeInTheDocument()
+    expect(runButton).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Download .mbc' })
+    ).not.toBeInTheDocument()
+    expect(buildSnapshotMock).toHaveBeenCalledTimes(buildCount)
 
     await waitFor(() => {
       expect(buildSnapshotMock).toHaveBeenLastCalledWith(
@@ -666,6 +739,9 @@ describe('Snapshot playground', () => {
     })
 
     expect(screen.queryByText('stale')).not.toBeInTheDocument()
+    expect(screen.getByText('Compiling snapshot…')).toBeInTheDocument()
+
+    await screen.findByLabelText('Snapshot size')
     expect(
       screen.getByText(/executes the bytes above on the GC VM/)
     ).toBeInTheDocument()

--- a/packages/playground/src/test/SnapshotView.test.tsx
+++ b/packages/playground/src/test/SnapshotView.test.tsx
@@ -91,6 +91,7 @@ function okBuild(hasDebugInfo = true): SnapshotBuildState {
 function renderView({
   build = okBuild(),
   run = { status: 'idle' } as SnapshotRunState,
+  stale = false,
   stripDebug = false,
   onStripDebugChange = vi.fn(),
   onErrorSpanSelect = vi.fn(),
@@ -100,6 +101,7 @@ function renderView({
       <SnapshotView
         build={build}
         run={run}
+        stale={stale}
         stripDebug={stripDebug}
         onStripDebugChange={onStripDebugChange}
         onErrorSpanSelect={onErrorSpanSelect}
@@ -214,6 +216,24 @@ describe('SnapshotView', () => {
     expect(
       screen.queryByRole('button', { name: /Show in editor/ })
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps stale builds mounted with an announced rebuild notice', () => {
+    renderView({ stale: true })
+
+    expect(screen.getByRole('status')).toHaveTextContent('Rebuilding snapshot…')
+    expect(screen.getByLabelText('Snapshot size')).toHaveTextContent('13 bytes')
+    expect(screen.getByText('4d 42 43 00')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Download .mbc' })
+    ).toBeDisabled()
+    expect(screen.getByRole('radio', { name: 'Stripped' })).toBeEnabled()
+  })
+
+  it('announces the initial compile placeholder to assistive tech', () => {
+    renderView({ build: { status: 'idle' } })
+
+    expect(screen.getByRole('status')).toHaveTextContent('Compiling snapshot…')
   })
 
   it('renders idle hints, run results, and build failures', () => {

--- a/packages/playground/src/test/SnapshotView.test.tsx
+++ b/packages/playground/src/test/SnapshotView.test.tsx
@@ -1,0 +1,237 @@
+import { Theme } from '@radix-ui/themes'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SnapshotLayout } from '../snapshot'
+import {
+  SnapshotView,
+  type SnapshotBuildState,
+  type SnapshotRunState,
+} from '../SnapshotView'
+
+function layout(hasDebugInfo = true): SnapshotLayout {
+  const regions: SnapshotLayout['regions'] = [
+    {
+      offset: 0,
+      length: 4,
+      section: 'header',
+      label: 'magic',
+      detail: 'file signature "MBC\\0"',
+    },
+    {
+      offset: 4,
+      length: 1,
+      section: 'header',
+      label: 'version',
+      detail: 'container format version 1',
+    },
+    {
+      offset: 5,
+      length: 4,
+      section: 'header',
+      label: 'abi fingerprint',
+      detail: '0x0000002a — FNV-1a over the opcode and builtin tables',
+    },
+    {
+      offset: 9,
+      length: 1,
+      section: 'header',
+      label: 'flags',
+      detail: hasDebugInfo
+        ? '0b00000001 — debug info present'
+        : '0b00000000 — debug info stripped',
+    },
+    {
+      offset: 10,
+      length: 1,
+      section: 'main',
+      label: 'main length',
+      detail: '1 bytes of main instructions follow (ULEB128)',
+    },
+    {
+      offset: 11,
+      length: 1,
+      section: 'main',
+      label: 'OpPop',
+      detail: 'main pc 0000',
+    },
+  ]
+  if (hasDebugInfo) {
+    regions.push({
+      offset: 12,
+      length: 1,
+      section: 'debug',
+      label: 'main span count',
+      detail: '0 pc→span entries (ULEB128)',
+    })
+  }
+  return {
+    byteLength: hasDebugInfo ? 13 : 12,
+    formatVersion: 1,
+    abiFingerprint: '0x0000002a',
+    hasDebugInfo,
+    regions,
+  }
+}
+
+function okBuild(hasDebugInfo = true): SnapshotBuildState {
+  const built = layout(hasDebugInfo)
+  return {
+    status: 'ok',
+    bytes: new Uint8Array([
+      0x4d, 0x42, 0x43, 0x00, 0x01, 0x2a, 0x00, 0x00, 0x00,
+      hasDebugInfo ? 0x01 : 0x00, 0x01, 0x02,
+      ...(hasDebugInfo ? [0x00] : []),
+    ]),
+    layout: built,
+  }
+}
+
+function renderView({
+  build = okBuild(),
+  run = { status: 'idle' } as SnapshotRunState,
+  stripDebug = false,
+  onStripDebugChange = vi.fn(),
+  onErrorSpanSelect = vi.fn(),
+} = {}) {
+  render(
+    <Theme>
+      <SnapshotView
+        build={build}
+        run={run}
+        stripDebug={stripDebug}
+        onStripDebugChange={onStripDebugChange}
+        onErrorSpanSelect={onErrorSpanSelect}
+      />
+    </Theme>
+  )
+  return { onStripDebugChange, onErrorSpanSelect }
+}
+
+describe('SnapshotView', () => {
+  afterEach(cleanup)
+
+  it('renders the summary facts and the annotated hexdump', () => {
+    renderView()
+
+    expect(screen.getByLabelText('Snapshot size')).toHaveTextContent(
+      '13 bytes'
+    )
+    expect(screen.getByLabelText('Snapshot format version')).toHaveTextContent(
+      '1'
+    )
+    expect(
+      screen.getByLabelText('Snapshot ABI fingerprint')
+    ).toHaveTextContent('0x0000002a')
+    expect(screen.getByLabelText('Snapshot debug info')).toHaveTextContent(
+      'included'
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Header' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Main program' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Debug info' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('magic')).toBeInTheDocument()
+    expect(screen.getByText('4d 42 43 00')).toBeInTheDocument()
+    expect(screen.getByText('OpPop')).toBeInTheDocument()
+    expect(screen.getByText('main pc 0000')).toBeInTheDocument()
+  })
+
+  it('reports the strip toggle and downloads the bytes', async () => {
+    const user = userEvent.setup()
+    const createObjectURL = vi.fn(() => 'blob:snapshot')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    })
+    const anchorClick = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {})
+
+    try {
+      const { onStripDebugChange } = renderView()
+
+      await user.click(screen.getByRole('radio', { name: 'Stripped' }))
+      expect(onStripDebugChange).toHaveBeenCalledWith(true)
+
+      await user.click(screen.getByRole('button', { name: 'Download .mbc' }))
+      expect(createObjectURL).toHaveBeenCalledTimes(1)
+      expect(anchorClick).toHaveBeenCalledTimes(1)
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:snapshot')
+    } finally {
+      anchorClick.mockRestore()
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('shows run results and lets runtime errors jump to their span', async () => {
+    const user = userEvent.setup()
+    const { onErrorSpanSelect } = renderView({
+      run: {
+        status: 'error',
+        stage: 'runtime',
+        message: 'not a function: Integer',
+        span: { start: 22, end: 36 },
+      },
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('runtime error')
+    expect(alert).toHaveTextContent('not a function: Integer')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Show in editor (22–36)' })
+    )
+    expect(onErrorSpanSelect).toHaveBeenCalledWith({ start: 22, end: 36 })
+  })
+
+  it('explains missing spans on stripped snapshots', () => {
+    renderView({
+      build: okBuild(false),
+      stripDebug: true,
+      run: {
+        status: 'error',
+        stage: 'runtime',
+        message: 'not a function: Integer',
+        span: null,
+      },
+    })
+
+    expect(screen.getByLabelText('Snapshot debug info')).toHaveTextContent(
+      'stripped'
+    )
+    expect(
+      screen.getByText(/Stripped snapshots drop the pc→span table/)
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Show in editor/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders idle hints, run results, and build failures', () => {
+    renderView({ run: { status: 'ok', result: '3' } })
+    expect(screen.getByLabelText('Snapshot run result')).toHaveTextContent('3')
+    cleanup()
+
+    renderView()
+    expect(
+      screen.getByText(/executes the bytes above on the GC VM/)
+    ).toBeInTheDocument()
+    cleanup()
+
+    renderView({
+      build: { status: 'error', stage: 'parse', message: 'unexpected token' },
+    })
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'parse error: unexpected token'
+    )
+  })
+})

--- a/packages/playground/src/test/setup.ts
+++ b/packages/playground/src/test/setup.ts
@@ -24,3 +24,18 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: () => false,
   }),
 })
+
+// jsdom implements neither element scrolling nor the Pointer Events capture
+// API, both of which Radix Select and the AST tree's selection sync call into.
+if (!window.HTMLElement.prototype.scrollIntoView) {
+  window.HTMLElement.prototype.scrollIntoView = () => {}
+}
+if (!window.Element.prototype.hasPointerCapture) {
+  window.Element.prototype.hasPointerCapture = () => false
+}
+if (!window.Element.prototype.setPointerCapture) {
+  window.Element.prototype.setPointerCapture = () => {}
+}
+if (!window.Element.prototype.releasePointerCapture) {
+  window.Element.prototype.releasePointerCapture = () => {}
+}

--- a/packages/playground/src/test/snapshot.test.ts
+++ b/packages/playground/src/test/snapshot.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatByteOffset,
+  groupRegionsBySection,
+  hexToBytes,
+  parseSnapshotBuildEnvelope,
+  parseSnapshotRunEnvelope,
+  regionHex,
+  type SnapshotRegion,
+} from '../snapshot'
+
+function headerLayout() {
+  return {
+    byteLength: 10,
+    formatVersion: 1,
+    abiFingerprint: '0x0000002a',
+    hasDebugInfo: false,
+    regions: [
+      {
+        offset: 0,
+        length: 4,
+        section: 'header',
+        label: 'magic',
+        detail: 'file signature "MBC\\0"',
+      },
+      {
+        offset: 4,
+        length: 1,
+        section: 'header',
+        label: 'version',
+        detail: 'container format version 1',
+      },
+      {
+        offset: 5,
+        length: 4,
+        section: 'header',
+        label: 'abi fingerprint',
+        detail: '0x0000002a',
+      },
+      {
+        offset: 9,
+        length: 1,
+        section: 'main',
+        label: 'main length',
+        detail: '0 bytes of main instructions follow (ULEB128)',
+      },
+    ],
+  }
+}
+
+function buildEnvelope(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    status: 'ok',
+    bytesHex: '4d424300012a00000000',
+    layout: headerLayout(),
+    ...overrides,
+  })
+}
+
+describe('parseSnapshotBuildEnvelope', () => {
+  it('parses a success envelope into bytes and a validated layout', () => {
+    const envelope = parseSnapshotBuildEnvelope(buildEnvelope())
+    if (envelope.status !== 'ok') {
+      throw new Error('expected a success envelope')
+    }
+    expect(envelope.bytes).toBeInstanceOf(Uint8Array)
+    expect(Array.from(envelope.bytes.slice(0, 4))).toEqual([
+      0x4d, 0x42, 0x43, 0x00,
+    ])
+    expect(envelope.layout.byteLength).toBe(10)
+    expect(envelope.layout.regions).toHaveLength(4)
+    expect(envelope.layout.regions[0].label).toBe('magic')
+  })
+
+  it('parses error envelopes for every build stage', () => {
+    for (const stage of ['parse', 'compile', 'snapshot'] as const) {
+      expect(
+        parseSnapshotBuildEnvelope(
+          JSON.stringify({ status: 'error', stage, message: 'boom' })
+        )
+      ).toEqual({ status: 'error', stage, message: 'boom' })
+    }
+    expect(() =>
+      parseSnapshotBuildEnvelope(
+        JSON.stringify({ status: 'error', stage: 'runtime', message: 'boom' })
+      )
+    ).toThrow(/stage must be/)
+  })
+
+  it('rejects bytes that disagree with the layout length', () => {
+    expect(() =>
+      parseSnapshotBuildEnvelope(buildEnvelope({ bytesHex: '4d4243' }))
+    ).toThrow(/bytesHex length must match/)
+    expect(() =>
+      parseSnapshotBuildEnvelope(buildEnvelope({ bytesHex: '4D424300012A00000000' }))
+    ).toThrow(/lowercase hex/)
+  })
+
+  it('rejects regions that do not tile the buffer', () => {
+    const gap = headerLayout()
+    gap.regions[1] = { ...gap.regions[1], offset: 5, length: 1 }
+    expect(() =>
+      parseSnapshotBuildEnvelope(buildEnvelope({ layout: gap }))
+    ).toThrow(/must start at byte 4/)
+
+    const short = headerLayout()
+    short.regions.pop()
+    expect(() =>
+      parseSnapshotBuildEnvelope(buildEnvelope({ layout: short }))
+    ).toThrow(/tile the buffer/)
+
+    const empty = headerLayout()
+    empty.regions[0] = { ...empty.regions[0], length: 0 }
+    expect(() =>
+      parseSnapshotBuildEnvelope(buildEnvelope({ layout: empty }))
+    ).toThrow(/at least 1/)
+  })
+
+  it('rejects unknown sections and debug regions in stripped layouts', () => {
+    const unknown = headerLayout()
+    unknown.regions[0] = { ...unknown.regions[0], section: 'trailer' }
+    expect(() =>
+      parseSnapshotBuildEnvelope(buildEnvelope({ layout: unknown }))
+    ).toThrow(/known snapshot section/)
+
+    const strippedWithDebug = headerLayout()
+    strippedWithDebug.regions[3] = {
+      ...strippedWithDebug.regions[3],
+      section: 'debug',
+    }
+    expect(() =>
+      parseSnapshotBuildEnvelope(buildEnvelope({ layout: strippedWithDebug }))
+    ).toThrow(/must not contain debug regions/)
+  })
+})
+
+describe('parseSnapshotRunEnvelope', () => {
+  it('parses success, runtime error with span, and snapshot rejection', () => {
+    expect(
+      parseSnapshotRunEnvelope(JSON.stringify({ status: 'ok', result: '3' }))
+    ).toEqual({ status: 'ok', result: '3' })
+
+    expect(
+      parseSnapshotRunEnvelope(
+        JSON.stringify({
+          status: 'error',
+          stage: 'runtime',
+          message: 'not a function',
+          span: { start: 22, end: 36 },
+        })
+      )
+    ).toEqual({
+      status: 'error',
+      stage: 'runtime',
+      message: 'not a function',
+      span: { start: 22, end: 36 },
+    })
+
+    expect(
+      parseSnapshotRunEnvelope(
+        JSON.stringify({
+          status: 'error',
+          stage: 'snapshot',
+          message: 'BadMagic',
+          span: null,
+        })
+      )
+    ).toEqual({
+      status: 'error',
+      stage: 'snapshot',
+      message: 'BadMagic',
+      span: null,
+    })
+  })
+
+  it('rejects unknown statuses and stages', () => {
+    expect(() =>
+      parseSnapshotRunEnvelope(JSON.stringify({ status: 'maybe' }))
+    ).toThrow(/status must be ok or error/)
+    expect(() =>
+      parseSnapshotRunEnvelope(
+        JSON.stringify({ status: 'error', stage: 'parse', message: 'x' })
+      )
+    ).toThrow(/stage must be snapshot or runtime/)
+  })
+})
+
+describe('hexdump helpers', () => {
+  it('formats offsets as 4-digit hex', () => {
+    expect(formatByteOffset(0)).toBe('0000')
+    expect(formatByteOffset(255)).toBe('00ff')
+    expect(formatByteOffset(0x1a2b)).toBe('1a2b')
+  })
+
+  it('decodes hex and slices region bytes', () => {
+    const bytes = hexToBytes('4d424300ff')
+    expect(Array.from(bytes)).toEqual([0x4d, 0x42, 0x43, 0x00, 0xff])
+    const region: SnapshotRegion = {
+      offset: 1,
+      length: 3,
+      section: 'header',
+      label: 'x',
+      detail: 'y',
+    }
+    expect(regionHex(bytes, region)).toBe('42 43 00')
+    expect(() => hexToBytes('4d4')).toThrow(/hex byte pairs/)
+  })
+
+  it('groups consecutive regions by section', () => {
+    const envelope = parseSnapshotBuildEnvelope(buildEnvelope())
+    if (envelope.status !== 'ok') {
+      throw new Error('expected a success envelope')
+    }
+    const groups = groupRegionsBySection(envelope.layout.regions)
+    expect(groups.map((group) => group.section)).toEqual(['header', 'main'])
+    expect(groups[0].regions).toHaveLength(3)
+    expect(groups[1].regions).toHaveLength(1)
+  })
+})

--- a/packages/playground/src/test/sourceSpan.test.ts
+++ b/packages/playground/src/test/sourceSpan.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 
 import {
   utf16OffsetToUtf8Byte,
-  utf16SpanToUtf8Byte,
   utf8ByteOffsetToUtf16,
   utf8ByteSpanToUtf16,
 } from '../sourceSpan'
@@ -17,13 +16,9 @@ describe('source span offsets', () => {
       start: 4,
       end: 9,
     })
-    expect(utf16SpanToUtf8Byte(source, { start: 4, end: 9 })).toEqual({
-      start: 4,
-      end: 9,
-    })
   })
 
-  it('maps BMP characters between UTF-8 bytes and UTF-16 positions', () => {
+  it('maps two-byte characters between UTF-8 bytes and UTF-16 positions', () => {
     const source = 'éx'
 
     expect(utf8ByteOffsetToUtf16(source, 1)).toBe(0)
@@ -31,6 +26,23 @@ describe('source span offsets', () => {
     expect(utf8ByteOffsetToUtf16(source, 3)).toBe(2)
     expect(utf16OffsetToUtf8Byte(source, 1)).toBe(2)
     expect(utf16OffsetToUtf8Byte(source, 2)).toBe(3)
+  })
+
+  it('maps three-byte characters between UTF-8 bytes and UTF-16 positions', () => {
+    const source = '中x'
+
+    expect(utf8ByteOffsetToUtf16(source, 1)).toBe(0)
+    expect(utf8ByteOffsetToUtf16(source, 3)).toBe(1)
+    expect(utf8ByteOffsetToUtf16(source, 4)).toBe(2)
+    expect(utf16OffsetToUtf8Byte(source, 1)).toBe(3)
+    expect(utf16OffsetToUtf8Byte(source, 2)).toBe(4)
+
+    // U+0800 and U+FFFF bracket the three-byte encoding range.
+    const boundaries = '\u0800\uffffx'
+    expect(utf8ByteOffsetToUtf16(boundaries, 3)).toBe(1)
+    expect(utf8ByteOffsetToUtf16(boundaries, 6)).toBe(2)
+    expect(utf16OffsetToUtf8Byte(boundaries, 1)).toBe(3)
+    expect(utf16OffsetToUtf8Byte(boundaries, 2)).toBe(6)
   })
 
   it('maps astral characters without splitting surrogate pairs', () => {

--- a/packages/playground/src/test/sourceSpan.test.ts
+++ b/packages/playground/src/test/sourceSpan.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  utf16OffsetToUtf8Byte,
+  utf16SpanToUtf8Byte,
+  utf8ByteOffsetToUtf16,
+  utf8ByteSpanToUtf16,
+} from '../sourceSpan'
+
+describe('source span offsets', () => {
+  it('leaves ASCII offsets unchanged', () => {
+    const source = 'let value = 1;'
+
+    expect(utf8ByteOffsetToUtf16(source, 9)).toBe(9)
+    expect(utf16OffsetToUtf8Byte(source, 9)).toBe(9)
+    expect(utf8ByteSpanToUtf16(source, { start: 4, end: 9 })).toEqual({
+      start: 4,
+      end: 9,
+    })
+    expect(utf16SpanToUtf8Byte(source, { start: 4, end: 9 })).toEqual({
+      start: 4,
+      end: 9,
+    })
+  })
+
+  it('maps BMP characters between UTF-8 bytes and UTF-16 positions', () => {
+    const source = 'éx'
+
+    expect(utf8ByteOffsetToUtf16(source, 1)).toBe(0)
+    expect(utf8ByteOffsetToUtf16(source, 2)).toBe(1)
+    expect(utf8ByteOffsetToUtf16(source, 3)).toBe(2)
+    expect(utf16OffsetToUtf8Byte(source, 1)).toBe(2)
+    expect(utf16OffsetToUtf8Byte(source, 2)).toBe(3)
+  })
+
+  it('maps astral characters without splitting surrogate pairs', () => {
+    const source = '😀x'
+
+    expect(utf8ByteOffsetToUtf16(source, 3)).toBe(0)
+    expect(utf8ByteOffsetToUtf16(source, 4)).toBe(2)
+    expect(utf8ByteOffsetToUtf16(source, 5)).toBe(3)
+    expect(utf16OffsetToUtf8Byte(source, 1)).toBe(0)
+    expect(utf16OffsetToUtf8Byte(source, 2)).toBe(4)
+    expect(utf16OffsetToUtf8Byte(source, 3)).toBe(5)
+  })
+
+  it('clamps invalid and out-of-range offsets to document boundaries', () => {
+    const source = 'éx'
+
+    expect(utf8ByteOffsetToUtf16(source, -1)).toBe(0)
+    expect(utf8ByteOffsetToUtf16(source, Number.NaN)).toBe(0)
+    expect(utf8ByteOffsetToUtf16(source, Number.POSITIVE_INFINITY)).toBe(2)
+    expect(utf8ByteOffsetToUtf16(source, 99)).toBe(2)
+
+    expect(utf16OffsetToUtf8Byte(source, -1)).toBe(0)
+    expect(utf16OffsetToUtf8Byte(source, Number.NaN)).toBe(0)
+    expect(utf16OffsetToUtf8Byte(source, Number.POSITIVE_INFINITY)).toBe(3)
+    expect(utf16OffsetToUtf8Byte(source, 99)).toBe(3)
+  })
+})

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -49,6 +49,8 @@ async function createWasmBindings(): Promise<MonkeyWasm> {
     compile_detail: bindings.compile_detail,
     compile_with_debug: bindings.compile_with_debug,
     run_gc_with_report: bindings.run_gc_with_report,
+    compile_to_snapshot: bindings.compile_to_snapshot,
+    run_snapshot: bindings.run_snapshot,
   }
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -2,6 +2,8 @@ mod utils;
 
 use crate::utils::set_panic_hook;
 use compiler::compiler::Compiler;
+use compiler::snapshot::{read_bytecode, write_bytecode};
+use compiler::snapshot_layout::describe_bytecode;
 use parser::parse as parser_pase;
 use parser::parse_ast_json_string;
 use wasm_bindgen::prelude::*;
@@ -95,4 +97,94 @@ pub fn run_gc_with_report(input: &str) -> String {
     };
 
     serde_json::to_string(&envelope).expect("GC run envelope serialization should not fail")
+}
+
+/// Compile Monkey source into a `.mbc` snapshot and return a tagged JSON envelope
+/// with the raw bytes (lowercase hex) plus a byte-range annotation of the container
+/// layout for the playground inspector.
+///
+/// User parse and compile failures are data in the envelope, not JavaScript
+/// exceptions, mirroring [`run_gc_with_report`].
+#[wasm_bindgen]
+pub fn compile_to_snapshot(input: &str, strip_debug: bool) -> String {
+    set_panic_hook();
+
+    let envelope = match snapshot_envelope(input, strip_debug) {
+        Ok(envelope) => envelope,
+        Err((stage, message)) => serde_json::json!({
+            "status": "error",
+            "stage": stage,
+            "message": message,
+        }),
+    };
+    serde_json::to_string(&envelope).expect("snapshot envelope serialization should not fail")
+}
+
+fn snapshot_envelope(
+    input: &str,
+    strip_debug: bool,
+) -> Result<serde_json::Value, (&'static str, String)> {
+    let program = parser_pase(input).map_err(|errors| {
+        let message = errors
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "unknown parse error".to_string());
+        ("parse", message)
+    })?;
+    let mut compiler = Compiler::new();
+    let bytecode = compiler
+        .compile(&program)
+        .map_err(|message| ("compile", message))?;
+    let bytes = write_bytecode(&bytecode, strip_debug)
+        .map_err(|error| ("snapshot", format!("{:?}", error)))?;
+    let layout = describe_bytecode(&bytes).map_err(|error| ("snapshot", format!("{:?}", error)))?;
+    Ok(serde_json::json!({
+        "status": "ok",
+        "bytesHex": hex_encode(&bytes),
+        "layout": layout,
+    }))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(out, "{:02x}", byte).expect("writing to a String cannot fail");
+    }
+    out
+}
+
+/// Execute `.mbc` snapshot bytes on the cycle-collecting VM — the browser twin of
+/// `monkey-gc run foo.mbc`, sharing its execution path (`gc::run_bytecode`).
+///
+/// The buffer is untrusted input: it goes through the validating snapshot reader
+/// before the VM. Failures are data in the envelope — stage `snapshot` when the
+/// bytes are rejected, `runtime` when the VM errors (the span is only present
+/// when the snapshot kept its debug info).
+#[wasm_bindgen]
+pub fn run_snapshot(bytes: &[u8]) -> String {
+    set_panic_hook();
+
+    let envelope = match read_bytecode(bytes) {
+        Ok(bytecode) => match gc::run_bytecode(bytecode, PLAYGROUND_GC_INSTRUCTION_BUDGET) {
+            Ok(result) => serde_json::json!({
+                "status": "ok",
+                "result": result,
+            }),
+            Err(error) => serde_json::json!({
+                "status": "error",
+                "stage": "runtime",
+                "message": error.message,
+                "span": error.span,
+            }),
+        },
+        Err(error) => serde_json::json!({
+            "status": "error",
+            "stage": "snapshot",
+            "message": format!("{:?}", error),
+            "span": null,
+        }),
+    };
+    serde_json::to_string(&envelope).expect("snapshot run envelope serialization should not fail")
 }

--- a/wasm/tests/web.rs
+++ b/wasm/tests/web.rs
@@ -3,7 +3,7 @@
 #![cfg(target_arch = "wasm32")]
 
 extern crate wasm_bindgen_test;
-use monkey_wasm::{parse, run_gc_with_report};
+use monkey_wasm::{compile_to_snapshot, parse, run_gc_with_report, run_snapshot};
 use serde_json::Value;
 use wasm_bindgen_test::*;
 
@@ -152,4 +152,129 @@ fn gc_error_envelope_distinguishes_all_stages_and_instruction_limit() {
         .as_str()
         .unwrap()
         .contains("instruction limit exceeded"));
+}
+
+fn build_snapshot(source: &str, strip_debug: bool) -> Value {
+    serde_json::from_str(&compile_to_snapshot(source, strip_debug))
+        .expect("valid snapshot envelope JSON")
+}
+
+fn snapshot_bytes(envelope: &Value) -> Vec<u8> {
+    let hex = envelope["bytesHex"].as_str().expect("bytesHex string");
+    (0..hex.len())
+        .step_by(2)
+        .map(|index| u8::from_str_radix(&hex[index..index + 2], 16).expect("hex byte"))
+        .collect()
+}
+
+fn run_bytes(bytes: &[u8]) -> Value {
+    serde_json::from_str(&run_snapshot(bytes)).expect("valid snapshot run envelope JSON")
+}
+
+#[wasm_bindgen_test]
+fn snapshot_envelope_roundtrips_through_the_vm() {
+    let envelope = build_snapshot("let add = fn(a, b) { a + b }; add(1, 2)", false);
+    assert_eq!(envelope["status"], "ok");
+
+    let bytes = snapshot_bytes(&envelope);
+    assert_eq!(envelope["layout"]["byteLength"], bytes.len());
+
+    let run = run_bytes(&bytes);
+    assert_eq!(run["status"], "ok");
+    assert_eq!(run["result"], "3");
+}
+
+#[wasm_bindgen_test]
+fn snapshot_layout_regions_tile_the_buffer_and_disassemble() {
+    let envelope = build_snapshot("let add = fn(a, b) { a + b }; add(1, 2)", false);
+    let layout = &envelope["layout"];
+    assert_eq!(layout["formatVersion"], 1);
+    assert_eq!(layout["hasDebugInfo"], true);
+    assert!(layout["abiFingerprint"].as_str().unwrap().starts_with("0x"));
+
+    let regions = layout["regions"].as_array().expect("regions array");
+    let labels: Vec<&str> = regions
+        .iter()
+        .take(4)
+        .filter_map(|region| region["label"].as_str())
+        .collect();
+    assert_eq!(labels, vec!["magic", "version", "abi fingerprint", "flags"]);
+
+    let mut cursor = 0u64;
+    for region in regions {
+        assert_eq!(region["offset"], cursor);
+        cursor += region["length"].as_u64().expect("region length");
+    }
+    assert_eq!(Value::from(cursor), layout["byteLength"]);
+    assert!(regions
+        .iter()
+        .any(|region| region["label"] == "OpCall 2" && region["section"] == "main"));
+}
+
+#[wasm_bindgen_test]
+fn stripped_snapshots_drop_debug_info_and_error_spans() {
+    let source = "let not_callable = 5; not_callable()";
+    let with_debug = build_snapshot(source, false);
+    let stripped = build_snapshot(source, true);
+
+    assert_eq!(stripped["layout"]["hasDebugInfo"], false);
+    assert!(
+        stripped["layout"]["byteLength"].as_u64().unwrap()
+            < with_debug["layout"]["byteLength"].as_u64().unwrap()
+    );
+    assert!(stripped["layout"]["regions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|region| region["section"] != "debug"));
+
+    let with_debug_run = run_bytes(&snapshot_bytes(&with_debug));
+    assert_eq!(with_debug_run["status"], "error");
+    assert_eq!(with_debug_run["stage"], "runtime");
+    assert!(with_debug_run["span"]["start"].is_number());
+
+    let stripped_run = run_bytes(&snapshot_bytes(&stripped));
+    assert_eq!(stripped_run["status"], "error");
+    assert_eq!(stripped_run["stage"], "runtime");
+    assert!(stripped_run["span"].is_null());
+    assert_eq!(stripped_run["message"], with_debug_run["message"]);
+}
+
+#[wasm_bindgen_test]
+fn hostile_snapshot_bytes_are_rejected_before_the_vm() {
+    let mut bytes = snapshot_bytes(&build_snapshot("1", false));
+    bytes[0] = b'X';
+
+    let run = run_bytes(&bytes);
+    assert_eq!(run["status"], "error");
+    assert_eq!(run["stage"], "snapshot");
+    assert!(run["message"].as_str().unwrap().contains("BadMagic"));
+}
+
+#[wasm_bindgen_test]
+fn snapshot_runs_share_the_playground_instruction_budget() {
+    let source = "
+let fibonacci = fn(n) {
+  if (n < 2) { n } else { fibonacci(n - 1) + fibonacci(n - 2) }
+};
+fibonacci(30);
+";
+    let run = run_bytes(&snapshot_bytes(&build_snapshot(source, false)));
+    assert_eq!(run["status"], "error");
+    assert_eq!(run["stage"], "runtime");
+    assert!(run["message"]
+        .as_str()
+        .unwrap()
+        .contains("instruction limit exceeded"));
+}
+
+#[wasm_bindgen_test]
+fn snapshot_parse_and_compile_failures_are_envelope_data() {
+    let parse_error = build_snapshot("let =", false);
+    assert_eq!(parse_error["status"], "error");
+    assert_eq!(parse_error["stage"], "parse");
+
+    let compile_error = build_snapshot("this;", false);
+    assert_eq!(compile_error["status"], "error");
+    assert_eq!(compile_error["stage"], "compile");
 }


### PR DESCRIPTION
Follow-up to #287 (continuing #67): now that `.mbc` snapshots exist, this makes them visible. The playground gets a **Snapshot** tab that turns the container format into a teaching tool.

## What it shows

- **Live snapshot build** — the current source compiles to `.mbc` bytes as you type (debounced, like the AST/bytecode views), with size, format version, ABI fingerprint, and debug-info facts.
- **Annotated hexdump** — every byte of the container explained: header fields, each disassembled main-program opcode, tagged constants (integers / strings / functions with their nested bodies), and pc→span debug tables, grouped and colored by section.
- **Download `.mbc`** — the exact bytes `monkey-gc compile` writes; take the file and `monkey-gc run program.mbc` locally.
- **Run snapshot** — executes the bytes on the GC VM through the same `read_bytecode` loader as the CLI; the source editor is not consulted. Runtime errors jump to their source span when debug info is present, and a strip-debug toggle shows what `--strip` costs you (identical error, no span).

## How

- `compiler/snapshot_layout.rs`: `describe_bytecode` re-validates via `read_bytecode`, then re-walks the buffer into labeled regions that tile it exactly — no gaps, no overlaps, tested against the real writer.
- `wasm`: `compile_to_snapshot(source, strip_debug)` returns `{bytesHex, layout}`; `run_snapshot(bytes)` loads and runs under the shared playground instruction budget. Errors are envelope data (`stage: parse|compile|snapshot|runtime`), never exceptions, and hostile bytes are rejected by the validating loader before the VM sees them.
- `playground`: `SnapshotView` plus envelope parsers that re-check the tiling invariant on the JS side.

## Testing

- Rust: `snapshot_layout` tests (tiling, disassembly, tag annotation, debug stripping, loader-error parity) and wasm-pack node tests (round-trip, hostile bytes, instruction budget, stripped spans).
- Playground: vitest unit, component, and App integration tests; oxlint and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)