### PR TITLE
ci: use latest macOS runner for ARM64 e2e

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
 
   arm64-e2e-macos:
     # Apple Silicon runner: the e2e suite exercises the Mach-O flavor natively.
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust


### PR DESCRIPTION
## Summary

- run the arm64-e2e-macos job on macos-latest
- keep native Apple Silicon Mach-O coverage while following GitHub's latest stable macOS runner

## Validation

- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/rust.yml