### PR TITLE
docs: introduce the arm64 ASM backend in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Monkey has a C-like syntax, supports **variable bindings**, **prefix** and **inf
 - bytecode viewer from source
 - **GC** ([`monkey-gc`](gc/README.md)): alternate bytecode VM with QuickJS-style refcounting and three-phase cycle collection (`gc_decref` → `gc_scan` → `gc_free_cycles`) on a `GcHeap`, so cyclic object graphs can be reclaimed without changing `object` or the default `Rc` VM.
 - **Bytecode snapshots** (`.mbc`): QuickJS-style ahead-of-time compilation, mirroring `qjsc` — `monkey-gc compile foo.monkey` serializes the compiled bytecode to a `.mbc` file and `monkey-gc run foo.mbc` executes it without the parser/compiler, treating the file as untrusted input behind a three-layer validation model ([design doc](docs/bytecode-snapshot-design.md)).
+- **ASM** ([`monkey-asm`](asm/README.md)): AOT arm64 (AArch64) assembly backend — single-pass lowering from the AST to AArch64 assembly text, assembled and linked against a cross-built Rust runtime into a native executable, in Linux/ELF and macOS/Mach-O flavors (the Linux flavor runs on any host via `qemu-aarch64`); the playground's **ARM64** tab shows the same assembly godbolt-style ([design doc](docs/arm64-asm-backend-design.md)).
 
 ## Resources
 Official site is: https://monkeylang.org/. It's has various implementation languages :).

--- a/asm/README.md
+++ b/asm/README.md
@@ -9,6 +9,15 @@ stack. One instruction stream, two output flavors selected with
 `--platform linux|macos` (default: the host): Linux/ELF (GNU as spelling)
 and macOS/Mach-O (Apple Silicon, `_`-prefixed symbols, `@PAGE` relocations).
 
+## Playground
+
+The [compiler playground](https://monkey-lang-playground-jw.vercel.app/) has an
+**ARM64** tab — a godbolt-style source ↔ assembly view with bidirectional span
+highlighting and a Download `.s` button, backed by the `compile_to_arm64` wasm
+export (which reuses `lower` in the browser). Nothing executes arm64 there; the
+tab renders the exact text `monkey-asm emit` writes, and the downloaded `.s`
+cross-assembles with the commands in [Usage](#usage) below.
+
 ## One crate, built twice
 
 | Build         | Command                                                                        | Product                                                         |
@@ -68,15 +77,6 @@ host.
 canonical result record (u64 big-endian length + JSON) to fd 3 at exit, while
 stdout stays the untouched `puts` byte stream; `run --observe` decodes the
 record to stderr.
-
-## Playground
-
-The [compiler playground](https://monkey-lang-playground-jw.vercel.app/) has an
-**ARM64** tab — a godbolt-style source ↔ assembly view with bidirectional span
-highlighting and a Download `.s` button, backed by the `compile_to_arm64` wasm
-export (which reuses `lower` in the browser). Nothing executes arm64 there; the
-tab renders the exact text `monkey-asm emit` writes, and the downloaded `.s`
-cross-assembles with the command above.
 
 ## Layout
 


### PR DESCRIPTION
Adds a **ASM** bullet to the Features list, in the same style as the GC and `.mbc` entries: one sentence covering the AOT arm64 backend (AST → AArch64 assembly, cross-built Rust runtime, Linux/ELF + macOS/Mach-O flavors, qemu portability, playground ARM64 tab), linking to [`asm/README.md`](asm/README.md) and the [design doc](docs/arm64-asm-backend-design.md) for details.

Also reorders `asm/README.md` to lead with the feature: the **Playground** section moves up right after the intro (with its "command above" reference retargeted to the now-below [Usage](asm/README.md#usage) section), before the build/usage mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)