### PR TITLE
ci: enforce workspace-wide clippy with -D warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,13 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -47,8 +54,6 @@ jobs:
           rustup target add aarch64-unknown-linux-gnu
       - name: Run Linux AArch64 end-to-end tests
         run: MONKEY_ASM_E2E_REQUIRED=1 cargo test -p monkey-asm -- --ignored --test-threads=1
-      - name: Lint ARM64 backend
-        run: cargo clippy -p monkey-asm --all-targets --no-deps
 
   arm64-e2e-macos:
     # Apple Silicon runner: the e2e suite exercises the Mach-O flavor natively.

--- a/parser/ast.rs
+++ b/parser/ast.rs
@@ -222,7 +222,7 @@ pub struct IDENTIFIER {
 
 impl fmt::Display for IDENTIFIER {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", &self.name)
+        write!(f, "{}", self.name)
     }
 }
 

--- a/parser/lib.rs
+++ b/parser/lib.rs
@@ -794,10 +794,8 @@ pub fn parse(input: &str) -> Result<Node, ParseErrors> {
 }
 
 pub fn parse_ast_json_string(input: &str) -> Result<String, ParseErrors> {
-    let ast = match parse(input) {
-        Ok(node) => serde_json::to_string_pretty(&node).unwrap(),
-        Err(e) => return Err(e),
-    };
+    let node = parse(input)?;
+    let ast = serde_json::to_string_pretty(&node).unwrap();
 
     return Ok(ast);
 }


### PR DESCRIPTION
## Summary

Follow-up to #290: now that the workspace is clippy-clean, enforce it in CI so it stays that way.

- New `lint` job: `cargo clippy --workspace --all-targets -- -D warnings` — any new clippy warning fails CI. Runs in parallel with `build`, so it adds no wall-clock time.
- Removed the asm-only clippy step from `arm64-e2e`: it linted only `monkey-asm` (host target) and didn't deny warnings, so the new workspace-wide job strictly supersedes it.

Note: `-D warnings` applies to clippy/rustc lints only — cargo's own `profiles for the non root package will be ignored` note (see #290) does not fail the job.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` exits 0 locally on this branch
- The `lint` job on this PR is the live check

🤖 Generated with [Claude Code](https://claude.com/claude-code)