### PR TITLE
fix(playground): increase theme/GitHub button spacing

### DIFF
--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -37,7 +37,7 @@ export function Header() {
           </Heading>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-4">
           <ThemeToggle />
           <a
             href={GITHUB_URL}


### PR DESCRIPTION
## Summary
- Widen the playground header gap between the theme toggle and GitHub link (`gap-2` → `gap-4`) to reduce accidental mis-taps.

## Test plan
- [ ] Open the playground header on desktop and confirm the two controls have clearer separation
- [ ] On a narrow viewport, confirm the theme toggle and GitHub icon are still easy to hit independently


Made with [Cursor](https://cursor.com)