### PR TITLE
feat: add Monkey source minifier

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # Corepack is unmaintained, so CI installs pnpm directly. Node stays on
+      # 20.19: the oldest version whose synchronous require(esm) the minifier's
+      # Node entrypoint supports.
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.15.1
       - uses: actions/setup-node@v6
         with:
           node-version: '20.19'
@@ -37,7 +43,6 @@ jobs:
         run: cd wasm && wasm-pack test --node
       - name: Build and test minifier
         run: |
-          corepack enable
           pnpm install --filter @gengjiawen/monkey-minifier... --frozen-lockfile
           pnpm --filter @gengjiawen/monkey-minifier build
           pnpm --filter @gengjiawen/monkey-minifier test:browser
@@ -45,12 +50,10 @@ jobs:
           pnpm --filter @gengjiawen/monkey-minifier test
       - name: Run playground tests
         run: |
-          corepack enable
           pnpm install --filter monkey-playground... --frozen-lockfile
           pnpm --filter monkey-playground test
       - name: Build VS Code extension
         run: |
-          corepack enable
           pnpm install --filter monkey-extension... --frozen-lockfile
           pnpm --filter monkey-extension run build
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,15 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Corepack is unmaintained, so CI installs pnpm directly. Node stays on
-      # 20.19: the oldest version whose synchronous require(esm) the minifier's
-      # Node entrypoint supports.
+      # Corepack is unmaintained, so CI installs pnpm directly.
       - uses: pnpm/action-setup@v6
         with:
           version: 11.15.1
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.19'
+          node-version: '24'
       - run: npx envinfo
       - name: Build
         run: cargo build
@@ -56,6 +54,15 @@ jobs:
         run: |
           pnpm install --filter monkey-extension... --frozen-lockfile
           pnpm --filter monkey-extension run build
+      # pnpm 11 itself needs Node >= 22.13, so the minifier's supported floor
+      # is exercised with plain node: 20.19 is the oldest version whose
+      # synchronous require(esm) the Node entrypoint relies on.
+      - name: Switch to the minifier's minimum supported Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20.19'
+      - name: Smoke test the Node entrypoint on Node 20.19
+        run: node packages/monkey-minifier/test/node-smoke.cjs
 
   arm64-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,15 +54,6 @@ jobs:
         run: |
           pnpm install --filter monkey-extension... --frozen-lockfile
           pnpm --filter monkey-extension run build
-      # pnpm 11 itself needs Node >= 22.13, so the minifier's supported floor
-      # is exercised with plain node: 20.19 is the oldest version whose
-      # synchronous require(esm) the Node entrypoint relies on.
-      - name: Switch to the minifier's minimum supported Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20.19'
-      - name: Smoke test the Node entrypoint on Node 20.19
-        run: node packages/monkey-minifier/test/node-smoke.cjs
 
   arm64-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20.19'
       - run: npx envinfo
       - name: Build
         run: cargo build
@@ -32,6 +35,14 @@ jobs:
         run: cd wasm && wasm-pack build --release --scope=gengjiawen
       - name: Run wasm tests
         run: cd wasm && wasm-pack test --node
+      - name: Build and test minifier
+        run: |
+          corepack enable
+          pnpm install --filter @gengjiawen/monkey-minifier... --frozen-lockfile
+          pnpm --filter @gengjiawen/monkey-minifier build
+          pnpm --filter @gengjiawen/monkey-minifier test:browser
+          pnpm --filter @gengjiawen/monkey-minifier test:node
+          pnpm --filter @gengjiawen/monkey-minifier test
       - name: Run playground tests
         run: |
           corepack enable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Project Structure & Module Organization
 
-- Rust workspace (`Cargo.toml`) with crates: `lexer/`, `parser/`, `object/`, `interpreter/`, `compiler/`, `wasm/`.
-- JS/TS packages under `packages/`: `prettier-plugin-monkey/` (Prettier plugin) and `playground/` (web demo). Workspace managed by `pnpm` (`pnpm-workspace.yaml`).
+- Rust workspace (`Cargo.toml`) with crates: `lexer/`, `parser/`, `object/`, `interpreter/`, `compiler/`, `gc/`, `asm/`, `wasm/`.
+- JS/TS packages under `packages/`: `prettier-plugin-monkey/` (Prettier plugin), `monkey-minifier/` (source minifier), `playground/` (web demo), and `vscode-extension/`. Workspace managed by `pnpm` (`pnpm-workspace.yaml`).
 - Examples in `examples/`; CI in `.github/workflows/`.
 - Crates use flat files (no `src/`); primary files live at crate root (for example `parser/lib.rs`, `compiler/vm.rs`). Tests are colocated as `*_test.rs` plus `insta` snapshots in `snapshots/`.
 
@@ -15,6 +15,7 @@
 - Note: the playground consumes `wasm/pkg/` (the wasm-pack output), not the Rust sources directly. After changes to lexer/parser/compiler, rebuild the wasm package first, otherwise the playground runs stale bytecode. `cargo test` passing does not imply the wasm is up to date.
 - JS workspace: `pnpm i` then
   - Playground: `pnpm -C packages/playground dev` (local server) or `pnpm build`.
+  - Minifier: `pnpm -C packages/monkey-minifier test` and `pnpm -C packages/monkey-minifier build`.
   - Prettier plugin: `pnpm -C packages/prettier-plugin-monkey test` and `pnpm -C packages/prettier-plugin-monkey build`.
 
 ## Coding Style & Naming Conventions

--- a/docs/minifier-plan.md
+++ b/docs/minifier-plan.md
@@ -430,9 +430,11 @@ compiler 也接受时才进入语义语料；两者结果冲突时以 compiler +
 - CI：`.github/workflows/rust.yml` 已有 playground 测试；给 scoped 包加 build、
   Vitest、Node 发布入口和 Vite browser 入口冒烟，并在声明的最低 Node 24 上
   运行。playground 的测试步骤顺带覆盖 `MinifyView`。
-- 版本：按 `AGENTS.md`，功能 PR 不带版本号变更。留给维护者的后续接线：
-  `scripts/bump_cargo_packages.ts` 加上新包；要发 npm 时补 release-please /
-  publish 配置。playground demo 不依赖发布。
+- 版本：按 `AGENTS.md`，功能 PR 不带版本号变更。
+  `scripts/bump_cargo_packages.ts` 会在 release PR 中同步 minifier 版本、
+  Wasm 最低版本和 playground 的 minifier range；要发 npm 时仍需补
+  release-please / publish 配置。
+  playground demo 不依赖发布。
 - 文档：更新 `AGENTS.md` 的项目结构一节（它连 vscode extension 都还没写进去），
   新包加 README。
 

--- a/docs/minifier-plan.md
+++ b/docs/minifier-plan.md
@@ -1,13 +1,16 @@
-# Monkey Minifier — 设计与实施计划
+# Monkey Minifier — 设计与实现
 
-为本仓库的 Monkey 方言实现一个 source-to-source minifier，用 TypeScript 写成
-workspace 新包，并在 playground 里提供在线演示视图。
+本仓库为 Monkey 方言实现了一个 TypeScript source-to-source minifier，作为
+workspace package 提供，并准备发布为 npm package；playground 已提供在线 demo。
+本文记录当前实现、correctness boundaries 和仍未完成的 release follow-up；Phase
+编号只表示功能演进顺序，不再表示多个待提交的 PR。
 
 处理管线：
 
 ```
-源码 ──wasm parse_lossless──▶ JSON AST ──(变换 pass)──▶ AST ──紧凑 printer──▶ 压缩后源码
-                                         mangle / 常量折叠 / 常量传播 / 死代码消除
+source ──wasm parse_lossless──▶ JSON AST ──optimization passes──▶ AST ──compact printer──▶ minified source
+                                         mangling / constant folding /
+                                         constant propagation / DCE
 ```
 
 Parser 不重新实现。minifier 消费 `@gengjiawen/monkey-wasm` 新增的
@@ -17,21 +20,24 @@ Parser 不重新实现。minifier 消费 `@gengjiawen/monkey-wasm` 新增的
 
 ## 目标
 
-- 正确性优先，并把检查拆成两个可判定的不变量：
-  - v0：`parse_lossless(print(parse_lossless(src)))` 与原 AST 结构相等（忽略 span）。
-  - 有变换时：打印结果重新 parse 后与 pass 产出的 canonical AST 结构相等；运行
-    等价由**全新 `Compiler` + GC VM** 的 `status/result/stdout` 判定。
-    interpreter 在重绑定闭包等场景与 compiler 已有不同语义，因此只作补充兼容
-    检查，不是优化的语义权威。
-- v0 做空白/注释剥离 + 冗余括号消除；v1 做标识符改名（mangle）；v2 做常量
-  折叠、常量传播与死 `let` 消除（可选增量）。
+- 正确性优先，并把检查拆成两个可判定的 invariant：
+  - v0：`canonical(reparse(print(ast))) === canonical(ast)`，其中 `ast` 来自
+    `parse_lossless(source)`。
+  - 有 optimization pass 时：打印结果重新 parse 后与 pass 产出的 canonical AST
+    结构相等；runtime equivalence 由**全新 `Compiler` + GC VM** 判定：success
+    比较 `status/result/stdout`，failure 比较 `status/stage/kind/stdout`。
+    Interpreter 与 compiler 在 `rebinding + closure` 等场景下的 semantics 已有差异，
+    因此不作为 optimization oracle。
+- v0 做空白/注释剥离和冗余括号消除；v1 做 identifier mangling；v2 做
+  constant folding、constant propagation 和 dead `let` elimination（DCE）。
 - 发布为 npm 包，API 小而稳定：`minify(source, options)`。
-- Playground 演示：新增 `Minify` 输出视图，实时展示压缩结果和字节数统计。
+- Playground demo：提供 `Minify` 输出视图，实时展示 minified output 和 byte
+  statistics。
 
 ## 非目标（暂时）
 
 - Source map（AST 里有 span，以后想做随时能做）。
-- 属性/方法名改名（`obj.prop` 保持原样——和 terser 默认关闭 `mangleProps`
+- Property/method mangling（`obj.prop` 保持原样——和 terser 默认关闭 `mangleProps`
   同一个原因，不安全）。
 - 面向 gzip 的启发式优化。
 - 一切格式化相关的事——那是 `prettier-plugin-monkey` 的职责。
@@ -40,11 +46,12 @@ Parser 不重新实现。minifier 消费 `@gengjiawen/monkey-wasm` 新增的
 
 新包 `packages/monkey-minifier`（`packages/*` 通配自动进 workspace）。npm 包名用
 `@gengjiawen/monkey-minifier`——和 `@gengjiawen/monkey-wasm` 一样带 scope，避免
-抢注问题；构建/测试配置照抄 `prettier-plugin-monkey`（纯 `tsc` + vitest）。
+抢注问题。构建使用 `tsc` 生成 Node entry/types，再用 esbuild 生成 browser ESM
+bundle；测试使用 Vitest，并另有 Node/browser package smoke tests。
 
 ```
 packages/monkey-minifier/
-  package.json          # 依赖: @gengjiawen/monkey-wasm；build: tsc + ESM bundle
+  package.json          # 依赖: @gengjiawen/monkey-wasm；build: tsc + esbuild
   tsconfig.json
   src/
     index.ts            # 浏览器/bundler 入口
@@ -52,29 +59,35 @@ packages/monkey-minifier/
     core.ts             # minify() 共享管线、选项处理
     cli.ts              # monkey-minify 命令行入口
     types.ts            # AST 类型（复制而来，见下）
-    printer.ts          # 紧凑 printer（Phase 1）
-    scope.ts            # 作用域分析（Phase 3）
-    mangle.ts           # 标识符改名（Phase 3）
-    fold.ts             # 常量折叠 / 死代码消除（Phase 4）
-    propagate.ts        # 常量传播（Phase 4）
+    printer.ts          # compact printer（Phase 1）
+    scope.ts            # scope analysis（Phase 3）
+    mangle.ts           # identifier mangling（Phase 3）
+    fold.ts             # constant folding / DCE（Phase 4）
+    propagate.ts        # constant propagation（Phase 4）
   test/
+    corpus/
     printer.test.ts
     roundtrip.test.ts
     differential.test.ts
     mangle.test.ts
+    fold.test.ts
+    node-entry.test.ts
+    package.test.ts
+    browser-smoke.mjs
+    node-smoke.cjs
 ```
 
 ### Lossless AST 传输与类型
 
-PR 1 先在 parser/wasm 增加一个工具专用的 lossless AST serializer 和
-`parse_lossless()` 导出。这是 blocker，不是后续优化：Rust 节点的
-`Integer.raw` 是 i64，而现有 TS 镜像写成 `number`；例如
+parser/wasm 提供工具专用的 lossless AST serializer 和 `parse_lossless()` 导出。
+这是 minifier 的 correctness prerequisite：Rust AST 中的 `Integer.raw` 是 i64，
+而现有 TS 镜像写成 `number`；例如
 `9007199254740993` 经 `JSON.parse` 会变成 `9007199254740992`，原 AST 和
 round-trip AST 两边一起失真时甚至会假通过。
 
-lossless JSON 只把 `Integer.raw` 投影为十进制字符串，其他节点形状保持不变；不
-修改现有 `parse()` 的返回格式，以免破坏 prettier/playground 消费方。minifier 的
-`src/types.ts` 相应使用：
+lossless JSON 只把 `Integer.raw` 投影为十进制字符串，其余 AST node shapes 保持
+不变。现有 `parse()` 的返回格式不变，以免破坏 prettier/playground 消费方。minifier
+的 `src/types.ts` 相应使用：
 
 ```ts
 interface IntegerLiteral extends ASTNode {
@@ -83,14 +96,15 @@ interface IntegerLiteral extends ASTNode {
 }
 ```
 
-printer 原样输出已验证的十进制串，数值 pass 用 `BigInt(raw)` 运算，任何时候都不
-把 Monkey 整数放进 JS `number`。测试必须包含 `2^53 + 1` 和 `i64::MAX`，并直接
-断言 lossless AST/输出，不能用两个已失真的 `number` 做比较。
+printer 原样输出已验证的十进制串，numeric passes 用 `BigInt(raw)` 运算，任何时候
+都不把 Monkey 整数放进 JS `number`。parser、Wasm 和 minifier tests 直接覆盖
+`2^53 + 1`、`i64::MAX` 以及 nested array/hash 中的整数，不通过 JS `number`
+中转。
 
 ### AST 类型：先复制，不共享
 
 `src/types.ts` 起步时直接复制
-`packages/prettier-plugin-monkey/src/types.ts` 里的节点类型。从 prettier 插件
+`packages/prettier-plugin-monkey/src/types.ts` 里的 AST node types。从 prettier 插件
 import 会把它的 `prettier` peerDependency 拖进 minifier 的依赖图，方向也是反的。
 这些类型是 serde JSON 输出的手写镜像，变动频率很低，两份拷贝可以接受。
 
@@ -104,8 +118,8 @@ import 会把它的 `prettier` peerDependency 拖进 minifier 的依赖图，方
 
 ```ts
 interface MinifyOptions {
-  mangle?: boolean | { reserved?: string[] } // Phase 3 落地后默认 true
-  fold?: boolean // Phase 4 落地后默认 true
+  mangle?: boolean | { reserved?: string[] } // default: true
+  fold?: boolean // controls folding, propagation and DCE; default: true
 }
 
 interface MinifyResult {
@@ -129,20 +143,20 @@ CommonJS `require`），Node 主入口加载生成的 `*_bg.js` glue，再通过
 `WebAssembly.Module`/`WebAssembly.Instance` 同步实例化同一份 Wasm。CLI 复用
 Node 入口，从而保持 `minify()` 同步 API；Node 最低版本是 24。
 
-## Phase 1 — 紧凑 printer（v0）
+## Phase 1 — Compact printer（v0）
 
 v0 里唯一真正需要动脑的部分。三个设计点：
 
 **不抄 Rust 的 `Display` 实现。** 它是调试辅助，不是代码生成器：infix 全括号
 打印（`ast.rs:302`），`if` 条件打印时不带括号——而 parser 强制要求括号
 （`parser/lib.rs:397` 的 `expect_peek(LPAREN)`），也就是说 `Display` 的输出
-确定不能 re-parse。TS printer 从语法出发重写，round-trip 测试是正确性的唯一
-裁判。
+确定不能 re-parse。TS printer 从语法出发重写，structural round-trip test 是
+正确性的裁判。
 
 **按优先级决定括号。** 把 `parser/precedences.rs` 的表搬过来
 （`Lowest < Equals < LessGreater < Sum < Product < Prefix < Postfix`）。规则：
 
-- 子表达式优先级低于上下文优先级时才加括号。
+- 只有 child expression 的 precedence 低于 parent context 时才加括号。
 - 所有 infix 运算符都按左结合 parse：同优先级时只给右子树加括号
   （`a - (b - c)`），左子树永远不加。对 `+`/`*` 也统一套用这条——正确且简单，
   可证结合的场景跳过括号属于后期微优化。
@@ -152,300 +166,342 @@ v0 里唯一真正需要动脑的部分。三个设计点：
 AST 不记录冗余括号（parse 时作为 grouped expression 就消掉了），所以 v0 对
 括号多的源码天然就有压缩收益。
 
-**语句分隔与 token 粘连。** `Let`、`Return`、`SetProperty` 和表达式语句后补
-`;`；`Class` 后**不能**补分号，`class A {};` 会让 parser 把多出的 `;` 当成一条
-没有 prefix parser 的表达式并报错。相邻语句是否需要分隔由 statement printer
-显式处理。
+**Statement separators 与 token boundaries。** `Let`、`Return`、
+`SetProperty` 和 expression statement 后补 `;`；`Class` 后**不能**补分号，
+`class A {};` 会让 parser 把多出的 `;` 当成一条没有 prefix parser 的 expression
+并报错。statement printer 显式决定 adjacent statements 之间是否需要 separator。
 
 词法空格只在删掉后会把两个 token 合并时插入，例如 `let x`、`return x`、
 `new Foo`、`class Foo`。输出永远是 `fn(` 和 `}else{`，这里不需要空格。另用
-token-boundary fixture 固化 `a- -b`/`a--b`、关键字与标识符、相邻语句等情况；
-语句开头的 `{` 无歧义地是 hash 字面量（这个语法没有通用块语句）。
+token-boundary fixture 固化 `a- -b`/`a--b`、keyword/identifier boundary、adjacent
+statements 等情况；以 `{` 开头的 statement 无歧义地是 hash literal（这个语法没有
+通用 block statement）。
 
-**节点全覆盖。** 语句：`Let`、`Return`、`Class`、`SetProperty`、表达式语句。
-表达式：标识符、五种 `Literal`（`Integer`、`Boolean`、`String`、`Array`、
-`Hash`）、prefix、infix、`if`/`else`、`fn`、调用、index、`this`、属性访问、
-`new`。三个已从源码确认的输出形态：
+**Node coverage。** Statements：`Let`、`Return`、`Class`、`SetProperty`、expression
+statement。Expressions：identifier、五种 `Literal`（`Integer`、`Boolean`、`String`、
+`Array`、`Hash`）、prefix、infix、`if`/`else`、`fn`、call、index、`this`、property
+access、`new`。三个已从源码确认的输出形态：
 
 - `if` 条件必须带括号：`if(c){...}else{...}`。
 - 函数一律输出 `fn(params){...}`：`fn name()` 不能 parse（`parser/lib.rs:463`，
   `fn` 后紧跟 `expect_peek(LPAREN)`）。AST 里的 `FunctionDeclaration.name`
-  是 `parse_let_statement` 从 let 绑定回填的递归元数据（`parser/lib.rs:121`，
-  compiler 在函数内部为它定义 `Function` symbol）；printer 不输出这个字段，
-  但变换后的 canonical AST 必须同步维护它。
-- 字符串字面量原样输出：lexer 的 `read_string`（`lexer/lib.rs:195`）没有任何
+  是 `parse_let_statement` 根据 let binding 回填的 recursion metadata
+  （`parser/lib.rs:121`）；compiler 在函数内部为它定义 `Function` symbol。printer
+  不输出这个字段，但 transformed canonical AST 必须同步维护它。
+- string literal 原样输出：lexer 的 `read_string`（`lexer/lib.rs:195`）没有任何
   转义机制，读到下一个 `"` 为止——字符串内容不可能含 `"`，反斜杠是普通字符，
   还可以跨行。printer 直接输出 `"` + 原文 + `"`，零处理。
 
 注释根本进不了 AST，剥离零成本。
 
-## Phase 2 — playground 演示
+## Phase 2 — Playground demo
 
-沿用 `packages/playground/src/App.tsx` 现有的输出视图模式：
+`packages/playground/src/App.tsx` 已接入 Minify view：
 
-- `OutputView`（`App.tsx:107`）加 `'minify'`，SegmentedControl 里在
-  AST / Bytecode / GC / Snapshot / ARM64 旁边加一个 **Minify** tab。
-- 新建 `src/MinifyView.tsx`，照 `Arm64View` 的样子：只读 CodeMirror `Editor`
-  展示压缩结果，加一条统计栏——原始字节数 → 压缩后字节数和节省百分比。状态
-  类型 `MinifyState = idle | ok | invalid`，对齐 `Arm64BuildState`；两端字节数都用
-  `TextEncoder` 算 UTF-8 bytes。
-- 视图激活时才计算，带 debounce，抄 `debouncedArm64Compile` 的 effect 写法
-  （`App.tsx:328`）。动态 import 和计算结果都携带递增 request id，并在提交状态
-  前确认它仍对应最新 source、当前视图仍激活；否则首次加载较慢时旧请求可能覆盖
-  新输入。
-- 通过动态 `import('../../monkey-minifier/src/index')` 引入——和 Format 按钮
-  引 prettier 插件的先例完全一致（`App.tsx:281`），所以 **demo 不依赖发 npm**。
-- Parse 错误时面板里展示错误信息，和其他视图一致。
+- `OutputView` 包含 `'minify'`，SegmentedControl 在 AST / Bytecode / GC /
+  Snapshot / ARM64 旁边提供 **Minify** tab。
+- `src/MinifyView.tsx` 使用只读 CodeMirror `Editor` 展示 minified output，并显示
+  input/output UTF-8 bytes 和节省百分比。状态类型是
+  `MinifyState = idle | ok | invalid`。
+- 只在 view 激活时 debounce 计算。dynamic import 和计算结果都携带递增 request
+  id；提交状态前再次核对最新 source 和 active view，防止慢请求覆盖新输入。
+- 通过动态 `import('../../monkey-minifier/src/index')` 引入，和 Format action
+  动态引入 prettier plugin 的方式一致，所以 **demo 不依赖 npm release**。
+- Parse error 直接显示在 panel；toolbar 已提供 `Mangle names` switch。
+- Playground 已包含 `Constant folding` snippet，展示下一节的 constant
+  folding/propagation pipeline 最终把程序压缩为 `print(2);`。
 
-后续增量（不阻塞第一个 demo PR）：
+`src/test/MinifyView.test.tsx` 覆盖状态和 UTF-8 byte 统计，`App.test.tsx` 覆盖 lazy
+execution、stale request guard 和 mangle switch。
 
-- Phase 3 落地后在工具栏加 mangle 开关 `Switch`，访客能实时看到改名效果。
-- "runs identically ✓" 徽章：在下面测试章节的 output-aware runner 落地后，分别
-  执行原始和压缩版并对比 `status/result/stdout`，把正确性主张变成看得见的演示；
-  不能只用当前不捕获输出的 `run_snapshot`。
-- 如果现有 snippet 演示效果不够好，加一个专门的 `Minify` snippet
-  （闭包 + class 的组合最能展示）。
+唯一保留的 UI follow-up 是可选的 `runs identically ✓` badge。所需的 output-aware
+runner 已经存在；若实现 badge，应分别执行 original/minified program 并比较
+`status/result/stdout`，不能退回不捕获 stdout 的 `run_snapshot`。
 
-测试放 `src/test/MinifyView.test.tsx`，沿用现有视图测试的写法。
+## Phase 3 — Identifier mangling（v1）
 
-## Phase 3 — 标识符 mangle（v1）
-
-实际压缩收益的大头，但只改名能解析到明确 binding identity 的标识符。以下名字
-保持不动，生成名也不能与它们碰撞：
+这是实际压缩收益的大头，但只对能解析到明确 binding identity 的 identifier 做
+rename。以下名字保持不动，生成名也不能与它们碰撞：
 
 - builtin：完整列表是 `len`、`puts`、`first`、`last`、`rest`、`push`、`print`
-  （`object/builtins.rs`）。builtin 引用不改名；用户 `let` 可以 shadow builtin，
+  （`object/builtins.rs`）。builtin reference 不改名；用户 `let` 可以 shadow builtin，
   该用户 binding 则是另一个 identity，可以改名。
-- 属性名和方法名：`PropertyExpression.property`、
+- Property 和 method 名：`PropertyExpression.property`、
   `SetPropertyStatement.property`、`MethodDefinition.name`。Hash key 是普通表达式，
   也绝不能被当作属性名统一改写。
-- class declaration 的 binding 及解析到它的引用。虽然 class 名参与普通词法解析，
-  GC VM 会在 class、instance、bound method 的最终值和 `puts` 输出中显示它；直接
-  把 `class LongName` 改成 `class a` 会改变可观察结果。同名的后续 `let` 重绑定是
-  独立 identity，不受此限制。
-- `this`、用户传入的 `options.mangle.reserved`，以及所有未解析/外部标识符。遇到
-  analyzer 无法精确建模的节点时 fail closed，不对相关 scope 改名。
+- class declaration 的 binding 及解析到它的 references。虽然 class 名参与普通词法
+  解析，GC VM 会在 class、instance、bound method 的最终值和 `puts` 输出中显示它；
+  直接把 `class LongName` 改成 `class a` 会改变 observable result。同名的后续 `let`
+  rebinding 是独立 identity，不受此限制。
+- `this`、用户传入的 `options.mangle.reserved`，以及所有 unresolved/external
+  identifiers。unresolved name 保留原 spelling 并加入生成名禁用集合；遇到 analyzer
+  无法精确建模的 unknown node 时，整个 pass fail closed。
 
 `scope.ts` 不是只收集字符串的传统 hoist scope，而是按
-`Compiler::compile_stmt` 的遍历顺序构建 binding/reference graph。语义权威是每次
-都从干净状态创建的 standalone compiler；不能用 interpreter environment 反推，
-因为例如重绑定后闭包读取的值，两套引擎目前并不一致。需要逐条镜像这些规则：
+`Compiler::compile_stmt` 的遍历顺序构建 binding/reference graph。Semantic
+authority 是每次都从干净状态创建的 standalone compiler；不能用 interpreter
+environment 反推，因为例如 rebinding 后 closure 读取的值，两套引擎目前并不一致。
+需要逐条 mirror 这些规则：
 
-1. 只有 program、函数字面量和每个 method body 创建 symbol scope；`if`/`else`
+1. 只有 program、function literal 和每个 method body 创建 symbol scope；`if`/`else`
    block 不创建 scope，class declaration 自身也不创建额外 scope。
 2. 普通 `let` 先解析/编译 RHS，再定义一个新 slot。同名 `let` 是新的 binding，
-   只遮蔽它之后的引用；更早创建的闭包继续捕获旧 binding。分析器可先创建一个
-   pending identity，但在 RHS 结束前不能把它放进普通可见名字表。
+   只遮蔽它之后的 reference；更早创建的 closure 继续 capture 旧 binding。Analyzer
+   可先创建一个 pending identity，但在 RHS 结束前不能把它放进普通可见名字表。
 3. 直接形如 `let f=fn(...){...}` 的 RHS 是特例：parser 回填的
-   `FunctionDeclaration.name` 会在函数内部先定义递归 self symbol；它与 pending
+   `FunctionDeclaration.name` 会在函数内部先定义 recursive self symbol；它与 pending
    `f` 绑定关联，但不让 `f` 在 RHS 的其他位置提前可见。进入函数后先定义这个
-   self symbol，再按参数列表顺序定义参数；重复参数或与 self 同名的参数以最后
-   定义的 slot 为引用目标。
-4. class binding 在编译 methods **之前**定义，因此方法可引用本 class。method
-   scope 先有隐式 `this`，再按顺序定义参数；嵌套函数按正常闭包规则捕获 `this`。
+   self symbol，再按参数列表顺序定义 parameters；duplicate parameters 或与 self
+   同名的 parameter 以最后定义的 slot 为 reference target。
+4. class binding 在编译 methods **之前**定义，因此 methods 内的 class reference
+   可以正常 resolve。method scope 先有 implicit `this`，再按顺序定义 parameter；
+   nested function 按正常 closure capture 规则捕获 `this`。
 5. compiler 依次编译 `if` 的 condition、consequent、alternate，两个 branch 共用
    当前 symbol table；即使运行时只走一个 branch，其中的 `let` 也会按这个编译
-   顺序影响另一个 branch 和后续引用。分析器必须复现这个行为，不能分别 clone
+   顺序影响另一个 branch 和后续 references。Analyzer 必须复现这个行为，不能分别 clone
    两份词法环境再 merge。
 6. builtin 是初始 symbol，用户声明可按上述源码顺序 shadow；找不到 binding 的
    identifier 保持原拼写，并加入生成名禁用集合，防止意外 capture。
 
 `mangle.ts` 按 graph 中的 identity 改 declaration 和所有已绑定 reference，而非
-按字符串全局替换。第一版优先保证可靠：按引用频率给可改 binding 分配全程序唯一
-的短名（`a`–`z`，再到 `a0`…），并跳过关键字、builtin、reserved、class 名、未
-解析名和所有保留原名的 binding。以后再基于 interference/liveness 证明安全地在
-不相交 scope 复用短名。
+按字符串全局替换。当前策略按 reference frequency 给可改 binding 分配全程序唯一
+的短名（`a`–`z`，再到 `a0`…），并跳过 keyword、builtin、reserved、class 名、
+unresolved name 和所有保留原名的 binding。以后可基于 interference/liveness
+证明安全地在不相交 scope 复用短名。
 
-改直接绑定函数字面量的 `let` 时，还要同步其 `FunctionDeclaration.name` 元数据；
-printer 仍只输出 `fn(`，重新 parse 会根据新 let 名回填同样的 metadata。fixture
-至少覆盖连续重绑定、RHS 读取旧 binding、自递归、重复参数、builtin shadow、
-闭包捕获、两个 if branch、隐式 `this`、class 自引用和未解析 identifier。
+改直接绑定 function literal 的 `let` 时，还要同步其 `FunctionDeclaration.name`
+metadata。printer 仍只输出 `fn(`，重新 parse 会根据新 let 名回填同样的 metadata。
+Tests 覆盖连续 rebinding、RHS 读取旧 binding、self-recursion、duplicate parameters、
+builtin shadow、closure capture、两个 if branch、implicit `this`、class reference 和
+unresolved identifier。
 
-## Phase 4 — 压缩 pass（v2，可选）
+## Phase 4 — Optimization passes（v2）
 
-每个都是自包含的 AST→AST pass，但集成顺序固定为：常量折叠与常量传播交替到
-不动点 → 重建 binding/effect 分析 → 死 `let` 消除到不动点 → 再分析 →
-mangle → printer。不能宣称任意顺序；折叠为传播制造 literal 初始化式，传播为
-折叠解锁卡在 identifier 上的表达式，两者共同暴露死绑定，删除又会改变引用
-频率和后续 slot 编号。任一分析不确定时保留原节点。
+每个都是自包含的 AST→AST pass，但 integration order 固定为：constant folding 与
+constant propagation 交替到 fixed point → DCE 到 fixed point（每轮发生删除后重跑
+scope analysis）→ mangling（使用 fresh scope analysis）→ printer。不能宣称任意
+顺序：
+folding 为 propagation 制造 literal initializer，propagation 为 folding 解锁卡在
+identifier 上的 expression；两者共同暴露 dead binding，删除又会改变 reference
+frequency 和后续 slot 编号。任一 analysis 不确定时保留原 node。
 
-### 常量折叠
+### Constant folding
 
 整数算术、字符串拼接、布尔/比较运算、前缀运算严格镜像 production GC VM，而
 不是 interpreter。整数从 lossless `raw` 用 `BigInt` 计算：
 
-- 加、减、乘和负号按 i64 two's-complement 回绕，用
-  `BigInt.asIntN(64, value)`。启用此 pass 前先把 GC VM 对应操作改成显式
-  `wrapping_add/sub/mul/neg`，消除 Rust debug/release overflow 行为差异。
-- 除法用 BigInt 的向零截断；除数为 0、以及 `i64::MIN / -1` 都保留原表达式，让
-  VM 产生原来的 runtime error。
-- AST 没有负整数字面量。负结果必须构造成 `UnaryExpression(-, Integer(abs))`；
-  `i64::MIN` 的绝对值超出 lexer 可接受的正 i64，无法这样打印，因此放弃该次
-  折叠，绝不生成非法 literal。
-- 只有操作数类型和 VM 结果都能证明时才折叠；字符串只折叠 `+`，比较/`!` 也只
-  覆盖 GC VM 已定义的常量类型组合。每个溢出边界和错误路径都写 differential
-  fixture。
+- 加、减、乘和负号按 i64 two's-complement wrap，用
+  `BigInt.asIntN(64, value)`。GC VM 已显式使用
+  `wrapping_add/sub/mul/neg`；minifier 只 mirror 这项既有语义，本实现不需要修改
+  gc crate。
+- division 使用 BigInt 的 truncation toward zero；divisor 为 0、以及
+  `i64::MIN / -1` 都保留原 expression，让 VM 产生原来的 runtime error。
+- AST 没有 negative integer literal。负结果必须构造成
+  `UnaryExpression(-, Integer(abs))`；`i64::MIN` 的绝对值超出 lexer 可接受的正 i64，
+  无法这样打印，因此放弃该次 fold，绝不生成非法 literal。
+- 只有 operand type 和 VM result 都能证明时才 fold；string 只 fold `+`，比较和
+  `!` 也只覆盖 GC VM 已定义的 constant type 组合。Overflow boundaries 和 error
+  paths 由 unit/differential fixtures 覆盖。
+
+下面是直接经过 `minify(source, { fold: true, mangle: false })` 的实际结果；这些
+program 没有 binding，因此单独展示的是 constant folding 效果：
+
+| Source                       | Output                  |
+| ---------------------------- | ----------------------- |
+| `40 + 2`                     | `42;`                   |
+| `"mon" + "key"`              | `"monkey";`             |
+| `if (true) { 1 } else { 2 }` | `1;`                    |
+| `9223372036854775807 + 2`    | `-9223372036854775807;` |
+
+相反，`1 / 0` 和 `(-9223372036854775807 - 1) / -1` 会保留原 expression，让 GC
+VM 产生原有 runtime error。
 
 `if` 是 expression，而它的 branch 是任意 `BlockStatement`，语言又没有可打印的
-`null` literal，所以不能通用地拿选中 block 替换整个 `if`。v2 只折叠可表示子集：
+`null` literal，所以不能通用地拿 selected block 替换整个 `if`。v2 只 fold
+可表示子集：
 
-- condition 已被证明为无副作用的常量；
-- 被选 branch 恰好只有一个表达式语句，可直接替换为该 expression；
+- condition 已被证明是 side-effect-free constant；
+- selected branch 恰好只有一个 expression statement，可直接替换为该 expression；
 - consequent 和 alternate 都不含会修改当前 compiler symbol table 的声明，否则
-  删除未执行 branch 仍可能改变另一个 branch 或后续引用的 binding；
+  删除未执行 branch 仍可能改变另一个 branch 或后续 reference 的 binding resolution；
 - constant false 且没有 `else` 时保留原 `if`，因为 AST 中没有 Null literal。
 
-例如 `let x=if(true){let y=1;y};` 不能折叠成一个 block，必须保留。
+例如 `let x=if(true){let y=1;y};` 不能 fold 成一个 block，必须保留。
 
-还有一个 parser 元数据边界：`let f=fn(){...}` 会给函数体注入递归 self binding，
-而 `let f=if(true){fn(){...}}` 里的嵌套函数是匿名的。即使 condition 是常量，也
-不能把后者折叠成直接 RHS 函数字面量，否则打印后重新 parse 会改变闭包捕获。
+还有一个 parser metadata boundary：`let f=fn(){...}` 会给 function body 注入
+recursive self binding，而 `let f=if(true){fn(){...}}` 里的 nested function 是
+anonymous。即使 condition 是 constant，也不能把后者 fold 成直接 RHS function
+literal，否则打印后重新 parse 会改变 closure capture。
 
-### 常量传播
+### Constant propagation
 
-折叠只处理“表达式内部全是常量”的情况；`let a=1+1; let b=a+1; print(a)` 里
-`b` 的 RHS 和 `print` 的实参都卡在 identifier 上，折叠自身永远打不开。传播
-pass 把“初始化式在折叠后已是 literal”的 binding 的每处引用替换成该 literal
-的深拷贝（后续 pass 原地改写节点，多处共享同一节点会被重复改写），从而让
-上面的程序最终压成 `print(2);`，对齐 terser 在等价 JavaScript 上的输出。
-传播自己不删语句：引用清零的 binding 交给死 `let` 消除按它的规则处理。
+Folding 只处理 expression 内部全是 constant 的情况。Playground 的
+`Constant folding` snippet 故意展示完整 pipeline：
 
-安全论证建立在 compiler 的 slot 语义上：每条 `let` 都分配新 slot（重绑定
-不是赋值），slot 恰好写入一次，因此解析到某 binding 的引用读到的值恒等于
-该 binding 初始化式的值——闭包也一样，`let v=1; let g=fn(){v}; let v=2;`
+```monkey
+let a = 1 + 1;
+let b = a + 1;
+print(a)
+```
+
+处理过程是：
+
+1. constant folding 先得到 `let a=2;`；
+2. constant propagation 把 `a` 的 reference 替换为 `2`；
+3. 下一轮 folding 把 `let b=2+1;` 变成 `let b=3;`；
+4. DCE 删除 zero-reference bindings `a` 和 `b`。
+
+最终输出：
+
+```monkey
+print(2);
+```
+
+Propagation pass 把“initializer 在 folding 后已是 literal”的 binding reference
+替换成该 literal 的独立 clone。后续 pass 会原地改写 node，因此不能让多个位置
+共享同一个 AST object。Propagation 本身不删 statement：reference 清零的 binding
+交给 DCE。
+
+安全论证建立在 compiler 的 slot semantics 上：每条 `let` 都分配新 slot（rebinding
+不是赋值），slot 恰好写入一次，因此解析到某 binding 的 reference 读到的值恒等于
+该 binding initializer 的值——closure 也一样，`let v=1; let g=fn(){v}; let v=2;`
 中 `g()` 返回 1，已用探针在真实 GC VM 上验证。唯一反例是 `if` arm 里的
-`let`：两个 branch 共用符号表（Phase 3 规则 5），`let` 之后的引用会解析到
-它，但 arm 未执行时 slot 从未写入，引用处读到 null——
-`let v=1; if(1>2){let v=2;}; puts(v);` 输出 `null`。scope 分析给这类
-binding 打 `conditional` 标记，传播一律跳过；函数/方法体是新的执行边界，
+`let`：两个 branch 共用符号表（Phase 3 规则 5），`let` 之后的 reference 会解析到
+它，但 arm 未执行时 slot 从未写入，reference site 读到 null——
+`let v=1; if(1>2){let v=2;}; puts(v);` 输出 `null`。Scope analysis 给这类
+binding 打 `conditional` 标记，propagation 一律跳过；函数/方法体是新的执行边界，
 body 顶层 `let` 每次调用都执行，标记在 callable 边界重置。
 
 其余护栏：
 
-- 只传播四种折叠后形态：integer/boolean/string literal 与
-  `UnaryExpression(-, Integer)`。array/hash 字面量每次求值分配新值，复制到
-  多个位置会改变别名关系，直接排除。
-- `new` 的 callee 语法上必须是 identifier，不可替换；该引用保留后 binding
+- 只 propagate 四种 folded shape：integer/boolean/string literal 与
+  `UnaryExpression(-, Integer)`。array/hash literal 每次求值分配新值，复制到
+  多个位置会改变 aliasing，直接排除。
+- `new` 的 callee 语法上必须是 identifier，不可替换；保留该 reference 后 binding
   自然存活。
-- 体积护栏：保留 binding 的成本是 `let x=<lit>;` 的 7 个固定字符加每处引用
-  1 字符（mangle 后），内联成本是每处 `width` 字符；
-  `refs × (width−1) > 7 + width` 时放弃，例如 `"hello"` 引用三次就保留
-  绑定。
+- Size guard：保留 binding 的成本是 `let x=<lit>;` 的 7 个固定字符加每处 reference
+  1 字符（mangle 后），inline 成本是每处 `width` 字符；
+  `refs × (width−1) > 7 + width` 时放弃，例如 `"hello"` 有三个 references 时就保留
+  binding。
 
-传播与折叠互相解锁——传播把 literal 塞进卡在 identifier 上的表达式，折叠
-再把它算成新的 literal 初始化式——所以两者交替运行到不动点，之后才进入死
-`let` 消除。终止性：每轮成功传播至少替换掉一个 identifier 节点，而两个
-pass 都不会新建 identifier，identifier 总数严格递减、有下界。三个危险案例
-（conditional `let`、重绑定 + 闭包捕获、`new` callee）各有 differential
+例如关闭 mangling 后，下面的 binding 会因为 size guard 保留，而不是复制三份
+`"hello"`：
+
+```monkey
+let s="hello";puts(s);puts(s);puts(s);
+```
+
+Propagation 与 folding 互相解锁，所以两者交替运行到 fixed point，之后才进入
+DCE。Termination proof：每轮成功 propagation 至少替换掉一个 identifier node，
+而两个 pass 都不会新建 identifier，identifier 总数严格递减、有下界。三个危险案例
+（conditional `let`、rebinding + closure capture、`new` callee）各有 differential
 fixture 钉住。
 
-### 死 `let` 消除（去掉无用变量）
+### Dead `let` elimination（DCE）
 
-一个 binding identity 零引用，并且 initializer 被证明为“无副作用且 total/no
-throw”时，才删除整条 `let`。仅检查 `FunctionCall`/`New` 不够：属性/index 读取、
-类型不匹配的运算和除零同样会报 runtime error；删除它们会把错误程序变成成功
-程序。
+一个 binding identity 的 reference count 为 0，并且 initializer 被证明为
+side-effect-free and total（不会 throw）时，才删除整条 `let`。仅检查
+`FunctionCall`/`New` 不够：property/index read、invalid operand type 和 division by
+zero 同样会报 runtime error；删除它们会把 error program 变成 success program。
 
-实现一个保守的 effect summary（至少区分 `hasEffects` 与 `mayThrow`），初版采用
-白名单证明安全，而不是列一份黑名单猜纯度：
+当前实现用保守的 `isPureTotal` allowlist 同时证明“没有 side effect”和“不会
+throw”，而不是分别维护 `hasEffects` / `mayThrow` summary，也不是用 denylist 猜
+purity：
 
-- integer/boolean/string literal 是 total；array/hash 只有在所有子表达式 total、
-  且 hash key 已证明可 hash 时才是 total。
+- integer/boolean/string literal 是 total；array/hash 只有在所有 child expressions
+  都 total，且 hash key 已证明 hashable 时才是 total。
 - prefix/infix 只有在静态已知的 operand 类型受 GC VM 支持、且整数除法排除两个
   错误条件时才是 total。
-- `FunctionCall`、`New` 一律不可删；`PropertyExpression` 和 `IndexExpression`
-  默认 `mayThrow`，即使没有 getter 也不能当作安全读取。未知 identifier/节点也
-  默认不可删。
-- 函数字面量的**创建**不执行 body，所以 runtime effect 分析把 body 当叶子；但
-  body 中若有未解析名字或其他 compiler/analyzer diagnostic，必须给 initializer
-  加不可变换标记，不能借删除改变 compile status。
+- `FunctionCall`、`New` 一律不可删；`PropertyExpression` 和 `IndexExpression` 都是
+  potentially throwing，即使没有 getter 也不能当作安全读取。unresolved identifier /
+  unknown node 也默认不可删。
+- function literal 的**创建**不执行 body，所以 runtime effect proof 把 body 当叶子；
+  但 body 中若有 unresolved name 或其他 compiler/analyzer diagnostic，必须给
+  initializer 加不可变换标记，不能借删除改变 compile status。
 
 典型边界：
 
-```
-let unusedHelper = fn(x) { puts(x) };   // 可删：定义时什么都不执行
-let x = compute();                       // 不可删：初始化有调用，可能有副作用
-let y = 42;                              // 可删：纯字面量，零引用
-let z = 1 / 0;                           // 不可删：会报错
-let p = 1.missing;                       // 不可删：属性读取会报错
+```monkey
+let unusedHelper = fn(x) { puts(x) };   // removable: creating a closure is pure/total
+let x = compute();                       // retained: call may have side effects
+let y = 42;                              // removable: pure/total literal, no references
+let z = 1 / 0;                           // retained: division by zero throws
+let p = 1.missing;                       // retained: property read may throw
 ```
 
-删除会级联：删掉一条 `let` 可能让另一条失去唯一引用者，所以每轮基于 binding
-identity 重新分析并迭代到不动点。DCE 在 mangle **之前**运行，让最终引用频率和
-命名建立在实际保留的程序上。
+删除会级联：删掉一条 `let` 可能让另一条失去唯一 reference，所以每轮基于 binding
+identity 重新运行 analysis 并迭代到 fixed point。DCE 在 mangling **之前**运行，让
+最终 reference frequency 和命名建立在实际保留的 program 上。
 
 `let` 还有两个 compiler/VM 特有的保守边界：
 
-- function/method 或 `if` branch 的末尾 `let` 是隐式返回值的 barrier；删除它会
-  暴露前一条表达式，所以必须保留。
+- function/method 或 `if` branch 的末尾 `let` 是 implicit return value barrier；
+  删除它会暴露前一条 expression，所以必须保留。
 - VM 进入 callable 时会一次性预留全部 local slots。若其中有空 `if` arm 或以
   `let` 结尾、因而可能不产生栈值的 arm，现有 bytecode 会让后续 pop/赋值读到
   预留 slot；此时改变任意 local 数量都可能改变现有运行结果。这样的 callable
   整体禁用 local DCE，并让嵌套 callable 各自独立判断。
 
-## 测试策略
+## Test strategy
 
-语料先行：`App.tsx` 里的 playground snippets、`examples/*.monkey`、以及从
-parser/compiler 各 `*_test.rs` 里提取的程序。interpreter 用例只有在 standalone
-compiler 也接受时才进入语义语料；两者结果冲突时以 compiler + GC VM 为准。统一
-收进 `test/corpus/`，下面所有套件共用。
+Fixtures 按用途组织；当前没有强制所有 suite 共用同一个 corpus：
 
-1. **Lossless contract**：单独测试 `parse_lossless()` 的 `Integer.raw` 是十进制
-   string，覆盖 `9007199254740993`、`i64::MAX`、嵌套 array/hash 中的整数；禁止
-   通过 JS `number` 中转。
-2. **Round-trip**（printer 主力）：定义一个只删除 `span`/comment 附属字段的
-   canonicalizer。v0 比较 `canonical(parse_lossless(print(ast)))` 与原 AST；有
-   pass 时比较 reparsed AST 与 pass 返回的 canonical transformed AST。不能只比
-   运行结果，因为两棵同样被错误打印的程序可能碰巧返回同一个值。
-3. **Differential 执行**：原始版和压缩版分别用全新的 `Compiler` 编译，再交给
-   GC VM 执行。当前 `run_snapshot` 只有 `{status,result}`，`puts`/`print` 最终走
-   `println!`，所以它不是完整 oracle；PR 1 就补齐下面的测试载具，而不是等 DCE：
-   - 给 GC VM 的 builtin 执行路径注入 output sink，避免换成语义不同的
-     interpreter，也避免共享的 thread-local 缓冲；
-   - 新增 `run_snapshot_with_output`（或等价内部 helper），成功和失败 envelope 都
-     返回已产生的 `stdout`，从而保留“输出后报错”的可观察顺序；
-   - 为 compile/runtime error 暴露稳定的 structured `kind`。成功时比较
-     `status + result + stdout`；失败时比较 `status + stage + kind + stdout`。
-     diagnostic message、变量名和 span 不纳入等价定义，因为 mangle/printer 会
-     合法地改变内部名字与源码位置。
-     differential corpus 使用确定终止、不会贴近 instruction budget 的程序；执行
-     上限测试独立进行，不把优化后少执行几条指令当作语言语义差异。
-4. **幂等性**：`minify(minify(src)).code === minify(src).code`，分别覆盖每组
-   options。
-5. **Mangle 安全性**（Phase 3 起）：连续重绑定、RHS 旧值、自递归、重复参数、
-   闭包捕获、builtin shadow、if 两分支污染、`this`、未解析名、class/属性各写
-   fixture，全部过 structural + differential 套件；另断言 class/instance 的
-   可见名称没有变化。
-6. **Fold/Propagate/DCE 安全性**（Phase 4 起）：覆盖 i64 边界、除零、
-   `i64::MIN / -1`、不可表示的 if、传播的三个危险案例（conditional `let`、
-   重绑定 + 闭包捕获、`new` callee），以及“无调用但会报错”的 initializer
-   （错误 operand 类型、property/index）。每次删除前后都跑 output-aware
-   differential。
+- `test/corpus/core.monkey` 和 `classes.monkey`、`examples/hello.monkey` 以及少量 inline
+  programs 用于 structural round-trip；
+- `differential.test.ts` 使用一组专门的、确定终止的 inline programs；
+- printer、mangling、folding、propagation 和 DCE 的窄边界由各自 unit tests 覆盖。
 
-全语料的压缩率在测试输出里打印成报告，不做断言，这样改进 printer 永远不会
-"挂"在一个过期数字上。
+Standalone compiler + GC VM 是 semantic authority。Interpreter 与 compiler 已有
+已知差异，因此不作为 optimization oracle。
 
-## CI、发布、文档接线
+1. **Lossless contract**：parser test 直接断言 `Integer.raw` 是 decimal string，
+   覆盖 `9007199254740993`、`i64::MAX` 和 nested array/hash；Wasm/minifier tests
+   继续钉住 API boundary 和 printer output，全程不通过 JS `number` 中转。
+2. **Structural round-trip**：canonicalizer 只删除 `span` 和 `comments`。Printer-only
+   case 比较原 AST 与重新 parse 的 AST；transformed case 按 production order 执行
+   folding ↔ propagation fixed point、DCE、mangling，再比较 transformed AST 与
+   reparsed AST。它能抓到 runtime differential test 可能看不出的 structural drift。
+3. **Output-aware differential test**：original/minified program 分别创建全新
+   `Compiler`，生成 snapshot 后交给 GC VM。`run_snapshot_with_output` 在
+   success/error envelope 中都保留已产生的 `stdout`，error 还提供稳定的
+   `stage`/`kind`。成功时比较
+   `status + result + stdout`；失败时比较 `status + stage + kind + stdout`。
+   Diagnostic message、变量名和 span 不属于 equivalence contract。Instruction
+   budget tests 独立运行，不把优化后少执行几条 instruction 当作 semantic change。
+4. **Idempotence**：四种 boolean option 组合都断言
+   `minify(minify(src)).code === minify(src).code`。
+5. **Mangling safety**：unit/structural/differential tests 合起来覆盖连续 rebinding、
+   RHS 旧值、self-recursion、duplicate parameters、closure capture、builtin shadow、
+   两个 `if` branch、`this`、unresolved name、class/property/method，并钉住
+   class/instance 的 visible name。
+6. **Folding/propagation/DCE safety**：unit tests 覆盖 i64 boundary、division by zero、
+   `i64::MIN / -1`、不可表示的 `if` 和 pure/total allowlist；end-to-end differential
+   programs 覆盖 conditional `let`、rebinding + closure capture、`new` callee，以及
+   property/index read 和 invalid operand type 等 potentially-throwing initializer。
 
-- CI：`.github/workflows/rust.yml` 已有 playground 测试；给 scoped 包加 build、
-  Vitest、Node 发布入口和 Vite browser 入口冒烟，并在声明的最低 Node 24 上
-  运行。playground 的测试步骤顺带覆盖 `MinifyView`。
-- 版本：按 `AGENTS.md`，功能 PR 不带版本号变更。
-  `scripts/bump_cargo_packages.ts` 会在 release PR 中同步 minifier 版本、
-  Wasm 最低版本和 playground 的 minifier range；要发 npm 时仍需补
-  release-please / publish 配置。
-  playground demo 不依赖发布。
-- 文档：更新 `AGENTS.md` 的项目结构一节（它连 vscode extension 都还没写进去），
-  新包加 README。
+Compression ratio 不是 correctness assertion，也不会写进 test output。Playground
+直接展示当前 source 的 UTF-8 byte delta，避免维护会过期的 golden ratio。
 
-## 里程碑 / PR 切分
+## CI、release 与 docs
 
-| PR  | 内容                                                                  | 预估     |
-| --- | --------------------------------------------------------------------- | -------- |
-| 1   | lossless AST 导出 + 脚手架 + printer + structural/output differential | 2 天     |
-| 2   | Playground `Minify` 视图 + UTF-8 字节统计 + stale request guard       | 0.5–1 天 |
-| 3   | compiler-order binding 分析 + mangler（+ playground 开关）            | 2–3 天   |
-| 4   | 明确 i64 VM 语义 + 常量/受限 `if` 折叠 + 常量传播 + 保守死 `let` 消除 | 2–3 天   |
-| 5   | CLI `bin` + 发布接线 + 文档                                           | 0.5 天   |
+- `.github/workflows/rust.yml` 已在最低 Node 24 上运行 minifier build、Vitest、Node
+  entry smoke、Vite/browser smoke，并由 playground test 覆盖 `MinifyView`。
+- 按 `AGENTS.md`，feature PR 不做 version bump。
+  `scripts/bump_cargo_packages.ts` 会在 release PR 中同步 minifier version、Wasm
+  dependency range 和 playground minifier range。
+- npm release 仍需给 release-please workflow 增加 minifier build/publish step；
+  playground demo 直接 import workspace source，不依赖 package 发布。
+- `AGENTS.md` 已加入 minifier package，package 自带 README 和 CLI usage。
 
-PR 1+2 合起来交付可见的 demo；之后全是增量。
+## Implementation status
+
+| Area                                                                | Status             |
+| ------------------------------------------------------------------- | ------------------ |
+| Lossless AST、package scaffold、compact printer                     | Implemented        |
+| Structural round-trip、output-aware differential runner             | Implemented        |
+| Playground Minify view、UTF-8 stats、stale request guard            | Implemented        |
+| Scope analysis、identifier mangling、playground switch              | Implemented        |
+| Constant folding、constant propagation、DCE                         | Implemented        |
+| CLI、Node/browser entries、package smoke tests、README              | Implemented        |
+| `runs identically ✓` playground badge                               | Optional follow-up |
+| release-please build/publish step for `@gengjiawen/monkey-minifier` | Follow-up          |

--- a/docs/minifier-plan.md
+++ b/docs/minifier-plan.md
@@ -1,0 +1,407 @@
+# Monkey Minifier — 设计与实施计划
+
+为本仓库的 Monkey 方言实现一个 source-to-source minifier，用 TypeScript 写成
+workspace 新包，并在 playground 里提供在线演示视图。
+
+处理管线：
+
+```
+源码 ──wasm parse_lossless──▶ JSON AST ──(变换 pass)──▶ AST ──紧凑 printer──▶ 压缩后源码
+                                         mangle / 常量折叠 / 死代码消除
+```
+
+Parser 不重新实现。minifier 消费 `@gengjiawen/monkey-wasm` 新增的
+`parse_lossless()` 输出；它和现有 `parse()` 来自同一个 Rust AST，但把 i64 整数
+序列化成十进制字符串，避免经过 JavaScript `number` 时丢精度。prettier 插件可以
+继续使用原 API，minifier 不直接消费当前的 `parse()`。
+
+## 目标
+
+- 正确性优先，并把检查拆成两个可判定的不变量：
+  - v0：`parse_lossless(print(parse_lossless(src)))` 与原 AST 结构相等（忽略 span）。
+  - 有变换时：打印结果重新 parse 后与 pass 产出的 canonical AST 结构相等；运行
+    等价由**全新 `Compiler` + GC VM** 的 `status/result/stdout` 判定。
+    interpreter 在重绑定闭包等场景与 compiler 已有不同语义，因此只作补充兼容
+    检查，不是优化的语义权威。
+- v0 做空白/注释剥离 + 冗余括号消除；v1 做标识符改名（mangle）；v2 做常量折叠
+  与死 `let` 消除（可选增量）。
+- 发布为 npm 包，API 小而稳定：`minify(source, options)`。
+- Playground 演示：新增 `Minify` 输出视图，实时展示压缩结果和字节数统计。
+
+## 非目标（暂时）
+
+- Source map（AST 里有 span，以后想做随时能做）。
+- 属性/方法名改名（`obj.prop` 保持原样——和 terser 默认关闭 `mangleProps`
+  同一个原因，不安全）。
+- 面向 gzip 的启发式优化。
+- 一切格式化相关的事——那是 `prettier-plugin-monkey` 的职责。
+
+## 包布局
+
+新包 `packages/monkey-minifier`（`packages/*` 通配自动进 workspace）。npm 包名用
+`@gengjiawen/monkey-minifier`——和 `@gengjiawen/monkey-wasm` 一样带 scope，避免
+抢注问题；构建/测试配置照抄 `prettier-plugin-monkey`（纯 `tsc` + vitest）。
+
+```
+packages/monkey-minifier/
+  package.json          # 依赖: @gengjiawen/monkey-wasm；build: tsc + ESM bundle
+  tsconfig.json
+  src/
+    index.ts            # 浏览器/bundler 入口
+    node.ts             # Node 入口，显式实例化 Wasm
+    core.ts             # minify() 共享管线、选项处理
+    cli.ts              # monkey-minify 命令行入口
+    types.ts            # AST 类型（复制而来，见下）
+    printer.ts          # 紧凑 printer（Phase 1）
+    scope.ts            # 作用域分析（Phase 3）
+    mangle.ts           # 标识符改名（Phase 3）
+    fold.ts             # 常量折叠 / 死代码消除（Phase 4）
+  test/
+    printer.test.ts
+    roundtrip.test.ts
+    differential.test.ts
+    mangle.test.ts
+```
+
+### Lossless AST 传输与类型
+
+PR 1 先在 parser/wasm 增加一个工具专用的 lossless AST serializer 和
+`parse_lossless()` 导出。这是 blocker，不是后续优化：Rust 节点的
+`Integer.raw` 是 i64，而现有 TS 镜像写成 `number`；例如
+`9007199254740993` 经 `JSON.parse` 会变成 `9007199254740992`，原 AST 和
+round-trip AST 两边一起失真时甚至会假通过。
+
+lossless JSON 只把 `Integer.raw` 投影为十进制字符串，其他节点形状保持不变；不
+修改现有 `parse()` 的返回格式，以免破坏 prettier/playground 消费方。minifier 的
+`src/types.ts` 相应使用：
+
+```ts
+interface IntegerLiteral extends ASTNode {
+  type: 'Integer'
+  raw: string
+}
+```
+
+printer 原样输出已验证的十进制串，数值 pass 用 `BigInt(raw)` 运算，任何时候都不
+把 Monkey 整数放进 JS `number`。测试必须包含 `2^53 + 1` 和 `i64::MAX`，并直接
+断言 lossless AST/输出，不能用两个已失真的 `number` 做比较。
+
+### AST 类型：先复制，不共享
+
+`src/types.ts` 起步时直接复制
+`packages/prettier-plugin-monkey/src/types.ts` 里的节点类型。从 prettier 插件
+import 会把它的 `prettier` peerDependency 拖进 minifier 的依赖图，方向也是反的。
+这些类型是 serde JSON 输出的手写镜像，变动频率很低，两份拷贝可以接受。
+
+如果以后开始难受，按顺序有两条退路：
+
+1. 抽一个 `packages/monkey-ast` 纯类型包，两边共同依赖。
+2. 用 `ts-rs` 从 Rust 的 AST 结构体直接生成 TS 类型，让 `parser/ast.rs` 成为
+   唯一事实来源。最符合本仓库 Rust-first 的架构，但 v0 不值得提前做。
+
+### 公共 API
+
+```ts
+interface MinifyOptions {
+  mangle?: boolean | { reserved?: string[] } // Phase 3 落地后默认 true
+  fold?: boolean // Phase 4 落地后默认 true
+}
+
+interface MinifyResult {
+  code: string
+}
+
+function minify(source: string, options?: MinifyOptions): MinifyResult // parse 失败抛 SyntaxError
+```
+
+字节数统计不进结果结构。调用方按 UTF-8 计算，不能用 UTF-16 code unit 数量的
+`source.length`：
+
+```ts
+const utf8Bytes = (text: string) => new TextEncoder().encode(text).byteLength
+```
+
+`@gengjiawen/monkey-wasm` 是 wasm-pack 的 bundler target，入口会静态 import
+`.wasm`；这适合 Vite/Next.js，但 Node 20 不能直接执行。npm 包因此用条件明确的双
+入口：`browser` 指向真正的 ESM bundle（不能把带异步 Wasm 初始化的依赖降成
+CommonJS `require`），Node 主入口加载生成的 `*_bg.js` glue，再通过
+`WebAssembly.Module`/`WebAssembly.Instance` 同步实例化同一份 Wasm。CLI 复用
+Node 入口，从而保持 `minify()` 同步 API；Node 最低版本是 20.19。
+
+## Phase 1 — 紧凑 printer（v0）
+
+v0 里唯一真正需要动脑的部分。三个设计点：
+
+**不抄 Rust 的 `Display` 实现。** 它是调试辅助，不是代码生成器：infix 全括号
+打印（`ast.rs:302`），`if` 条件打印时不带括号——而 parser 强制要求括号
+（`parser/lib.rs:397` 的 `expect_peek(LPAREN)`），也就是说 `Display` 的输出
+确定不能 re-parse。TS printer 从语法出发重写，round-trip 测试是正确性的唯一
+裁判。
+
+**按优先级决定括号。** 把 `parser/precedences.rs` 的表搬过来
+（`Lowest < Equals < LessGreater < Sum < Product < Prefix < Postfix`）。规则：
+
+- 子表达式优先级低于上下文优先级时才加括号。
+- 所有 infix 运算符都按左结合 parse：同优先级时只给右子树加括号
+  （`a - (b - c)`），左子树永远不加。对 `+`/`*` 也统一套用这条——正确且简单，
+  可证结合的场景跳过括号属于后期微优化。
+- 前缀运算符的操作数：低于 `Prefix` 才加括号（所以是 `-(a + b)`，但 `-a[0]`
+  不用加，index 是 `Postfix`）。
+
+AST 不记录冗余括号（parse 时作为 grouped expression 就消掉了），所以 v0 对
+括号多的源码天然就有压缩收益。
+
+**语句分隔与 token 粘连。** `Let`、`Return`、`SetProperty` 和表达式语句后补
+`;`；`Class` 后**不能**补分号，`class A {};` 会让 parser 把多出的 `;` 当成一条
+没有 prefix parser 的表达式并报错。相邻语句是否需要分隔由 statement printer
+显式处理。
+
+词法空格只在删掉后会把两个 token 合并时插入，例如 `let x`、`return x`、
+`new Foo`、`class Foo`。输出永远是 `fn(` 和 `}else{`，这里不需要空格。另用
+token-boundary fixture 固化 `a- -b`/`a--b`、关键字与标识符、相邻语句等情况；
+语句开头的 `{` 无歧义地是 hash 字面量（这个语法没有通用块语句）。
+
+**节点全覆盖。** 语句：`Let`、`Return`、`Class`、`SetProperty`、表达式语句。
+表达式：标识符、五种 `Literal`（`Integer`、`Boolean`、`String`、`Array`、
+`Hash`）、prefix、infix、`if`/`else`、`fn`、调用、index、`this`、属性访问、
+`new`。三个已从源码确认的输出形态：
+
+- `if` 条件必须带括号：`if(c){...}else{...}`。
+- 函数一律输出 `fn(params){...}`：`fn name()` 不能 parse（`parser/lib.rs:463`，
+  `fn` 后紧跟 `expect_peek(LPAREN)`）。AST 里的 `FunctionDeclaration.name`
+  是 `parse_let_statement` 从 let 绑定回填的递归元数据（`parser/lib.rs:121`，
+  compiler 在函数内部为它定义 `Function` symbol）；printer 不输出这个字段，
+  但变换后的 canonical AST 必须同步维护它。
+- 字符串字面量原样输出：lexer 的 `read_string`（`lexer/lib.rs:195`）没有任何
+  转义机制，读到下一个 `"` 为止——字符串内容不可能含 `"`，反斜杠是普通字符，
+  还可以跨行。printer 直接输出 `"` + 原文 + `"`，零处理。
+
+注释根本进不了 AST，剥离零成本。
+
+## Phase 2 — playground 演示
+
+沿用 `packages/playground/src/App.tsx` 现有的输出视图模式：
+
+- `OutputView`（`App.tsx:107`）加 `'minify'`，SegmentedControl 里在
+  AST / Bytecode / GC / Snapshot / ARM64 旁边加一个 **Minify** tab。
+- 新建 `src/MinifyView.tsx`，照 `Arm64View` 的样子：只读 CodeMirror `Editor`
+  展示压缩结果，加一条统计栏——原始字节数 → 压缩后字节数和节省百分比。状态
+  类型 `MinifyState = idle | ok | invalid`，对齐 `Arm64BuildState`；两端字节数都用
+  `TextEncoder` 算 UTF-8 bytes。
+- 视图激活时才计算，带 debounce，抄 `debouncedArm64Compile` 的 effect 写法
+  （`App.tsx:328`）。动态 import 和计算结果都携带递增 request id，并在提交状态
+  前确认它仍对应最新 source、当前视图仍激活；否则首次加载较慢时旧请求可能覆盖
+  新输入。
+- 通过动态 `import('../../monkey-minifier/src/index')` 引入——和 Format 按钮
+  引 prettier 插件的先例完全一致（`App.tsx:281`），所以 **demo 不依赖发 npm**。
+- Parse 错误时面板里展示错误信息，和其他视图一致。
+
+后续增量（不阻塞第一个 demo PR）：
+
+- Phase 3 落地后在工具栏加 mangle 开关 `Switch`，访客能实时看到改名效果。
+- "runs identically ✓" 徽章：在下面测试章节的 output-aware runner 落地后，分别
+  执行原始和压缩版并对比 `status/result/stdout`，把正确性主张变成看得见的演示；
+  不能只用当前不捕获输出的 `run_snapshot`。
+- 如果现有 snippet 演示效果不够好，加一个专门的 `Minify` snippet
+  （闭包 + class 的组合最能展示）。
+
+测试放 `src/test/MinifyView.test.tsx`，沿用现有视图测试的写法。
+
+## Phase 3 — 标识符 mangle（v1）
+
+实际压缩收益的大头，但只改名能解析到明确 binding identity 的标识符。以下名字
+保持不动，生成名也不能与它们碰撞：
+
+- builtin：完整列表是 `len`、`puts`、`first`、`last`、`rest`、`push`、`print`
+  （`object/builtins.rs`）。builtin 引用不改名；用户 `let` 可以 shadow builtin，
+  该用户 binding 则是另一个 identity，可以改名。
+- 属性名和方法名：`PropertyExpression.property`、
+  `SetPropertyStatement.property`、`MethodDefinition.name`。Hash key 是普通表达式，
+  也绝不能被当作属性名统一改写。
+- class declaration 的 binding 及解析到它的引用。虽然 class 名参与普通词法解析，
+  GC VM 会在 class、instance、bound method 的最终值和 `puts` 输出中显示它；直接
+  把 `class LongName` 改成 `class a` 会改变可观察结果。同名的后续 `let` 重绑定是
+  独立 identity，不受此限制。
+- `this`、用户传入的 `options.mangle.reserved`，以及所有未解析/外部标识符。遇到
+  analyzer 无法精确建模的节点时 fail closed，不对相关 scope 改名。
+
+`scope.ts` 不是只收集字符串的传统 hoist scope，而是按
+`Compiler::compile_stmt` 的遍历顺序构建 binding/reference graph。语义权威是每次
+都从干净状态创建的 standalone compiler；不能用 interpreter environment 反推，
+因为例如重绑定后闭包读取的值，两套引擎目前并不一致。需要逐条镜像这些规则：
+
+1. 只有 program、函数字面量和每个 method body 创建 symbol scope；`if`/`else`
+   block 不创建 scope，class declaration 自身也不创建额外 scope。
+2. 普通 `let` 先解析/编译 RHS，再定义一个新 slot。同名 `let` 是新的 binding，
+   只遮蔽它之后的引用；更早创建的闭包继续捕获旧 binding。分析器可先创建一个
+   pending identity，但在 RHS 结束前不能把它放进普通可见名字表。
+3. 直接形如 `let f=fn(...){...}` 的 RHS 是特例：parser 回填的
+   `FunctionDeclaration.name` 会在函数内部先定义递归 self symbol；它与 pending
+   `f` 绑定关联，但不让 `f` 在 RHS 的其他位置提前可见。进入函数后先定义这个
+   self symbol，再按参数列表顺序定义参数；重复参数或与 self 同名的参数以最后
+   定义的 slot 为引用目标。
+4. class binding 在编译 methods **之前**定义，因此方法可引用本 class。method
+   scope 先有隐式 `this`，再按顺序定义参数；嵌套函数按正常闭包规则捕获 `this`。
+5. compiler 依次编译 `if` 的 condition、consequent、alternate，两个 branch 共用
+   当前 symbol table；即使运行时只走一个 branch，其中的 `let` 也会按这个编译
+   顺序影响另一个 branch 和后续引用。分析器必须复现这个行为，不能分别 clone
+   两份词法环境再 merge。
+6. builtin 是初始 symbol，用户声明可按上述源码顺序 shadow；找不到 binding 的
+   identifier 保持原拼写，并加入生成名禁用集合，防止意外 capture。
+
+`mangle.ts` 按 graph 中的 identity 改 declaration 和所有已绑定 reference，而非
+按字符串全局替换。第一版优先保证可靠：按引用频率给可改 binding 分配全程序唯一
+的短名（`a`–`z`，再到 `a0`…），并跳过关键字、builtin、reserved、class 名、未
+解析名和所有保留原名的 binding。以后再基于 interference/liveness 证明安全地在
+不相交 scope 复用短名。
+
+改直接绑定函数字面量的 `let` 时，还要同步其 `FunctionDeclaration.name` 元数据；
+printer 仍只输出 `fn(`，重新 parse 会根据新 let 名回填同样的 metadata。fixture
+至少覆盖连续重绑定、RHS 读取旧 binding、自递归、重复参数、builtin shadow、
+闭包捕获、两个 if branch、隐式 `this`、class 自引用和未解析 identifier。
+
+## Phase 4 — 压缩 pass（v2，可选）
+
+每个都是自包含的 AST→AST pass，但集成顺序固定为：常量折叠 → 重建 binding/effect
+分析 → 死 `let` 消除到不动点 → 再分析 → mangle → printer。不能宣称任意顺序；
+折叠会暴露死绑定，删除又会改变引用频率和后续 slot 编号。任一分析不确定时保留
+原节点。
+
+### 常量折叠
+
+整数算术、字符串拼接、布尔/比较运算、前缀运算严格镜像 production GC VM，而
+不是 interpreter。整数从 lossless `raw` 用 `BigInt` 计算：
+
+- 加、减、乘和负号按 i64 two's-complement 回绕，用
+  `BigInt.asIntN(64, value)`。启用此 pass 前先把 GC VM 对应操作改成显式
+  `wrapping_add/sub/mul/neg`，消除 Rust debug/release overflow 行为差异。
+- 除法用 BigInt 的向零截断；除数为 0、以及 `i64::MIN / -1` 都保留原表达式，让
+  VM 产生原来的 runtime error。
+- AST 没有负整数字面量。负结果必须构造成 `UnaryExpression(-, Integer(abs))`；
+  `i64::MIN` 的绝对值超出 lexer 可接受的正 i64，无法这样打印，因此放弃该次
+  折叠，绝不生成非法 literal。
+- 只有操作数类型和 VM 结果都能证明时才折叠；字符串只折叠 `+`，比较/`!` 也只
+  覆盖 GC VM 已定义的常量类型组合。每个溢出边界和错误路径都写 differential
+  fixture。
+
+`if` 是 expression，而它的 branch 是任意 `BlockStatement`，语言又没有可打印的
+`null` literal，所以不能通用地拿选中 block 替换整个 `if`。v2 只折叠可表示子集：
+
+- condition 已被证明为无副作用的常量；
+- 被选 branch 恰好只有一个表达式语句，可直接替换为该 expression；
+- consequent 和 alternate 都不含会修改当前 compiler symbol table 的声明，否则
+  删除未执行 branch 仍可能改变另一个 branch 或后续引用的 binding；
+- constant false 且没有 `else` 时保留原 `if`，因为 AST 中没有 Null literal。
+
+例如 `let x=if(true){let y=1;y};` 不能折叠成一个 block，必须保留。
+
+还有一个 parser 元数据边界：`let f=fn(){...}` 会给函数体注入递归 self binding，
+而 `let f=if(true){fn(){...}}` 里的嵌套函数是匿名的。即使 condition 是常量，也
+不能把后者折叠成直接 RHS 函数字面量，否则打印后重新 parse 会改变闭包捕获。
+
+### 死 `let` 消除（去掉无用变量）
+
+一个 binding identity 零引用，并且 initializer 被证明为“无副作用且 total/no
+throw”时，才删除整条 `let`。仅检查 `FunctionCall`/`New` 不够：属性/index 读取、
+类型不匹配的运算和除零同样会报 runtime error；删除它们会把错误程序变成成功
+程序。
+
+实现一个保守的 effect summary（至少区分 `hasEffects` 与 `mayThrow`），初版采用
+白名单证明安全，而不是列一份黑名单猜纯度：
+
+- integer/boolean/string literal 是 total；array/hash 只有在所有子表达式 total、
+  且 hash key 已证明可 hash 时才是 total。
+- prefix/infix 只有在静态已知的 operand 类型受 GC VM 支持、且整数除法排除两个
+  错误条件时才是 total。
+- `FunctionCall`、`New` 一律不可删；`PropertyExpression` 和 `IndexExpression`
+  默认 `mayThrow`，即使没有 getter 也不能当作安全读取。未知 identifier/节点也
+  默认不可删。
+- 函数字面量的**创建**不执行 body，所以 runtime effect 分析把 body 当叶子；但
+  body 中若有未解析名字或其他 compiler/analyzer diagnostic，必须给 initializer
+  加不可变换标记，不能借删除改变 compile status。
+
+典型边界：
+
+```
+let unusedHelper = fn(x) { puts(x) };   // 可删：定义时什么都不执行
+let x = compute();                       // 不可删：初始化有调用，可能有副作用
+let y = 42;                              // 可删：纯字面量，零引用
+let z = 1 / 0;                           // 不可删：会报错
+let p = 1.missing;                       // 不可删：属性读取会报错
+```
+
+删除会级联：删掉一条 `let` 可能让另一条失去唯一引用者，所以每轮基于 binding
+identity 重新分析并迭代到不动点。DCE 在 mangle **之前**运行，让最终引用频率和
+命名建立在实际保留的程序上。
+
+`let` 还有两个 compiler/VM 特有的保守边界：
+
+- function/method 或 `if` branch 的末尾 `let` 是隐式返回值的 barrier；删除它会
+  暴露前一条表达式，所以必须保留。
+- VM 进入 callable 时会一次性预留全部 local slots。若其中有空 `if` arm 或以
+  `let` 结尾、因而可能不产生栈值的 arm，现有 bytecode 会让后续 pop/赋值读到
+  预留 slot；此时改变任意 local 数量都可能改变现有运行结果。这样的 callable
+  整体禁用 local DCE，并让嵌套 callable 各自独立判断。
+
+## 测试策略
+
+语料先行：`App.tsx` 里的 playground snippets、`examples/*.monkey`、以及从
+parser/compiler 各 `*_test.rs` 里提取的程序。interpreter 用例只有在 standalone
+compiler 也接受时才进入语义语料；两者结果冲突时以 compiler + GC VM 为准。统一
+收进 `test/corpus/`，下面所有套件共用。
+
+1. **Lossless contract**：单独测试 `parse_lossless()` 的 `Integer.raw` 是十进制
+   string，覆盖 `9007199254740993`、`i64::MAX`、嵌套 array/hash 中的整数；禁止
+   通过 JS `number` 中转。
+2. **Round-trip**（printer 主力）：定义一个只删除 `span`/comment 附属字段的
+   canonicalizer。v0 比较 `canonical(parse_lossless(print(ast)))` 与原 AST；有
+   pass 时比较 reparsed AST 与 pass 返回的 canonical transformed AST。不能只比
+   运行结果，因为两棵同样被错误打印的程序可能碰巧返回同一个值。
+3. **Differential 执行**：原始版和压缩版分别用全新的 `Compiler` 编译，再交给
+   GC VM 执行。当前 `run_snapshot` 只有 `{status,result}`，`puts`/`print` 最终走
+   `println!`，所以它不是完整 oracle；PR 1 就补齐下面的测试载具，而不是等 DCE：
+   - 给 GC VM 的 builtin 执行路径注入 output sink，避免换成语义不同的
+     interpreter，也避免共享的 thread-local 缓冲；
+   - 新增 `run_snapshot_with_output`（或等价内部 helper），成功和失败 envelope 都
+     返回已产生的 `stdout`，从而保留“输出后报错”的可观察顺序；
+   - 为 compile/runtime error 暴露稳定的 structured `kind`。成功时比较
+     `status + result + stdout`；失败时比较 `status + stage + kind + stdout`。
+     diagnostic message、变量名和 span 不纳入等价定义，因为 mangle/printer 会
+     合法地改变内部名字与源码位置。
+     differential corpus 使用确定终止、不会贴近 instruction budget 的程序；执行
+     上限测试独立进行，不把优化后少执行几条指令当作语言语义差异。
+4. **幂等性**：`minify(minify(src)).code === minify(src).code`，分别覆盖每组
+   options。
+5. **Mangle 安全性**（Phase 3 起）：连续重绑定、RHS 旧值、自递归、重复参数、
+   闭包捕获、builtin shadow、if 两分支污染、`this`、未解析名、class/属性各写
+   fixture，全部过 structural + differential 套件；另断言 class/instance 的
+   可见名称没有变化。
+6. **Fold/DCE 安全性**（Phase 4 起）：覆盖 i64 边界、除零、
+   `i64::MIN / -1`、不可表示的 if，以及“无调用但会报错”的 initializer（错误
+   operand 类型、property/index）。每次删除前后都跑 output-aware differential。
+
+全语料的压缩率在测试输出里打印成报告，不做断言，这样改进 printer 永远不会
+"挂"在一个过期数字上。
+
+## CI、发布、文档接线
+
+- CI：`.github/workflows/rust.yml` 已有 playground 测试；给 scoped 包加 build、
+  Vitest、Node 发布入口和 Vite browser 入口冒烟，并在声明的最低 Node 20.19 上
+  运行。playground 的测试步骤顺带覆盖 `MinifyView`。
+- 版本：按 `AGENTS.md`，功能 PR 不带版本号变更。留给维护者的后续接线：
+  `scripts/bump_cargo_packages.ts` 加上新包；要发 npm 时补 release-please /
+  publish 配置。playground demo 不依赖发布。
+- 文档：更新 `AGENTS.md` 的项目结构一节（它连 vscode extension 都还没写进去），
+  新包加 README。
+
+## 里程碑 / PR 切分
+
+| PR  | 内容                                                                  | 预估     |
+| --- | --------------------------------------------------------------------- | -------- |
+| 1   | lossless AST 导出 + 脚手架 + printer + structural/output differential | 2 天     |
+| 2   | Playground `Minify` 视图 + UTF-8 字节统计 + stale request guard       | 0.5–1 天 |
+| 3   | compiler-order binding 分析 + mangler（+ playground 开关）            | 2–3 天   |
+| 4   | 明确 i64 VM 语义 + 常量/受限 `if` 折叠 + 保守死 `let` 消除            | 2–3 天   |
+| 5   | CLI `bin` + 发布接线 + 文档                                           | 0.5 天   |
+
+PR 1+2 合起来交付可见的 demo；之后全是增量。

--- a/docs/minifier-plan.md
+++ b/docs/minifier-plan.md
@@ -7,7 +7,7 @@ workspace 新包，并在 playground 里提供在线演示视图。
 
 ```
 源码 ──wasm parse_lossless──▶ JSON AST ──(变换 pass)──▶ AST ──紧凑 printer──▶ 压缩后源码
-                                         mangle / 常量折叠 / 死代码消除
+                                         mangle / 常量折叠 / 常量传播 / 死代码消除
 ```
 
 Parser 不重新实现。minifier 消费 `@gengjiawen/monkey-wasm` 新增的
@@ -23,8 +23,8 @@ Parser 不重新实现。minifier 消费 `@gengjiawen/monkey-wasm` 新增的
     等价由**全新 `Compiler` + GC VM** 的 `status/result/stdout` 判定。
     interpreter 在重绑定闭包等场景与 compiler 已有不同语义，因此只作补充兼容
     检查，不是优化的语义权威。
-- v0 做空白/注释剥离 + 冗余括号消除；v1 做标识符改名（mangle）；v2 做常量折叠
-  与死 `let` 消除（可选增量）。
+- v0 做空白/注释剥离 + 冗余括号消除；v1 做标识符改名（mangle）；v2 做常量
+  折叠、常量传播与死 `let` 消除（可选增量）。
 - 发布为 npm 包，API 小而稳定：`minify(source, options)`。
 - Playground 演示：新增 `Minify` 输出视图，实时展示压缩结果和字节数统计。
 
@@ -56,6 +56,7 @@ packages/monkey-minifier/
     scope.ts            # 作用域分析（Phase 3）
     mangle.ts           # 标识符改名（Phase 3）
     fold.ts             # 常量折叠 / 死代码消除（Phase 4）
+    propagate.ts        # 常量传播（Phase 4）
   test/
     printer.test.ts
     roundtrip.test.ts
@@ -262,10 +263,11 @@ printer 仍只输出 `fn(`，重新 parse 会根据新 let 名回填同样的 me
 
 ## Phase 4 — 压缩 pass（v2，可选）
 
-每个都是自包含的 AST→AST pass，但集成顺序固定为：常量折叠 → 重建 binding/effect
-分析 → 死 `let` 消除到不动点 → 再分析 → mangle → printer。不能宣称任意顺序；
-折叠会暴露死绑定，删除又会改变引用频率和后续 slot 编号。任一分析不确定时保留
-原节点。
+每个都是自包含的 AST→AST pass，但集成顺序固定为：常量折叠与常量传播交替到
+不动点 → 重建 binding/effect 分析 → 死 `let` 消除到不动点 → 再分析 →
+mangle → printer。不能宣称任意顺序；折叠为传播制造 literal 初始化式，传播为
+折叠解锁卡在 identifier 上的表达式，两者共同暴露死绑定，删除又会改变引用
+频率和后续 slot 编号。任一分析不确定时保留原节点。
 
 ### 常量折叠
 
@@ -298,6 +300,44 @@ printer 仍只输出 `fn(`，重新 parse 会根据新 let 名回填同样的 me
 还有一个 parser 元数据边界：`let f=fn(){...}` 会给函数体注入递归 self binding，
 而 `let f=if(true){fn(){...}}` 里的嵌套函数是匿名的。即使 condition 是常量，也
 不能把后者折叠成直接 RHS 函数字面量，否则打印后重新 parse 会改变闭包捕获。
+
+### 常量传播
+
+折叠只处理“表达式内部全是常量”的情况；`let a=1+1; let b=a+1; print(a)` 里
+`b` 的 RHS 和 `print` 的实参都卡在 identifier 上，折叠自身永远打不开。传播
+pass 把“初始化式在折叠后已是 literal”的 binding 的每处引用替换成该 literal
+的深拷贝（后续 pass 原地改写节点，多处共享同一节点会被重复改写），从而让
+上面的程序最终压成 `print(2);`，对齐 terser 在等价 JavaScript 上的输出。
+传播自己不删语句：引用清零的 binding 交给死 `let` 消除按它的规则处理。
+
+安全论证建立在 compiler 的 slot 语义上：每条 `let` 都分配新 slot（重绑定
+不是赋值），slot 恰好写入一次，因此解析到某 binding 的引用读到的值恒等于
+该 binding 初始化式的值——闭包也一样，`let v=1; let g=fn(){v}; let v=2;`
+中 `g()` 返回 1，已用探针在真实 GC VM 上验证。唯一反例是 `if` arm 里的
+`let`：两个 branch 共用符号表（Phase 3 规则 5），`let` 之后的引用会解析到
+它，但 arm 未执行时 slot 从未写入，引用处读到 null——
+`let v=1; if(1>2){let v=2;}; puts(v);` 输出 `null`。scope 分析给这类
+binding 打 `conditional` 标记，传播一律跳过；函数/方法体是新的执行边界，
+body 顶层 `let` 每次调用都执行，标记在 callable 边界重置。
+
+其余护栏：
+
+- 只传播四种折叠后形态：integer/boolean/string literal 与
+  `UnaryExpression(-, Integer)`。array/hash 字面量每次求值分配新值，复制到
+  多个位置会改变别名关系，直接排除。
+- `new` 的 callee 语法上必须是 identifier，不可替换；该引用保留后 binding
+  自然存活。
+- 体积护栏：保留 binding 的成本是 `let x=<lit>;` 的 7 个固定字符加每处引用
+  1 字符（mangle 后），内联成本是每处 `width` 字符；
+  `refs × (width−1) > 7 + width` 时放弃，例如 `"hello"` 引用三次就保留
+  绑定。
+
+传播与折叠互相解锁——传播把 literal 塞进卡在 identifier 上的表达式，折叠
+再把它算成新的 literal 初始化式——所以两者交替运行到不动点，之后才进入死
+`let` 消除。终止性：每轮成功传播至少替换掉一个 identifier 节点，而两个
+pass 都不会新建 identifier，identifier 总数严格递减、有下界。三个危险案例
+（conditional `let`、重绑定 + 闭包捕获、`new` callee）各有 differential
+fixture 钉住。
 
 ### 死 `let` 消除（去掉无用变量）
 
@@ -376,9 +416,11 @@ compiler 也接受时才进入语义语料；两者结果冲突时以 compiler +
    闭包捕获、builtin shadow、if 两分支污染、`this`、未解析名、class/属性各写
    fixture，全部过 structural + differential 套件；另断言 class/instance 的
    可见名称没有变化。
-6. **Fold/DCE 安全性**（Phase 4 起）：覆盖 i64 边界、除零、
-   `i64::MIN / -1`、不可表示的 if，以及“无调用但会报错”的 initializer（错误
-   operand 类型、property/index）。每次删除前后都跑 output-aware differential。
+6. **Fold/Propagate/DCE 安全性**（Phase 4 起）：覆盖 i64 边界、除零、
+   `i64::MIN / -1`、不可表示的 if、传播的三个危险案例（conditional `let`、
+   重绑定 + 闭包捕获、`new` callee），以及“无调用但会报错”的 initializer
+   （错误 operand 类型、property/index）。每次删除前后都跑 output-aware
+   differential。
 
 全语料的压缩率在测试输出里打印成报告，不做断言，这样改进 printer 永远不会
 "挂"在一个过期数字上。
@@ -401,7 +443,7 @@ compiler 也接受时才进入语义语料；两者结果冲突时以 compiler +
 | 1   | lossless AST 导出 + 脚手架 + printer + structural/output differential | 2 天     |
 | 2   | Playground `Minify` 视图 + UTF-8 字节统计 + stale request guard       | 0.5–1 天 |
 | 3   | compiler-order binding 分析 + mangler（+ playground 开关）            | 2–3 天   |
-| 4   | 明确 i64 VM 语义 + 常量/受限 `if` 折叠 + 保守死 `let` 消除            | 2–3 天   |
+| 4   | 明确 i64 VM 语义 + 常量/受限 `if` 折叠 + 常量传播 + 保守死 `let` 消除 | 2–3 天   |
 | 5   | CLI `bin` + 发布接线 + 文档                                           | 0.5 天   |
 
 PR 1+2 合起来交付可见的 demo；之后全是增量。

--- a/docs/minifier-plan.md
+++ b/docs/minifier-plan.md
@@ -122,11 +122,11 @@ const utf8Bytes = (text: string) => new TextEncoder().encode(text).byteLength
 ```
 
 `@gengjiawen/monkey-wasm` 是 wasm-pack 的 bundler target，入口会静态 import
-`.wasm`；这适合 Vite/Next.js，但 Node 20 不能直接执行。npm 包因此用条件明确的双
+`.wasm`；这适合 Vite/Next.js，但 Node 不能直接执行。npm 包因此用条件明确的双
 入口：`browser` 指向真正的 ESM bundle（不能把带异步 Wasm 初始化的依赖降成
 CommonJS `require`），Node 主入口加载生成的 `*_bg.js` glue，再通过
 `WebAssembly.Module`/`WebAssembly.Instance` 同步实例化同一份 Wasm。CLI 复用
-Node 入口，从而保持 `minify()` 同步 API；Node 最低版本是 20.19。
+Node 入口，从而保持 `minify()` 同步 API；Node 最低版本是 24。
 
 ## Phase 1 — 紧凑 printer（v0）
 
@@ -386,7 +386,7 @@ compiler 也接受时才进入语义语料；两者结果冲突时以 compiler +
 ## CI、发布、文档接线
 
 - CI：`.github/workflows/rust.yml` 已有 playground 测试；给 scoped 包加 build、
-  Vitest、Node 发布入口和 Vite browser 入口冒烟，并在声明的最低 Node 20.19 上
+  Vitest、Node 发布入口和 Vite browser 入口冒烟，并在声明的最低 Node 24 上
   运行。playground 的测试步骤顺带覆盖 `MinifyView`。
 - 版本：按 `AGENTS.md`，功能 PR 不带版本号变更。留给维护者的后续接线：
   `scripts/bump_cargo_packages.ts` 加上新包；要发 npm 时补 release-please /

--- a/packages/monkey-minifier/README.md
+++ b/packages/monkey-minifier/README.md
@@ -1,0 +1,30 @@
+# `@gengjiawen/monkey-minifier`
+
+A source-to-source minifier for the Monkey language in this repository. It uses
+the Rust/Wasm parser, preserves the full signed 64-bit integer range, and emits
+compact Monkey source.
+
+```ts
+import { minify } from '@gengjiawen/monkey-minifier'
+
+const { code } = minify('let longName = 40 + 2; longName;')
+// let a=42;a;
+```
+
+`mangle` and `fold` default to `true`. Disable either pass when only compact
+printing is wanted:
+
+```ts
+minify(source, { mangle: false, fold: false })
+```
+
+Browser bundlers use the package's browser entry. The Node API and CLI require
+Node 20.19 or newer and load the same Wasm parser through Node's WebAssembly
+API.
+
+The CLI reads files or stdin:
+
+```sh
+monkey-minify input.monkey
+monkey-minify --no-mangle < input.monkey
+```

--- a/packages/monkey-minifier/README.md
+++ b/packages/monkey-minifier/README.md
@@ -19,7 +19,7 @@ minify(source, { mangle: false, fold: false })
 ```
 
 Browser bundlers use the package's browser entry. The Node API and CLI require
-Node 20.19 or newer and load the same Wasm parser through Node's WebAssembly
+Node 24 or newer and load the same Wasm parser through Node's WebAssembly
 API.
 
 The CLI reads files or stdin:

--- a/packages/monkey-minifier/README.md
+++ b/packages/monkey-minifier/README.md
@@ -8,7 +8,7 @@ compact Monkey source.
 import { minify } from '@gengjiawen/monkey-minifier'
 
 const { code } = minify('let longName = 40 + 2; longName;')
-// let a=42;a;
+// 42;
 ```
 
 `mangle` and `fold` default to `true`. Disable either pass when only compact

--- a/packages/monkey-minifier/package.json
+++ b/packages/monkey-minifier/package.json
@@ -24,7 +24,7 @@
   "author": "gengjiawen <technicalcute@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20.19"
+    "node": ">=24"
   },
   "repository": {
     "type": "git",

--- a/packages/monkey-minifier/package.json
+++ b/packages/monkey-minifier/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/gengjiawen/monkey-rust"
   },
   "dependencies": {
-    "@gengjiawen/monkey-wasm": "^1.1.0"
+    "@gengjiawen/monkey-wasm": "workspace:^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/monkey-minifier/package.json
+++ b/packages/monkey-minifier/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@gengjiawen/monkey-minifier",
+  "version": "1.1.0",
+  "description": "A semantics-preserving source-to-source minifier for Monkey",
+  "main": "dist/node.js",
+  "browser": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "monkey-minify": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc && esbuild src/index.ts --bundle --format=esm --platform=browser --target=es2020 --external:@gengjiawen/monkey-wasm --outfile=dist/index.mjs",
+    "test": "vitest run",
+    "test:browser": "node test/browser-smoke.mjs",
+    "test:node": "node test/node-smoke.cjs",
+    "dev": "tsc --watch",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "monkey",
+    "minifier",
+    "optimizer"
+  ],
+  "author": "gengjiawen <technicalcute@gmail.com>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.19"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gengjiawen/monkey-rust"
+  },
+  "dependencies": {
+    "@gengjiawen/monkey-wasm": "^1.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.28.0",
+    "typescript": "^5.0.0",
+    "vite": "^8.1.4",
+    "vite-plugin-wasm": "^3.6.0",
+    "vitest": "^4.1.10"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}

--- a/packages/monkey-minifier/src/cli.ts
+++ b/packages/monkey-minifier/src/cli.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+
+import { minify, type MinifyOptions } from './node'
+
+function main(argv: string[]): void {
+  const options: MinifyOptions = {}
+  const files: string[] = []
+  for (const argument of argv) {
+    switch (argument) {
+      case '--no-mangle':
+        options.mangle = false
+        break
+      case '--no-fold':
+        options.fold = false
+        break
+      case '-h':
+      case '--help':
+        process.stdout.write(
+          'Usage: monkey-minify [--no-mangle] [--no-fold] [file ...]\n' +
+            'With no files, source is read from stdin.\n'
+        )
+        return
+      default:
+        if (argument.startsWith('-')) {
+          throw new Error(`unknown option: ${argument}`)
+        }
+        files.push(argument)
+    }
+  }
+  const source = files.length
+    ? files.map((file) => readFileSync(file, 'utf8')).join('\n')
+    : readFileSync(0, 'utf8')
+  process.stdout.write(`${minify(source, options).code}\n`)
+}
+
+try {
+  main(process.argv.slice(2))
+} catch (error) {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`
+  )
+  process.exitCode = 1
+}

--- a/packages/monkey-minifier/src/core.ts
+++ b/packages/monkey-minifier/src/core.ts
@@ -1,0 +1,50 @@
+import { eliminateDeadLets, foldConstants } from './fold'
+import { mangle, type MangleOptions } from './mangle'
+import { printProgram } from './printer'
+import type { Program } from './types'
+
+export interface MinifyOptions {
+  mangle?: boolean | MangleOptions
+  fold?: boolean
+}
+
+export interface MinifyResult {
+  code: string
+}
+
+export type ParseLossless = (source: string) => string
+
+export function minifyWithParser(
+  parseLossless: ParseLossless,
+  source: string,
+  options: MinifyOptions = {}
+): MinifyResult {
+  const program = parseProgramWithParser(parseLossless, source)
+  if (options.fold !== false) {
+    foldConstants(program)
+    eliminateDeadLets(program)
+  }
+  if (options.mangle !== false) {
+    mangle(program, typeof options.mangle === 'object' ? options.mangle : {})
+  }
+  return { code: printProgram(program) }
+}
+
+export function parseProgramWithParser(
+  parseLossless: ParseLossless,
+  source: string
+): Program {
+  try {
+    const json = parseLossless(source)
+    const root = JSON.parse(json) as { Program?: Program } | Program
+    const program =
+      'Program' in root && root.Program ? root.Program : (root as Program)
+    if (program.type !== 'Program' || !Array.isArray(program.body)) {
+      throw new Error('parser returned an invalid Program')
+    }
+    return program
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new SyntaxError(`Monkey parse error: ${message}`)
+  }
+}

--- a/packages/monkey-minifier/src/core.ts
+++ b/packages/monkey-minifier/src/core.ts
@@ -1,6 +1,7 @@
 import { eliminateDeadLets, foldConstants } from './fold'
 import { mangle, type MangleOptions } from './mangle'
 import { printProgram } from './printer'
+import { propagateConstants } from './propagate'
 import type { Program } from './types'
 
 export interface MinifyOptions {
@@ -21,7 +22,12 @@ export function minifyWithParser(
 ): MinifyResult {
   const program = parseProgramWithParser(parseLossless, source)
   if (options.fold !== false) {
+    // Each propagation replaces at least one identifier with a literal and
+    // never introduces new identifiers, so the loop terminates.
     foldConstants(program)
+    while (propagateConstants(program)) {
+      foldConstants(program)
+    }
     eliminateDeadLets(program)
   }
   if (options.mangle !== false) {

--- a/packages/monkey-minifier/src/fold.ts
+++ b/packages/monkey-minifier/src/fold.ts
@@ -1,0 +1,718 @@
+import type {
+  ASTNode,
+  BlockStatement,
+  Expression,
+  FunctionDeclaration,
+  HashLiteral,
+  Program,
+  Statement,
+} from './types'
+import { tokenType } from './types'
+import { analyzeScopes, type ScopeAnalysis } from './scope'
+
+const ZERO = BigInt(0)
+const NEGATIVE_ONE = BigInt(-1)
+const I64_MIN = -(BigInt(1) << BigInt(63))
+
+type ConstantValue =
+  | { kind: 'integer'; value: bigint }
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'string'; value: string }
+
+export function foldConstants(program: Program): Program {
+  const analysis = analyzeScopes(program)
+  if (!analysis.safe) {
+    return program
+  }
+  foldStatements(program.body, analysis)
+  return program
+}
+
+export function eliminateDeadLets(program: Program): Program {
+  for (;;) {
+    const analysis = analyzeScopes(program)
+    if (!analysis.safe) {
+      return program
+    }
+    const removed = removeDeadStatements(program.body, analysis, false, true)
+    if (!removed) {
+      return program
+    }
+  }
+}
+
+function foldStatements(
+  statements: Statement[],
+  analysis: ScopeAnalysis
+): void {
+  for (let index = 0; index < statements.length; index += 1) {
+    const statement = statements[index]
+    switch (statement.type) {
+      case 'Let':
+        statement.expr = foldLetExpression(statement.expr, analysis)
+        break
+      case 'ReturnStatement':
+        statement.argument = foldExpression(statement.argument, analysis)
+        break
+      case 'ClassDeclaration':
+        for (const method of statement.methods) {
+          foldStatements(method.body.body, analysis)
+        }
+        break
+      case 'SetPropertyStatement':
+        statement.object = foldExpression(statement.object, analysis)
+        statement.value = foldExpression(statement.value, analysis)
+        break
+      default:
+        statements[index] = foldExpression(statement, analysis)
+    }
+  }
+}
+
+function foldLetExpression(
+  expression: Expression,
+  analysis: ScopeAnalysis
+): Expression {
+  const folded = foldExpression(expression, analysis)
+  // The parser names a function only when it is the direct RHS of a `let`,
+  // giving its body a recursive self binding. Folding an `if` (or a future
+  // wrapper expression) into an anonymous function at this position would
+  // therefore change captured-name resolution after printing and reparsing.
+  return expression.type !== 'FunctionDeclaration' &&
+    folded.type === 'FunctionDeclaration'
+    ? expression
+    : folded
+}
+
+function foldBlock(block: BlockStatement, analysis: ScopeAnalysis): void {
+  foldStatements(block.body, analysis)
+}
+
+function foldExpression(
+  expression: Expression,
+  analysis: ScopeAnalysis
+): Expression {
+  switch (expression.type) {
+    case 'IDENTIFIER':
+    case 'Integer':
+    case 'Boolean':
+    case 'String':
+    case 'ThisExpression':
+      return expression
+    case 'Array':
+      expression.elements = expression.elements.map((element) =>
+        foldExpression(element, analysis)
+      )
+      return expression
+    case 'Hash':
+      expression.elements = expression.elements.map(([key, value]) => [
+        foldExpression(key, analysis),
+        foldExpression(value, analysis),
+      ])
+      return expression
+    case 'UnaryExpression':
+      expression.operand = foldExpression(expression.operand, analysis)
+      return constantToExpression(evaluateConstant(expression)) ?? expression
+    case 'BinaryExpression':
+      expression.left = foldExpression(expression.left, analysis)
+      expression.right = foldExpression(expression.right, analysis)
+      return constantToExpression(evaluateConstant(expression)) ?? expression
+    case 'IF': {
+      const hasDiagnostic = containsDiagnostic(expression, analysis)
+      expression.condition = foldExpression(expression.condition, analysis)
+      foldBlock(expression.consequent, analysis)
+      if (expression.alternate) {
+        foldBlock(expression.alternate, analysis)
+      }
+      const condition = evaluateConstant(expression.condition)
+      if (
+        hasDiagnostic ||
+        !condition ||
+        branchesChangeScope(expression.consequent, expression.alternate)
+      ) {
+        return expression
+      }
+      const chosen = isTruthy(condition)
+        ? expression.consequent
+        : expression.alternate
+      if (
+        !chosen ||
+        chosen.body.length !== 1 ||
+        !isExpression(chosen.body[0])
+      ) {
+        return expression
+      }
+      return chosen.body[0]
+    }
+    case 'FunctionDeclaration':
+      foldBlock(expression.body, analysis)
+      return expression
+    case 'FunctionCall':
+      expression.callee = foldExpression(expression.callee, analysis)
+      expression.arguments = expression.arguments.map((argument) =>
+        foldExpression(argument, analysis)
+      )
+      return expression
+    case 'Index':
+      expression.object = foldExpression(expression.object, analysis)
+      expression.index = foldExpression(expression.index, analysis)
+      return expression
+    case 'PropertyExpression':
+      expression.object = foldExpression(expression.object, analysis)
+      return expression
+    case 'NewExpression':
+      expression.arguments = expression.arguments.map((argument) =>
+        foldExpression(argument, analysis)
+      )
+      return expression
+  }
+}
+
+function evaluateConstant(expression: Expression): ConstantValue | null {
+  switch (expression.type) {
+    case 'Integer':
+      return { kind: 'integer', value: BigInt(expression.raw) }
+    case 'Boolean':
+      return { kind: 'boolean', value: expression.raw }
+    case 'String':
+      return { kind: 'string', value: expression.raw }
+    case 'UnaryExpression': {
+      const operand = evaluateConstant(expression.operand)
+      if (!operand) {
+        return null
+      }
+      switch (tokenType(expression.op)) {
+        case 'MINUS':
+          return operand.kind === 'integer'
+            ? { kind: 'integer', value: BigInt.asIntN(64, -operand.value) }
+            : null
+        case 'BANG':
+          return {
+            kind: 'boolean',
+            value: operand.kind === 'boolean' ? !operand.value : false,
+          }
+        default:
+          return null
+      }
+    }
+    case 'BinaryExpression': {
+      const left = evaluateConstant(expression.left)
+      const right = evaluateConstant(expression.right)
+      return left && right
+        ? evaluateBinary(tokenType(expression.op), left, right)
+        : null
+    }
+    default:
+      return null
+  }
+}
+
+function evaluateBinary(
+  operator: string,
+  left: ConstantValue,
+  right: ConstantValue
+): ConstantValue | null {
+  if (left.kind === 'integer' && right.kind === 'integer') {
+    switch (operator) {
+      case 'PLUS':
+        return integer(BigInt.asIntN(64, left.value + right.value))
+      case 'MINUS':
+        return integer(BigInt.asIntN(64, left.value - right.value))
+      case 'ASTERISK':
+        return integer(BigInt.asIntN(64, left.value * right.value))
+      case 'SLASH':
+        if (
+          right.value === ZERO ||
+          (left.value === I64_MIN && right.value === NEGATIVE_ONE)
+        ) {
+          return null
+        }
+        return integer(left.value / right.value)
+      case 'LT':
+        return boolean(left.value < right.value)
+      case 'GT':
+        return boolean(left.value > right.value)
+      case 'EQ':
+        return boolean(left.value === right.value)
+      case 'NotEq':
+        return boolean(left.value !== right.value)
+      default:
+        return null
+    }
+  }
+  if (left.kind === 'boolean' && right.kind === 'boolean') {
+    if (operator === 'EQ' || operator === 'NotEq') {
+      return boolean(
+        operator === 'EQ'
+          ? left.value === right.value
+          : left.value !== right.value
+      )
+    }
+    return null
+  }
+  if (left.kind === 'string' && right.kind === 'string') {
+    switch (operator) {
+      case 'PLUS':
+        return { kind: 'string', value: left.value + right.value }
+      case 'EQ':
+        return boolean(left.value === right.value)
+      case 'NotEq':
+        return boolean(left.value !== right.value)
+      default:
+        return null
+    }
+  }
+  return null
+}
+
+function integer(value: bigint): ConstantValue {
+  return { kind: 'integer', value }
+}
+
+function boolean(value: boolean): ConstantValue {
+  return { kind: 'boolean', value }
+}
+
+function constantToExpression(value: ConstantValue | null): Expression | null {
+  if (!value) {
+    return null
+  }
+  switch (value.kind) {
+    case 'boolean':
+      return { type: 'Boolean', raw: value.value }
+    case 'string':
+      return { type: 'String', raw: value.value }
+    case 'integer':
+      if (value.value === I64_MIN) {
+        return null
+      }
+      if (value.value < ZERO) {
+        return {
+          type: 'UnaryExpression',
+          op: { kind: { type: 'MINUS' } },
+          operand: { type: 'Integer', raw: (-value.value).toString() },
+        }
+      }
+      return { type: 'Integer', raw: value.value.toString() }
+  }
+}
+
+function isTruthy(value: ConstantValue): boolean {
+  return value.kind === 'boolean' ? value.value : true
+}
+
+function branchesChangeScope(
+  consequent: BlockStatement,
+  alternate: BlockStatement | null | undefined
+): boolean {
+  return (
+    blockChangesScope(consequent) ||
+    (alternate ? blockChangesScope(alternate) : false)
+  )
+}
+
+function blockChangesScope(block: BlockStatement): boolean {
+  return block.body.some(statementChangesScope)
+}
+
+function statementChangesScope(statement: Statement): boolean {
+  switch (statement.type) {
+    case 'Let':
+    case 'ClassDeclaration':
+      return true
+    case 'ReturnStatement':
+      return expressionChangesScope(statement.argument)
+    case 'SetPropertyStatement':
+      return (
+        expressionChangesScope(statement.object) ||
+        expressionChangesScope(statement.value)
+      )
+    default:
+      return expressionChangesScope(statement)
+  }
+}
+
+function expressionChangesScope(expression: Expression): boolean {
+  switch (expression.type) {
+    case 'IF':
+      return (
+        expressionChangesScope(expression.condition) ||
+        blockChangesScope(expression.consequent) ||
+        (expression.alternate ? blockChangesScope(expression.alternate) : false)
+      )
+    case 'UnaryExpression':
+      return expressionChangesScope(expression.operand)
+    case 'BinaryExpression':
+      return (
+        expressionChangesScope(expression.left) ||
+        expressionChangesScope(expression.right)
+      )
+    case 'Array':
+      return expression.elements.some(expressionChangesScope)
+    case 'Hash':
+      return expression.elements.some(
+        ([key, value]) =>
+          expressionChangesScope(key) || expressionChangesScope(value)
+      )
+    case 'FunctionCall':
+      return (
+        expressionChangesScope(expression.callee) ||
+        expression.arguments.some(expressionChangesScope)
+      )
+    case 'Index':
+      return (
+        expressionChangesScope(expression.object) ||
+        expressionChangesScope(expression.index)
+      )
+    case 'PropertyExpression':
+      return expressionChangesScope(expression.object)
+    case 'NewExpression':
+      return expression.arguments.some(expressionChangesScope)
+    // Function bodies have their own compiler symbol scope.
+    case 'FunctionDeclaration':
+    default:
+      return false
+  }
+}
+
+function isExpression(statement: Statement): statement is Expression {
+  return ![
+    'Let',
+    'ReturnStatement',
+    'ClassDeclaration',
+    'SetPropertyStatement',
+  ].includes(statement.type)
+}
+
+function removeDeadStatements(
+  statements: Statement[],
+  analysis: ScopeAnalysis,
+  preserveTrailingLet: boolean,
+  removeLets: boolean
+): boolean {
+  let removed = false
+  const retained: Statement[] = []
+  for (const [index, statement] of statements.entries()) {
+    if (removeLets && statement.type === 'Let') {
+      const binding = analysis.letBindings.get(statement)
+      if (
+        binding &&
+        binding.references.length === 0 &&
+        isPureTotal(statement.expr, analysis) &&
+        // A trailing let is a value barrier in function/method bodies and in
+        // either arm of an if expression. Removing it can expose the previous
+        // expression as an implicit return/branch value. Keeping the final
+        // candidate is conservative and lets earlier dead bindings disappear.
+        (!preserveTrailingLet || index !== statements.length - 1)
+      ) {
+        removed = true
+        continue
+      }
+    }
+    removed = removeNested(statement, analysis, removeLets) || removed
+    retained.push(statement)
+  }
+  statements.splice(0, statements.length, ...retained)
+  return removed
+}
+
+function removeNested(
+  statement: Statement,
+  analysis: ScopeAnalysis,
+  removeLets: boolean
+): boolean {
+  switch (statement.type) {
+    case 'Let':
+      return removeNestedExpression(statement.expr, analysis, removeLets)
+    case 'ReturnStatement':
+      return removeNestedExpression(statement.argument, analysis, removeLets)
+    case 'ClassDeclaration':
+      return statement.methods.reduce(
+        (removed, method) =>
+          removeDeadStatements(
+            method.body.body,
+            analysis,
+            true,
+            !callableHasIncompleteIf(method.body)
+          ) || removed,
+        false
+      )
+    case 'SetPropertyStatement':
+      return (
+        removeNestedExpression(statement.object, analysis, removeLets) ||
+        removeNestedExpression(statement.value, analysis, removeLets)
+      )
+    default:
+      return removeNestedExpression(statement, analysis, removeLets)
+  }
+}
+
+function removeNestedExpression(
+  expression: Expression,
+  analysis: ScopeAnalysis,
+  removeLets: boolean
+): boolean {
+  switch (expression.type) {
+    case 'FunctionDeclaration': {
+      const removeFunctionLets = !callableHasIncompleteIf(expression.body)
+      return removeDeadStatements(
+        expression.body.body,
+        analysis,
+        true,
+        removeFunctionLets
+      )
+    }
+    case 'IF':
+      return (
+        removeDeadStatements(
+          expression.consequent.body,
+          analysis,
+          true,
+          removeLets
+        ) ||
+        (expression.alternate
+          ? removeDeadStatements(
+              expression.alternate.body,
+              analysis,
+              true,
+              removeLets
+            )
+          : false) ||
+        removeNestedExpression(expression.condition, analysis, removeLets)
+      )
+    case 'UnaryExpression':
+      return removeNestedExpression(expression.operand, analysis, removeLets)
+    case 'BinaryExpression':
+      return (
+        removeNestedExpression(expression.left, analysis, removeLets) ||
+        removeNestedExpression(expression.right, analysis, removeLets)
+      )
+    case 'Array':
+      return expression.elements.reduce(
+        (removed, item) =>
+          removeNestedExpression(item, analysis, removeLets) || removed,
+        false
+      )
+    case 'Hash':
+      return expression.elements.reduce(
+        (removed, [key, value]) =>
+          removeNestedExpression(key, analysis, removeLets) ||
+          removeNestedExpression(value, analysis, removeLets) ||
+          removed,
+        false
+      )
+    case 'FunctionCall':
+      return [expression.callee, ...expression.arguments].reduce(
+        (removed, item) =>
+          removeNestedExpression(item, analysis, removeLets) || removed,
+        false
+      )
+    case 'Index':
+      return (
+        removeNestedExpression(expression.object, analysis, removeLets) ||
+        removeNestedExpression(expression.index, analysis, removeLets)
+      )
+    case 'PropertyExpression':
+      return removeNestedExpression(expression.object, analysis, removeLets)
+    case 'NewExpression':
+      return expression.arguments.reduce(
+        (removed, item) =>
+          removeNestedExpression(item, analysis, removeLets) || removed,
+        false
+      )
+    default:
+      return false
+  }
+}
+
+// The compiler reserves every local slot when a function is entered. An `if`
+// arm that falls through without producing a value (an empty arm or one ending
+// in `let`) can make the surrounding expression consume one of those slots.
+// Removing any local from that callable then changes which value is consumed,
+// even when the removed binding itself has no references. Keep its local-slot
+// layout intact; nested functions and methods are assessed independently.
+function callableHasIncompleteIf(body: BlockStatement): boolean {
+  return blockContainsIncompleteIf(body)
+}
+
+function blockContainsIncompleteIf(block: BlockStatement): boolean {
+  return block.body.some(statementContainsIncompleteIf)
+}
+
+function statementContainsIncompleteIf(statement: Statement): boolean {
+  switch (statement.type) {
+    case 'Let':
+      return expressionContainsIncompleteIf(statement.expr)
+    case 'ReturnStatement':
+      return expressionContainsIncompleteIf(statement.argument)
+    case 'ClassDeclaration':
+      return false
+    case 'SetPropertyStatement':
+      return (
+        expressionContainsIncompleteIf(statement.object) ||
+        expressionContainsIncompleteIf(statement.value)
+      )
+    default:
+      return expressionContainsIncompleteIf(statement)
+  }
+}
+
+function expressionContainsIncompleteIf(expression: Expression): boolean {
+  switch (expression.type) {
+    case 'IF':
+      return (
+        ifCanFallThroughWithoutValue(expression) ||
+        expressionContainsIncompleteIf(expression.condition) ||
+        blockContainsIncompleteIf(expression.consequent) ||
+        (expression.alternate
+          ? blockContainsIncompleteIf(expression.alternate)
+          : false)
+      )
+    case 'UnaryExpression':
+      return expressionContainsIncompleteIf(expression.operand)
+    case 'BinaryExpression':
+      return (
+        expressionContainsIncompleteIf(expression.left) ||
+        expressionContainsIncompleteIf(expression.right)
+      )
+    case 'Array':
+      return expression.elements.some(expressionContainsIncompleteIf)
+    case 'Hash':
+      return expression.elements.some(
+        ([key, value]) =>
+          expressionContainsIncompleteIf(key) ||
+          expressionContainsIncompleteIf(value)
+      )
+    case 'FunctionCall':
+      return (
+        expressionContainsIncompleteIf(expression.callee) ||
+        expression.arguments.some(expressionContainsIncompleteIf)
+      )
+    case 'Index':
+      return (
+        expressionContainsIncompleteIf(expression.object) ||
+        expressionContainsIncompleteIf(expression.index)
+      )
+    case 'PropertyExpression':
+      return expressionContainsIncompleteIf(expression.object)
+    case 'NewExpression':
+      return expression.arguments.some(expressionContainsIncompleteIf)
+    case 'FunctionDeclaration':
+    default:
+      return false
+  }
+}
+
+function ifCanFallThroughWithoutValue(expression: {
+  consequent: BlockStatement
+  alternate?: BlockStatement | null
+}): boolean {
+  return (
+    blockCanFallThroughWithoutValue(expression.consequent) ||
+    (expression.alternate
+      ? blockCanFallThroughWithoutValue(expression.alternate)
+      : false)
+  )
+}
+
+function blockCanFallThroughWithoutValue(block: BlockStatement): boolean {
+  const last = block.body[block.body.length - 1]
+  if (!last) {
+    return true
+  }
+  switch (last.type) {
+    case 'Let':
+      return true
+    case 'ReturnStatement':
+    case 'ClassDeclaration':
+    case 'SetPropertyStatement':
+      return false
+    case 'IF':
+      return ifCanFallThroughWithoutValue(last)
+    default:
+      return false
+  }
+}
+
+function isPureTotal(expression: Expression, analysis: ScopeAnalysis): boolean {
+  switch (expression.type) {
+    case 'Integer':
+    case 'Boolean':
+    case 'String':
+      return true
+    case 'IDENTIFIER':
+      return analysis.referenceBindings.has(expression)
+    case 'Array':
+      return expression.elements.every((element) =>
+        isPureTotal(element, analysis)
+      )
+    case 'Hash':
+      return hashIsPureTotal(expression, analysis)
+    case 'UnaryExpression':
+      return (
+        isPureTotal(expression.operand, analysis) &&
+        (tokenType(expression.op) === 'BANG' ||
+          (tokenType(expression.op) === 'MINUS' &&
+            evaluateConstant(expression.operand)?.kind === 'integer'))
+      )
+    case 'BinaryExpression':
+      return (
+        isPureTotal(expression.left, analysis) &&
+        isPureTotal(expression.right, analysis) &&
+        evaluateConstant(expression) !== null
+      )
+    case 'FunctionDeclaration':
+      return !containsDiagnostic(expression, analysis)
+    default:
+      // Calls/new can have effects. Property/index operations may throw. If
+      // and unknown future nodes are deliberately retained.
+      return false
+  }
+}
+
+function hashIsPureTotal(hash: HashLiteral, analysis: ScopeAnalysis): boolean {
+  return hash.elements.every(([key, value]) => {
+    const constant = evaluateConstant(key)
+    return (
+      constant !== null &&
+      isPureTotal(key, analysis) &&
+      isPureTotal(value, analysis)
+    )
+  })
+}
+
+function containsDiagnostic(node: ASTNode, analysis: ScopeAnalysis): boolean {
+  if (analysis.diagnosticNodes.has(node)) {
+    return true
+  }
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (Array.isArray(child)) {
+          for (const tupleChild of child) {
+            if (
+              isNode(tupleChild) &&
+              containsDiagnostic(tupleChild, analysis)
+            ) {
+              return true
+            }
+          }
+        } else if (isNode(child) && containsDiagnostic(child, analysis)) {
+          return true
+        }
+      }
+    } else if (isNode(value) && containsDiagnostic(value, analysis)) {
+      return true
+    }
+  }
+  return false
+}
+
+function isNode(value: unknown): value is ASTNode {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    typeof (value as { type?: unknown }).type === 'string'
+  )
+}

--- a/packages/monkey-minifier/src/index.ts
+++ b/packages/monkey-minifier/src/index.ts
@@ -1,0 +1,27 @@
+import { parse_lossless } from '@gengjiawen/monkey-wasm'
+
+import {
+  minifyWithParser,
+  parseProgramWithParser,
+  type MinifyOptions,
+  type MinifyResult,
+} from './core'
+import type { Program } from './types'
+
+export function minify(
+  source: string,
+  options: MinifyOptions = {}
+): MinifyResult {
+  return minifyWithParser(parse_lossless, source, options)
+}
+
+export function parseProgram(source: string): Program {
+  return parseProgramWithParser(parse_lossless, source)
+}
+
+export { eliminateDeadLets, foldConstants } from './fold'
+export { mangle } from './mangle'
+export { printExpression, printProgram } from './printer'
+export type { MinifyOptions, MinifyResult } from './core'
+export type { MangleOptions } from './mangle'
+export type * from './types'

--- a/packages/monkey-minifier/src/mangle.ts
+++ b/packages/monkey-minifier/src/mangle.ts
@@ -1,0 +1,83 @@
+import type { Program } from './types'
+import { setIdentifierName } from './types'
+import { analyzeScopes, type Binding } from './scope'
+
+const KEYWORDS = new Set([
+  'let',
+  'return',
+  'fn',
+  'if',
+  'else',
+  'true',
+  'false',
+  'class',
+  'this',
+  'new',
+])
+
+export interface MangleOptions {
+  reserved?: string[]
+}
+
+export function mangle(program: Program, options: MangleOptions = {}): Program {
+  const analysis = analyzeScopes(program)
+  if (!analysis.safe) {
+    return program
+  }
+
+  const reserved = new Set(options.reserved ?? [])
+  const forbidden = new Set([
+    ...analysis.forbiddenNames,
+    ...reserved,
+    ...KEYWORDS,
+  ])
+  for (const binding of analysis.bindings) {
+    if (binding.preserve || reserved.has(binding.originalName)) {
+      binding.preserve = true
+      forbidden.add(binding.originalName)
+    }
+  }
+
+  const candidates = analysis.bindings
+    .filter((binding) => !binding.preserve && isUserBinding(binding))
+    .sort(
+      (left, right) =>
+        right.references.length - left.references.length || left.id - right.id
+    )
+
+  let index = 0
+  for (const binding of candidates) {
+    let name: string
+    do {
+      name = generatedName(index++)
+    } while (forbidden.has(name))
+    forbidden.add(name)
+    renameBinding(binding, name)
+  }
+  return program
+}
+
+function isUserBinding(binding: Binding): boolean {
+  return binding.kind === 'let' || binding.kind === 'parameter'
+}
+
+function renameBinding(binding: Binding, name: string): void {
+  for (const statement of binding.lets) {
+    setIdentifierName(statement, name)
+  }
+  for (const identifier of binding.identifiers) {
+    identifier.name = name
+  }
+  for (const reference of binding.references) {
+    reference.name = name
+  }
+  for (const declaration of binding.functions) {
+    declaration.name = name
+  }
+}
+
+function generatedName(index: number): string {
+  const letter = String.fromCharCode(97 + (index % 26))
+  const suffix = Math.floor(index / 26)
+  return suffix === 0 ? letter : `${letter}${suffix - 1}`
+}

--- a/packages/monkey-minifier/src/node.ts
+++ b/packages/monkey-minifier/src/node.ts
@@ -15,10 +15,10 @@ interface MonkeyWasmGlue extends WebAssembly.ModuleImports {
 }
 
 function loadNodeParser(): ParseLossless {
-  // wasm-pack's bundler target statically imports `.wasm`, which Node 20
-  // cannot execute directly. Load the generated glue without its bundler
-  // entrypoint and instantiate the same module through Node's WebAssembly API.
-  // Node 20.19+ can synchronously require this dependency's ESM glue module.
+  // wasm-pack's bundler target statically imports `.wasm`, which Node cannot
+  // execute directly. Load the generated glue without its bundler entrypoint
+  // and instantiate the same module through Node's WebAssembly API.
+  // Node 24 can synchronously require this dependency's ESM glue module.
   const glue =
     require('@gengjiawen/monkey-wasm/monkey_wasm_bg.js') as MonkeyWasmGlue
   const wasmPath = require.resolve(

--- a/packages/monkey-minifier/src/node.ts
+++ b/packages/monkey-minifier/src/node.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+
+import {
+  minifyWithParser,
+  parseProgramWithParser,
+  type MinifyOptions,
+  type MinifyResult,
+  type ParseLossless,
+} from './core'
+import type { Program } from './types'
+
+interface MonkeyWasmGlue extends WebAssembly.ModuleImports {
+  __wbg_set_wasm(exports: WebAssembly.Exports): void
+  parse_lossless: ParseLossless
+}
+
+function loadNodeParser(): ParseLossless {
+  // wasm-pack's bundler target statically imports `.wasm`, which Node 20
+  // cannot execute directly. Load the generated glue without its bundler
+  // entrypoint and instantiate the same module through Node's WebAssembly API.
+  // Node 20.19+ can synchronously require this dependency's ESM glue module.
+  const glue =
+    require('@gengjiawen/monkey-wasm/monkey_wasm_bg.js') as MonkeyWasmGlue
+  const wasmPath = require.resolve(
+    '@gengjiawen/monkey-wasm/monkey_wasm_bg.wasm'
+  )
+  const module = new WebAssembly.Module(readFileSync(wasmPath))
+  const instance = new WebAssembly.Instance(module, {
+    './monkey_wasm_bg.js': glue,
+  })
+  glue.__wbg_set_wasm(instance.exports)
+  const start = instance.exports.__wbindgen_start
+  if (typeof start === 'function') {
+    start()
+  }
+  return glue.parse_lossless
+}
+
+const parseLossless = loadNodeParser()
+
+export function minify(
+  source: string,
+  options: MinifyOptions = {}
+): MinifyResult {
+  return minifyWithParser(parseLossless, source, options)
+}
+
+export function parseProgram(source: string): Program {
+  return parseProgramWithParser(parseLossless, source)
+}
+
+export { eliminateDeadLets, foldConstants } from './fold'
+export { mangle } from './mangle'
+export { printExpression, printProgram } from './printer'
+export type { MinifyOptions, MinifyResult } from './core'
+export type { MangleOptions } from './mangle'
+export type * from './types'

--- a/packages/monkey-minifier/src/printer.ts
+++ b/packages/monkey-minifier/src/printer.ts
@@ -1,0 +1,226 @@
+import type {
+  BinaryExpression,
+  BlockStatement,
+  ClassDeclaration,
+  Expression,
+  FunctionDeclaration,
+  LetStatement,
+  Literal,
+  MethodDefinition,
+  Program,
+  SetPropertyStatement,
+  Statement,
+} from './types'
+import { identifierName, tokenType } from './types'
+
+enum Precedence {
+  Lowest,
+  Equals,
+  LessGreater,
+  Sum,
+  Product,
+  Prefix,
+  Postfix,
+  Primary,
+}
+
+const operators: Record<string, string> = {
+  PLUS: '+',
+  MINUS: '-',
+  ASTERISK: '*',
+  SLASH: '/',
+  BANG: '!',
+  LT: '<',
+  GT: '>',
+  EQ: '==',
+  NotEq: '!=',
+}
+
+const infixPrecedence: Record<string, Precedence> = {
+  EQ: Precedence.Equals,
+  NotEq: Precedence.Equals,
+  LT: Precedence.LessGreater,
+  GT: Precedence.LessGreater,
+  PLUS: Precedence.Sum,
+  MINUS: Precedence.Sum,
+  ASTERISK: Precedence.Product,
+  SLASH: Precedence.Product,
+}
+
+interface PrintedExpression {
+  code: string
+  precedence: Precedence
+}
+
+export function printProgram(program: Program): string {
+  return program.body.map(printStatement).join('')
+}
+
+function printStatement(statement: Statement): string {
+  switch (statement.type) {
+    case 'Let':
+      return printLet(statement)
+    case 'ReturnStatement':
+      return `return ${printExpression(statement.argument)};`
+    case 'ClassDeclaration':
+      return printClass(statement)
+    case 'SetPropertyStatement':
+      return printSetProperty(statement)
+    default:
+      return `${printExpression(statement)};`
+  }
+}
+
+function printLet(statement: LetStatement): string {
+  return `let ${identifierName(statement)}=${printExpression(statement.expr)};`
+}
+
+function printClass(statement: ClassDeclaration): string {
+  return `class ${statement.name.name}{${statement.methods
+    .map(printMethod)
+    .join('')}}`
+}
+
+function printMethod(method: MethodDefinition): string {
+  return `${method.name.name}(${method.params
+    .map((param) => param.name)
+    .join(',')})${printBlock(method.body)}`
+}
+
+function printSetProperty(statement: SetPropertyStatement): string {
+  const object = printChild(statement.object, Precedence.Postfix)
+  return `${object}.${statement.property.name}=${printExpression(
+    statement.value
+  )};`
+}
+
+function printBlock(block: BlockStatement): string {
+  return `{${block.body.map(printStatement).join('')}}`
+}
+
+export function printExpression(expression: Expression): string {
+  return renderExpression(expression).code
+}
+
+function printChild(
+  expression: Expression,
+  minimum: Precedence,
+  parenthesizeEqual = false
+): string {
+  const printed = renderExpression(expression)
+  return printed.precedence < minimum ||
+    (parenthesizeEqual && printed.precedence === minimum)
+    ? `(${printed.code})`
+    : printed.code
+}
+
+function renderExpression(expression: Expression): PrintedExpression {
+  switch (expression.type) {
+    case 'IDENTIFIER':
+      return primary(expression.name)
+    case 'Integer':
+      return primary(expression.raw)
+    case 'Boolean':
+      return primary(String(expression.raw))
+    case 'String':
+      return primary(`"${expression.raw}"`)
+    case 'Array':
+      return primary(`[${expression.elements.map(printExpression).join(',')}]`)
+    case 'Hash':
+      return primary(
+        `{${expression.elements
+          .map(
+            ([key, value]) =>
+              `${printExpression(key)}:${printExpression(value)}`
+          )
+          .join(',')}}`
+      )
+    case 'UnaryExpression': {
+      const operator = operatorFor(expression.op.kind.type)
+      return {
+        code: `${operator}${printChild(expression.operand, Precedence.Prefix)}`,
+        precedence: Precedence.Prefix,
+      }
+    }
+    case 'BinaryExpression':
+      return renderBinary(expression)
+    case 'IF':
+      return {
+        code: `if(${printExpression(expression.condition)})${printBlock(
+          expression.consequent
+        )}${
+          expression.alternate ? `else${printBlock(expression.alternate)}` : ''
+        }`,
+        precedence: Precedence.Lowest,
+      }
+    case 'FunctionDeclaration':
+      return renderFunction(expression)
+    case 'FunctionCall':
+      return {
+        code: `${printChild(
+          expression.callee,
+          Precedence.Postfix
+        )}(${expression.arguments.map(printExpression).join(',')})`,
+        precedence: Precedence.Postfix,
+      }
+    case 'Index':
+      return {
+        code: `${printChild(
+          expression.object,
+          Precedence.Postfix
+        )}[${printExpression(expression.index)}]`,
+        precedence: Precedence.Postfix,
+      }
+    case 'ThisExpression':
+      return primary('this')
+    case 'PropertyExpression':
+      return {
+        code: `${printChild(expression.object, Precedence.Postfix)}.${
+          expression.property.name
+        }`,
+        precedence: Precedence.Postfix,
+      }
+    case 'NewExpression':
+      return {
+        code: `new ${expression.callee.name}(${expression.arguments
+          .map(printExpression)
+          .join(',')})`,
+        precedence: Precedence.Postfix,
+      }
+  }
+}
+
+function renderBinary(expression: BinaryExpression): PrintedExpression {
+  const kind = tokenType(expression.op)
+  const precedence = infixPrecedence[kind]
+  if (precedence === undefined) {
+    throw new Error(`Unknown binary operator: ${kind}`)
+  }
+  return {
+    code: `${printChild(expression.left, precedence)}${operatorFor(
+      kind
+    )}${printChild(expression.right, precedence, true)}`,
+    precedence,
+  }
+}
+
+function renderFunction(expression: FunctionDeclaration): PrintedExpression {
+  return {
+    code: `fn(${expression.params
+      .map((param) => param.name)
+      .join(',')})${printBlock(expression.body)}`,
+    precedence: Precedence.Lowest,
+  }
+}
+
+function primary(code: string): PrintedExpression {
+  return { code, precedence: Precedence.Primary }
+}
+
+function operatorFor(kind: string): string {
+  const operator = operators[kind]
+  if (operator === undefined) {
+    throw new Error(`Unknown operator: ${kind}`)
+  }
+  return operator
+}

--- a/packages/monkey-minifier/src/propagate.ts
+++ b/packages/monkey-minifier/src/propagate.ts
@@ -1,0 +1,204 @@
+import type { Expression, Identifier, Program, Statement } from './types'
+import { tokenType } from './types'
+import { analyzeScopes } from './scope'
+
+// `let x=<literal>;` spends seven characters beyond the literal itself once
+// the name mangles to a single character.
+const BINDING_OVERHEAD = 7
+
+interface Substitution {
+  replacements: Map<Identifier, Expression>
+  replaced: boolean
+}
+
+// Replace references to literal-initialized bindings with the literal.
+//
+// The compiler resolves a name to the binding whose `let` most recently
+// precedes it in source order, and each such slot is written exactly once —
+// redeclaring a name allocates a fresh slot instead of mutating the old one.
+// A reference therefore always observes its own binding's initializer, except
+// when the `let` sits inside an `if` arm and may never have run; those
+// bindings stay put (`Binding.conditional`).
+//
+// Bindings whose references disappear here become dead and are collected by
+// `eliminateDeadLets`. Returns whether any reference was replaced so the
+// caller can re-fold and iterate to a fixpoint.
+export function propagateConstants(program: Program): boolean {
+  const analysis = analyzeScopes(program)
+  if (!analysis.safe) {
+    return false
+  }
+  const substitution: Substitution = {
+    replacements: new Map(),
+    replaced: false,
+  }
+  for (const [statement, binding] of analysis.letBindings) {
+    if (binding.conditional || binding.references.length === 0) {
+      continue
+    }
+    const width = literalWidth(statement.expr)
+    if (width === null) {
+      continue
+    }
+    // Inlining trades the binding (`let x=<literal>;` plus one-character
+    // reads) for a literal copy at every use site; skip when the copies cost
+    // more than the binding they free.
+    if (binding.references.length * (width - 1) > BINDING_OVERHEAD + width) {
+      continue
+    }
+    for (const reference of binding.references) {
+      substitution.replacements.set(reference, statement.expr)
+    }
+  }
+  if (substitution.replacements.size === 0) {
+    return false
+  }
+  substituteStatements(program.body, substitution)
+  return substitution.replaced
+}
+
+function literalWidth(expression: Expression): number | null {
+  switch (expression.type) {
+    case 'Integer':
+      return expression.raw.length
+    case 'Boolean':
+      return expression.raw ? 4 : 5
+    case 'String':
+      return expression.raw.length + 2
+    case 'UnaryExpression':
+      // Folding renders a negative integer as MINUS over a positive literal.
+      return tokenType(expression.op) === 'MINUS' &&
+        expression.operand.type === 'Integer'
+        ? expression.operand.raw.length + 1
+        : null
+    default:
+      return null
+  }
+}
+
+// Every use site gets its own copy: later passes rewrite nodes in place, and
+// one node aliased across the tree would receive every rewrite at once.
+function cloneLiteral(expression: Expression): Expression {
+  switch (expression.type) {
+    case 'Integer':
+      return { type: 'Integer', raw: expression.raw }
+    case 'Boolean':
+      return { type: 'Boolean', raw: expression.raw }
+    case 'String':
+      return { type: 'String', raw: expression.raw }
+    case 'UnaryExpression':
+      return {
+        type: 'UnaryExpression',
+        op: { kind: { type: 'MINUS' } },
+        operand: cloneLiteral(expression.operand),
+      }
+    default:
+      throw new Error(`not a propagated literal: ${expression.type}`)
+  }
+}
+
+function substituteStatements(
+  statements: Statement[],
+  substitution: Substitution
+): void {
+  for (let index = 0; index < statements.length; index += 1) {
+    const statement = statements[index]
+    switch (statement.type) {
+      case 'Let':
+        statement.expr = substituteExpression(statement.expr, substitution)
+        break
+      case 'ReturnStatement':
+        statement.argument = substituteExpression(
+          statement.argument,
+          substitution
+        )
+        break
+      case 'ClassDeclaration':
+        for (const method of statement.methods) {
+          substituteStatements(method.body.body, substitution)
+        }
+        break
+      case 'SetPropertyStatement':
+        statement.object = substituteExpression(statement.object, substitution)
+        statement.value = substituteExpression(statement.value, substitution)
+        break
+      default:
+        statements[index] = substituteExpression(statement, substitution)
+    }
+  }
+}
+
+function substituteExpression(
+  expression: Expression,
+  substitution: Substitution
+): Expression {
+  switch (expression.type) {
+    case 'IDENTIFIER': {
+      const template = substitution.replacements.get(expression)
+      if (!template) {
+        return expression
+      }
+      substitution.replaced = true
+      return cloneLiteral(template)
+    }
+    case 'Integer':
+    case 'Boolean':
+    case 'String':
+    case 'ThisExpression':
+      return expression
+    case 'Array':
+      expression.elements = expression.elements.map((element) =>
+        substituteExpression(element, substitution)
+      )
+      return expression
+    case 'Hash':
+      expression.elements = expression.elements.map(([key, value]) => [
+        substituteExpression(key, substitution),
+        substituteExpression(value, substitution),
+      ])
+      return expression
+    case 'UnaryExpression':
+      expression.operand = substituteExpression(
+        expression.operand,
+        substitution
+      )
+      return expression
+    case 'BinaryExpression':
+      expression.left = substituteExpression(expression.left, substitution)
+      expression.right = substituteExpression(expression.right, substitution)
+      return expression
+    case 'IF':
+      expression.condition = substituteExpression(
+        expression.condition,
+        substitution
+      )
+      substituteStatements(expression.consequent.body, substitution)
+      if (expression.alternate) {
+        substituteStatements(expression.alternate.body, substitution)
+      }
+      return expression
+    case 'FunctionDeclaration':
+      substituteStatements(expression.body.body, substitution)
+      return expression
+    case 'FunctionCall':
+      expression.callee = substituteExpression(expression.callee, substitution)
+      expression.arguments = expression.arguments.map((argument) =>
+        substituteExpression(argument, substitution)
+      )
+      return expression
+    case 'Index':
+      expression.object = substituteExpression(expression.object, substitution)
+      expression.index = substituteExpression(expression.index, substitution)
+      return expression
+    case 'PropertyExpression':
+      expression.object = substituteExpression(expression.object, substitution)
+      return expression
+    case 'NewExpression':
+      // The callee slot must stay an identifier node; an untouched reference
+      // here keeps its binding alive instead.
+      expression.arguments = expression.arguments.map((argument) =>
+        substituteExpression(argument, substitution)
+      )
+      return expression
+  }
+}

--- a/packages/monkey-minifier/src/scope.ts
+++ b/packages/monkey-minifier/src/scope.ts
@@ -1,0 +1,318 @@
+import type {
+  ASTNode,
+  BlockStatement,
+  ClassDeclaration,
+  Expression,
+  FunctionDeclaration,
+  Identifier,
+  LetStatement,
+  MethodDefinition,
+  Program,
+  Statement,
+} from './types'
+import { identifierName } from './types'
+
+export const BUILTIN_NAMES = [
+  'len',
+  'puts',
+  'first',
+  'last',
+  'rest',
+  'push',
+  'print',
+] as const
+
+export type BindingKind = 'builtin' | 'class' | 'let' | 'parameter' | 'this'
+
+export interface Binding {
+  id: number
+  kind: BindingKind
+  originalName: string
+  preserve: boolean
+  references: Identifier[]
+  identifiers: Identifier[]
+  lets: LetStatement[]
+  functions: FunctionDeclaration[]
+}
+
+export interface ScopeAnalysis {
+  bindings: Binding[]
+  letBindings: Map<LetStatement, Binding>
+  referenceBindings: Map<Identifier, Binding>
+  unresolved: Set<Identifier>
+  diagnosticNodes: Set<ASTNode>
+  forbiddenNames: Set<string>
+  safe: boolean
+}
+
+interface Scope {
+  parent?: Scope
+  names: Map<string, Binding>
+}
+
+interface Context {
+  callable: 'constructor' | 'function' | 'method' | null
+  receiverAvailable: boolean
+}
+
+export function analyzeScopes(program: Program): ScopeAnalysis {
+  const analysis: ScopeAnalysis = {
+    bindings: [],
+    letBindings: new Map(),
+    referenceBindings: new Map(),
+    unresolved: new Set(),
+    diagnosticNodes: new Set(),
+    forbiddenNames: new Set(BUILTIN_NAMES),
+    safe: true,
+  }
+  const root: Scope = { names: new Map() }
+  for (const name of BUILTIN_NAMES) {
+    define(root, createBinding(analysis, name, 'builtin', true))
+  }
+  analyzeStatements(program.body, root, analysis, {
+    callable: null,
+    receiverAvailable: false,
+  })
+  return analysis
+}
+
+function createBinding(
+  analysis: ScopeAnalysis,
+  name: string,
+  kind: BindingKind,
+  preserve: boolean
+): Binding {
+  const binding: Binding = {
+    id: analysis.bindings.length,
+    kind,
+    originalName: name,
+    preserve,
+    references: [],
+    identifiers: [],
+    lets: [],
+    functions: [],
+  }
+  analysis.bindings.push(binding)
+  if (preserve) {
+    analysis.forbiddenNames.add(name)
+  }
+  return binding
+}
+
+function define(scope: Scope, binding: Binding): void {
+  scope.names.set(binding.originalName, binding)
+}
+
+function resolve(scope: Scope, name: string): Binding | undefined {
+  for (
+    let current: Scope | undefined = scope;
+    current;
+    current = current.parent
+  ) {
+    const binding = current.names.get(name)
+    if (binding) {
+      return binding
+    }
+  }
+  return undefined
+}
+
+function analyzeStatements(
+  statements: Statement[],
+  scope: Scope,
+  analysis: ScopeAnalysis,
+  context: Context
+): void {
+  for (const statement of statements) {
+    analyzeStatement(statement, scope, analysis, context)
+  }
+}
+
+function analyzeStatement(
+  statement: Statement,
+  scope: Scope,
+  analysis: ScopeAnalysis,
+  context: Context
+): void {
+  switch (statement.type) {
+    case 'Let': {
+      // Mirror Compiler::compile_stmt: the RHS sees the preceding binding.
+      const binding = createBinding(
+        analysis,
+        identifierName(statement),
+        'let',
+        false
+      )
+      binding.lets.push(statement)
+      analysis.letBindings.set(statement, binding)
+      analyzeExpression(statement.expr, scope, analysis, context, binding)
+      define(scope, binding)
+      return
+    }
+    case 'ReturnStatement':
+      if (context.callable === 'constructor') {
+        analysis.diagnosticNodes.add(statement)
+      }
+      analyzeExpression(statement.argument, scope, analysis, context)
+      return
+    case 'ClassDeclaration':
+      analyzeClass(statement, scope, analysis, context)
+      return
+    case 'SetPropertyStatement':
+      analyzeExpression(statement.object, scope, analysis, context)
+      analyzeExpression(statement.value, scope, analysis, context)
+      return
+    default:
+      analyzeExpression(statement, scope, analysis, context)
+  }
+}
+
+function analyzeClass(
+  declaration: ClassDeclaration,
+  scope: Scope,
+  analysis: ScopeAnalysis,
+  context: Context
+): void {
+  // A class is visible while its methods are compiled. Its spelling is
+  // observable in rendered runtime values, so this binding is never mangled.
+  const binding = createBinding(analysis, declaration.name.name, 'class', true)
+  binding.identifiers.push(declaration.name)
+  define(scope, binding)
+  for (const method of declaration.methods) {
+    analyzeMethod(method, scope, analysis, context)
+  }
+}
+
+function analyzeMethod(
+  method: MethodDefinition,
+  parent: Scope,
+  analysis: ScopeAnalysis,
+  _context: Context
+): void {
+  const scope: Scope = { parent, names: new Map() }
+  define(scope, createBinding(analysis, 'this', 'this', true))
+  for (const parameter of method.params) {
+    const binding = createBinding(analysis, parameter.name, 'parameter', false)
+    binding.identifiers.push(parameter)
+    define(scope, binding)
+  }
+  analyzeStatements(method.body.body, scope, analysis, {
+    callable: method.kind === 'Constructor' ? 'constructor' : 'method',
+    receiverAvailable: true,
+  })
+}
+
+function analyzeFunction(
+  declaration: FunctionDeclaration,
+  parent: Scope,
+  analysis: ScopeAnalysis,
+  context: Context,
+  selfBinding?: Binding
+): void {
+  const scope: Scope = { parent, names: new Map() }
+  if (declaration.name) {
+    const binding =
+      selfBinding ?? createBinding(analysis, declaration.name, 'let', true)
+    binding.functions.push(declaration)
+    define(scope, binding)
+  }
+  for (const parameter of declaration.params) {
+    const binding = createBinding(analysis, parameter.name, 'parameter', false)
+    binding.identifiers.push(parameter)
+    define(scope, binding)
+  }
+  analyzeStatements(declaration.body.body, scope, analysis, {
+    callable: 'function',
+    receiverAvailable: context.receiverAvailable,
+  })
+}
+
+function analyzeIdentifier(
+  identifier: Identifier,
+  scope: Scope,
+  analysis: ScopeAnalysis
+): void {
+  const binding = resolve(scope, identifier.name)
+  if (!binding) {
+    analysis.unresolved.add(identifier)
+    analysis.diagnosticNodes.add(identifier)
+    analysis.forbiddenNames.add(identifier.name)
+    return
+  }
+  binding.references.push(identifier)
+  analysis.referenceBindings.set(identifier, binding)
+}
+
+function analyzeExpression(
+  expression: Expression,
+  scope: Scope,
+  analysis: ScopeAnalysis,
+  context: Context,
+  directLetBinding?: Binding
+): void {
+  switch (expression.type) {
+    case 'IDENTIFIER':
+      analyzeIdentifier(expression, scope, analysis)
+      return
+    case 'Integer':
+    case 'Boolean':
+    case 'String':
+      return
+    case 'Array':
+      for (const element of expression.elements) {
+        analyzeExpression(element, scope, analysis, context)
+      }
+      return
+    case 'Hash':
+      for (const [key, value] of expression.elements) {
+        analyzeExpression(key, scope, analysis, context)
+        analyzeExpression(value, scope, analysis, context)
+      }
+      return
+    case 'UnaryExpression':
+      analyzeExpression(expression.operand, scope, analysis, context)
+      return
+    case 'BinaryExpression':
+      analyzeExpression(expression.left, scope, analysis, context)
+      analyzeExpression(expression.right, scope, analysis, context)
+      return
+    case 'IF':
+      // Branches intentionally share this symbol table and are visited in the
+      // compiler's source order.
+      analyzeExpression(expression.condition, scope, analysis, context)
+      analyzeStatements(expression.consequent.body, scope, analysis, context)
+      if (expression.alternate) {
+        analyzeStatements(expression.alternate.body, scope, analysis, context)
+      }
+      return
+    case 'FunctionDeclaration':
+      analyzeFunction(expression, scope, analysis, context, directLetBinding)
+      return
+    case 'FunctionCall':
+      analyzeExpression(expression.callee, scope, analysis, context)
+      for (const argument of expression.arguments) {
+        analyzeExpression(argument, scope, analysis, context)
+      }
+      return
+    case 'Index':
+      analyzeExpression(expression.object, scope, analysis, context)
+      analyzeExpression(expression.index, scope, analysis, context)
+      return
+    case 'ThisExpression':
+      if (!context.receiverAvailable) {
+        analysis.diagnosticNodes.add(expression)
+      }
+      return
+    case 'PropertyExpression':
+      analyzeExpression(expression.object, scope, analysis, context)
+      return
+    case 'NewExpression':
+      analyzeIdentifier(expression.callee, scope, analysis)
+      for (const argument of expression.arguments) {
+        analyzeExpression(argument, scope, analysis, context)
+      }
+      return
+    default:
+      analysis.safe = false
+  }
+}

--- a/packages/monkey-minifier/src/scope.ts
+++ b/packages/monkey-minifier/src/scope.ts
@@ -29,6 +29,10 @@ export interface Binding {
   kind: BindingKind
   originalName: string
   preserve: boolean
+  // True when the binding's `let` sits inside an `if` arm: its slot is
+  // written only on executions that take the branch, so a later reference
+  // may still observe the unset slot.
+  conditional: boolean
   references: Identifier[]
   identifiers: Identifier[]
   lets: LetStatement[]
@@ -53,6 +57,7 @@ interface Scope {
 interface Context {
   callable: 'constructor' | 'function' | 'method' | null
   receiverAvailable: boolean
+  conditional: boolean
 }
 
 export function analyzeScopes(program: Program): ScopeAnalysis {
@@ -72,6 +77,7 @@ export function analyzeScopes(program: Program): ScopeAnalysis {
   analyzeStatements(program.body, root, analysis, {
     callable: null,
     receiverAvailable: false,
+    conditional: false,
   })
   return analysis
 }
@@ -87,6 +93,7 @@ function createBinding(
     kind,
     originalName: name,
     preserve,
+    conditional: false,
     references: [],
     identifiers: [],
     lets: [],
@@ -143,6 +150,7 @@ function analyzeStatement(
         'let',
         false
       )
+      binding.conditional = context.conditional
       binding.lets.push(statement)
       analysis.letBindings.set(statement, binding)
       analyzeExpression(statement.expr, scope, analysis, context, binding)
@@ -199,6 +207,7 @@ function analyzeMethod(
   analyzeStatements(method.body.body, scope, analysis, {
     callable: method.kind === 'Constructor' ? 'constructor' : 'method',
     receiverAvailable: true,
+    conditional: false,
   })
 }
 
@@ -221,9 +230,12 @@ function analyzeFunction(
     binding.identifiers.push(parameter)
     define(scope, binding)
   }
+  // A body's own top-level `let`s run on every call, so conditionality does
+  // not carry across the callable boundary.
   analyzeStatements(declaration.body.body, scope, analysis, {
     callable: 'function',
     receiverAvailable: context.receiverAvailable,
+    conditional: false,
   })
 }
 
@@ -276,15 +288,17 @@ function analyzeExpression(
       analyzeExpression(expression.left, scope, analysis, context)
       analyzeExpression(expression.right, scope, analysis, context)
       return
-    case 'IF':
+    case 'IF': {
       // Branches intentionally share this symbol table and are visited in the
       // compiler's source order.
       analyzeExpression(expression.condition, scope, analysis, context)
-      analyzeStatements(expression.consequent.body, scope, analysis, context)
+      const branch = { ...context, conditional: true }
+      analyzeStatements(expression.consequent.body, scope, analysis, branch)
       if (expression.alternate) {
-        analyzeStatements(expression.alternate.body, scope, analysis, context)
+        analyzeStatements(expression.alternate.body, scope, analysis, branch)
       }
       return
+    }
     case 'FunctionDeclaration':
       analyzeFunction(expression, scope, analysis, context, directLetBinding)
       return

--- a/packages/monkey-minifier/src/types.ts
+++ b/packages/monkey-minifier/src/types.ts
@@ -1,0 +1,192 @@
+export interface Span {
+  start: number
+  end: number
+}
+
+export interface TokenKind {
+  type: string
+  value?: unknown
+}
+
+export interface IdentifierTokenKind extends TokenKind {
+  type: 'IDENTIFIER'
+  value: { name: string }
+}
+
+export interface Token {
+  kind: TokenKind
+  span?: Span
+}
+
+export interface ASTNode {
+  type: string
+  span?: Span
+}
+
+export interface Program extends ASTNode {
+  type: 'Program'
+  body: Statement[]
+}
+
+export interface BlockStatement extends ASTNode {
+  type: 'BlockStatement'
+  body: Statement[]
+}
+
+export interface LetStatement extends ASTNode {
+  type: 'Let'
+  identifier: Token & { kind: IdentifierTokenKind }
+  expr: Expression
+}
+
+export interface ReturnStatement extends ASTNode {
+  type: 'ReturnStatement'
+  argument: Expression
+}
+
+export type MethodKind = 'Constructor' | 'Method'
+
+export interface ClassDeclaration extends ASTNode {
+  type: 'ClassDeclaration'
+  name: Identifier
+  methods: MethodDefinition[]
+}
+
+export interface MethodDefinition extends ASTNode {
+  type: 'MethodDefinition'
+  kind: MethodKind
+  name: Identifier
+  params: Identifier[]
+  body: BlockStatement
+}
+
+export interface SetPropertyStatement extends ASTNode {
+  type: 'SetPropertyStatement'
+  object: Expression
+  property: Identifier
+  value: Expression
+}
+
+export type Statement =
+  | LetStatement
+  | ReturnStatement
+  | ClassDeclaration
+  | SetPropertyStatement
+  | Expression
+
+export interface Identifier extends ASTNode {
+  type: 'IDENTIFIER'
+  name: string
+}
+
+export interface UnaryExpression extends ASTNode {
+  type: 'UnaryExpression'
+  op: Token
+  operand: Expression
+}
+
+export interface BinaryExpression extends ASTNode {
+  type: 'BinaryExpression'
+  op: Token
+  left: Expression
+  right: Expression
+}
+
+export interface IfExpression extends ASTNode {
+  type: 'IF'
+  condition: Expression
+  consequent: BlockStatement
+  alternate?: BlockStatement | null
+}
+
+export interface FunctionDeclaration extends ASTNode {
+  type: 'FunctionDeclaration'
+  params: Identifier[]
+  body: BlockStatement
+  name: string
+}
+
+export interface FunctionCall extends ASTNode {
+  type: 'FunctionCall'
+  callee: Expression
+  arguments: Expression[]
+}
+
+export interface IndexExpression extends ASTNode {
+  type: 'Index'
+  object: Expression
+  index: Expression
+}
+
+export interface ThisExpression extends ASTNode {
+  type: 'ThisExpression'
+}
+
+export interface PropertyExpression extends ASTNode {
+  type: 'PropertyExpression'
+  object: Expression
+  property: Identifier
+}
+
+export interface NewExpression extends ASTNode {
+  type: 'NewExpression'
+  callee: Identifier
+  arguments: Expression[]
+}
+
+export interface IntegerLiteral extends ASTNode {
+  type: 'Integer'
+  raw: string
+}
+
+export interface BooleanLiteral extends ASTNode {
+  type: 'Boolean'
+  raw: boolean
+}
+
+export interface StringLiteral extends ASTNode {
+  type: 'String'
+  raw: string
+}
+
+export interface ArrayLiteral extends ASTNode {
+  type: 'Array'
+  elements: Expression[]
+}
+
+export interface HashLiteral extends ASTNode {
+  type: 'Hash'
+  elements: [Expression, Expression][]
+}
+
+export type Literal =
+  | IntegerLiteral
+  | BooleanLiteral
+  | StringLiteral
+  | ArrayLiteral
+  | HashLiteral
+
+export type Expression =
+  | Identifier
+  | Literal
+  | UnaryExpression
+  | BinaryExpression
+  | IfExpression
+  | FunctionDeclaration
+  | FunctionCall
+  | IndexExpression
+  | ThisExpression
+  | PropertyExpression
+  | NewExpression
+
+export function identifierName(statement: LetStatement): string {
+  return statement.identifier.kind.value.name
+}
+
+export function setIdentifierName(statement: LetStatement, name: string): void {
+  statement.identifier.kind.value.name = name
+}
+
+export function tokenType(token: Token): string {
+  return token.kind.type
+}

--- a/packages/monkey-minifier/test/browser-smoke.mjs
+++ b/packages/monkey-minifier/test/browser-smoke.mjs
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { build } from 'vite'
+import wasm from 'vite-plugin-wasm'
+
+// Exercise the artifact selected by package.json's `browser` field. In
+// particular, the Wasm dependency must remain an ESM import: turning it into a
+// CommonJS require makes bundlers reject its asynchronous Wasm initialization.
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+)
+
+await build({
+  logLevel: 'silent',
+  plugins: [wasm()],
+  build: {
+    write: false,
+    rollupOptions: {
+      input: fileURLToPath(
+        new URL(`../${packageJson.browser}`, import.meta.url)
+      ),
+    },
+  },
+})

--- a/packages/monkey-minifier/test/corpus/classes.monkey
+++ b/packages/monkey-minifier/test/corpus/classes.monkey
@@ -1,0 +1,6 @@
+class Box {
+  constructor(value) { this.value = value; }
+  get() { this.value }
+}
+let box = new Box(42);
+box.get();

--- a/packages/monkey-minifier/test/corpus/core.monkey
+++ b/packages/monkey-minifier/test/corpus/core.monkey
@@ -1,0 +1,5 @@
+let makeAdder = fn(value) {
+  fn(extra) { value + extra }
+};
+let addTwo = makeAdder(2);
+puts(addTwo(40));

--- a/packages/monkey-minifier/test/differential.test.ts
+++ b/packages/monkey-minifier/test/differential.test.ts
@@ -31,6 +31,14 @@ const programs = [
   'let make = fn(longArg) { longArg }; make;',
   // Pins that a removed top-level trailing let never contributed to the result.
   '42; let tail = 5;',
+  // Constant propagation folds this to `print(2);` without observable change.
+  'let a = 1 + 1;\nlet b= a + 1;\nprint(a)',
+  // A conditional let's slot may stay unset; propagation must leave it alone.
+  'let v = 1; if (1 > 2) { let v = 2; }; puts(v);',
+  // A closure keeps observing the pre-redeclaration slot.
+  'let v = 1; let g = fn() { v }; let v = 2; puts(g()); v;',
+  // `new` requires its callee to stay an identifier reference.
+  'let a = 1; let b = new a(); b;',
 ]
 
 describe('GC VM differential semantics', () => {

--- a/packages/monkey-minifier/test/differential.test.ts
+++ b/packages/monkey-minifier/test/differential.test.ts
@@ -21,7 +21,10 @@ const programs = [
    instance.read();`,
   '9223372036854775807 + 2;',
   'puts("before"); 1 / 0;',
+  // DCE must retain every potentially throwing initializer.
   'let unused = 1.missing; 42;',
+  'let unused = [][0]; 42;',
+  'let unused = 1 + true; 42;',
   'let f = fn() { 42; let unused = 1; }; f();',
   'let f = fn() { if (true) { 1; let first = 2; } else { let second = 2; 1; } }; f();',
   'if (true) { 42; let unused = 1; };',

--- a/packages/monkey-minifier/test/differential.test.ts
+++ b/packages/monkey-minifier/test/differential.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { minify } from '../src'
+import { observe } from './helpers'
+
+const programs = [
+  'puts("before"); 40 + 2;',
+  'let value = 1; let read = fn() { value }; let value = 2; puts(read()); value;',
+  'let factorial = fn(n) { if (n == 0) { 1 } else { n * factorial(n - 1) } }; factorial(6);',
+  'let len = fn(value) { value }; len(7);',
+  'let duplicate = fn(value, value) { value }; duplicate(1, 2);',
+  'let outer = 1; if (false) { let branch = 2; } else { branch; };',
+  'let make = fn(value) { fn(extra) { value + extra } }; make(40)(2);',
+  `class VisibleClass {
+     constructor(value) { this.longProperty = value; }
+     read() { fn() { this.longProperty }() }
+   }
+   puts(VisibleClass);
+   let instance = new VisibleClass(42);
+   puts(instance);
+   instance.read();`,
+  '9223372036854775807 + 2;',
+  'puts("before"); 1 / 0;',
+  'let unused = 1.missing; 42;',
+  'let f = fn() { 42; let unused = 1; }; f();',
+  'let f = fn() { if (true) { 1; let first = 2; } else { let second = 2; 1; } }; f();',
+  'if (true) { 42; let unused = 1; };',
+  'if (true) { 1 } else { missing };',
+  'let value = 1; let value = if (true) { fn() { value } } else { fn() { 0 } }; value();',
+]
+
+describe('GC VM differential semantics', () => {
+  it.each(programs)('preserves status/result/stdout for %s', (source) => {
+    const optimized = minify(source).code
+    expect(observe(optimized)).toEqual(observe(source))
+  })
+})

--- a/packages/monkey-minifier/test/differential.test.ts
+++ b/packages/monkey-minifier/test/differential.test.ts
@@ -27,6 +27,10 @@ const programs = [
   'if (true) { 42; let unused = 1; };',
   'if (true) { 1 } else { missing };',
   'let value = 1; let value = if (true) { fn() { value } } else { fn() { 0 } }; value();',
+  // Pins that closures render without their (mangled) parameter names.
+  'let make = fn(longArg) { longArg }; make;',
+  // Pins that a removed top-level trailing let never contributed to the result.
+  '42; let tail = 5;',
 ]
 
 describe('GC VM differential semantics', () => {

--- a/packages/monkey-minifier/test/fold.test.ts
+++ b/packages/monkey-minifier/test/fold.test.ts
@@ -81,3 +81,42 @@ describe('constant folding and conservative DCE', () => {
     expect(optimize('let value = [][0];')).toBe('let value=[][0];')
   })
 })
+
+describe('constant propagation', () => {
+  const optimize = (source: string) =>
+    minify(source, { fold: true, mangle: false }).code
+
+  it('inlines literal bindings through folding to a fixed point', () => {
+    expect(optimize('let a = 1 + 1;\nlet b= a + 1;\nprint(a)')).toBe(
+      'print(2);'
+    )
+    expect(minify('let a = 1 + 1;\nlet b= a + 1;\nprint(a)').code).toBe(
+      'print(2);'
+    )
+    expect(optimize('let a = 2; let b = a; let c = b; c;')).toBe('2;')
+  })
+
+  it('propagates every literal shape', () => {
+    expect(optimize('let n = 0 - 5; n;')).toBe('-5;')
+    expect(optimize('let t = true; t == false;')).toBe('false;')
+    expect(optimize('let s = "hello"; puts(s);')).toBe('puts("hello");')
+  })
+
+  it('keeps a binding when inlined copies would outweigh it', () => {
+    expect(optimize('let s = "hello"; puts(s); puts(s); puts(s);')).toBe(
+      'let s="hello";puts(s);puts(s);puts(s);'
+    )
+  })
+
+  it('leaves conditional lets alone: their slot may never be written', () => {
+    expect(optimize('let v = 1; if (1 > 2) { let v = 2; }; puts(v);')).toBe(
+      'if(false){let v=2;};puts(v);'
+    )
+  })
+
+  it('propagates across a redeclaration: each slot is written once', () => {
+    expect(optimize('let v = 1; let g = fn() { v }; let v = 2; g() + v;')).toBe(
+      'let g=fn(){1;};g()+2;'
+    )
+  })
+})

--- a/packages/monkey-minifier/test/fold.test.ts
+++ b/packages/monkey-minifier/test/fold.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import { minify } from '../src'
+
+describe('constant folding and conservative DCE', () => {
+  const optimize = (source: string) =>
+    minify(source, { fold: true, mangle: false }).code
+
+  it.each([
+    ['40 + 2', '42;'],
+    ['9223372036854775807 + 2', '-9223372036854775807;'],
+    ['"mon" + "key"', '"monkey";'],
+    ['1 < 2 == true', 'true;'],
+    ['!!1', 'true;'],
+    ['if (true) { 1 } else { 2 }', '1;'],
+  ])('folds %s', (source, expected) => {
+    expect(optimize(source)).toBe(expected)
+  })
+
+  it('retains arithmetic errors and unprintable i64::MIN results', () => {
+    expect(optimize('1 / 0')).toBe('1/0;')
+    expect(optimize('9223372036854775807 + 1')).toBe('9223372036854775807+1;')
+    expect(optimize('(-9223372036854775807 - 1) / -1')).toBe(
+      '(-9223372036854775807-1)/-1;'
+    )
+  })
+
+  it('only folds if branches that do not alter compiler scope', () => {
+    const code = optimize('if (true) { 1 } else { let value = 2; value }')
+    expect(code).toContain('if(true)')
+    expect(code).toContain('let value=2')
+  })
+
+  it('does not hide diagnostics in an unselected branch', () => {
+    expect(optimize('if (true) { 1 } else { missing };')).toBe(
+      'if(true){1;}else{missing;};'
+    )
+  })
+
+  it('does not turn an indirectly assigned function into a recursive one', () => {
+    expect(
+      optimize(
+        'let value = 1; let value = if (true) { fn() { value } } else { fn() { 0 } }; value();'
+      )
+    ).toContain('if(true)')
+  })
+
+  it('deletes pure unused lets to a fixed point', () => {
+    expect(optimize('let first = 1; let second = first; 42;')).toBe('42;')
+    expect(optimize('let helper = fn(x) { puts(x) }; 0;')).toBe('0;')
+  })
+
+  it('keeps trailing lets that determine block value semantics', () => {
+    expect(optimize('let f = fn() { 42; let unused = 1; }; f();')).toBe(
+      'let f=fn(){42;let unused=1;};f();'
+    )
+    expect(optimize('if (true) { 42; let unused = 1; };')).toBe(
+      'if(true){42;let unused=1;};'
+    )
+  })
+
+  it('keeps a stack-sensitive callable local layout intact', () => {
+    const source = `
+      let f = fn() {
+        if (true) { 1; let first = 2; }
+        else { let second = 2; 1; }
+      };
+      f();
+    `
+    expect(optimize(source)).toBe(
+      'let f=fn(){if(true){1;let first=2;}else{let second=2;1;};};f();'
+    )
+  })
+
+  it('retains effectful and potentially throwing initializers', () => {
+    expect(optimize('let value = puts("visible");')).toBe(
+      'let value=puts("visible");'
+    )
+    expect(optimize('let value = 1 / 0;')).toBe('let value=1/0;')
+    expect(optimize('let value = 1.missing;')).toBe('let value=1.missing;')
+    expect(optimize('let value = [][0];')).toBe('let value=[][0];')
+  })
+})

--- a/packages/monkey-minifier/test/helpers.ts
+++ b/packages/monkey-minifier/test/helpers.ts
@@ -1,0 +1,64 @@
+import {
+  compile_to_snapshot,
+  parse_lossless,
+  run_snapshot_with_output,
+} from '@gengjiawen/monkey-wasm'
+
+import type { Program } from '../src/types'
+
+export function parseProgram(source: string): Program {
+  const root = JSON.parse(parse_lossless(source)) as { Program: Program }
+  return root.Program
+}
+
+export function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonical)
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => key !== 'span' && key !== 'comments')
+        .map(([key, child]) => [key, canonical(child)])
+    )
+  }
+  return value
+}
+
+interface Observable {
+  status: 'ok' | 'error'
+  result?: string
+  stage?: string
+  kind?: string
+  stdout: string
+}
+
+export function observe(source: string): Observable {
+  const built = JSON.parse(compile_to_snapshot(source, false)) as {
+    status: 'ok' | 'error'
+    bytesHex?: string
+    stage?: string
+    kind?: string
+  }
+  if (built.status === 'error') {
+    return {
+      status: 'error',
+      stage: built.stage,
+      kind: built.kind,
+      stdout: '',
+    }
+  }
+  const bytes = Uint8Array.from(
+    built.bytesHex!.match(/../g)!.map((byte) => Number.parseInt(byte, 16))
+  )
+  const run = JSON.parse(run_snapshot_with_output(bytes)) as Observable
+  if (run.status === 'ok') {
+    return { status: 'ok', result: run.result, stdout: run.stdout }
+  }
+  return {
+    status: 'error',
+    stage: run.stage,
+    kind: run.kind,
+    stdout: run.stdout,
+  }
+}

--- a/packages/monkey-minifier/test/mangle.test.ts
+++ b/packages/monkey-minifier/test/mangle.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { minify } from '../src'
+
+describe('binding-aware mangling', () => {
+  const mangleOnly = (source: string) =>
+    minify(source, { fold: false, mangle: true }).code
+
+  it('tracks source-ordered rebinding and RHS lookup', () => {
+    expect(mangleOnly('let value = 1; let value = value + 1; value;')).toBe(
+      'let a=1;let b=a+1;b;'
+    )
+  })
+
+  it('keeps recursive function metadata in sync with its let binding', () => {
+    const code = mangleOnly(
+      'let recurse = fn(number) { if (number == 0) { 0 } else { recurse(number - 1) } }; recurse(2);'
+    )
+    expect(code).not.toContain('recurse')
+    expect(() => minify(code, { fold: false, mangle: false })).not.toThrow()
+  })
+
+  it('supports builtin shadowing and reserved names', () => {
+    expect(mangleOnly('let len = fn(value) { value }; len(1);')).not.toContain(
+      'let len'
+    )
+    expect(
+      minify('let publicName = 1; publicName;', {
+        fold: false,
+        mangle: { reserved: ['publicName'] },
+      }).code
+    ).toBe('let publicName=1;publicName;')
+  })
+
+  it('never mangles class, property, or method names', () => {
+    const code = mangleOnly(`
+      class VeryLongClass {
+        constructor(longValue) { this.longProperty = longValue; }
+        longMethod() { this.longProperty }
+      }
+      let longInstance = new VeryLongClass(1);
+      longInstance.longMethod();
+    `)
+    expect(code).toContain('class VeryLongClass')
+    expect(code).toContain('new VeryLongClass')
+    expect(code).toContain('.longProperty')
+    expect(code).toContain('.longMethod')
+    expect(code).not.toContain('longInstance')
+    expect(code).not.toContain('longValue')
+  })
+
+  it('does not capture unresolved external names', () => {
+    const code = mangleOnly('let longName = external; longName;')
+    expect(code).toContain('external')
+    expect(code).not.toContain('let external=')
+  })
+})

--- a/packages/monkey-minifier/test/node-entry.test.ts
+++ b/packages/monkey-minifier/test/node-entry.test.ts
@@ -4,7 +4,7 @@ import { minify, parseProgram } from '../src/node'
 
 describe('Node entrypoint', () => {
   it('loads the bundler-target Wasm package without native Wasm imports', () => {
-    expect(minify('let longName = 40 + 2; longName;').code).toBe('let a=42;a;')
+    expect(minify('let longName = 40 + 2; longName;').code).toBe('42;')
     expect(parseProgram('9007199254740993').body[0]).toMatchObject({
       type: 'Integer',
       raw: '9007199254740993',

--- a/packages/monkey-minifier/test/node-entry.test.ts
+++ b/packages/monkey-minifier/test/node-entry.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { minify, parseProgram } from '../src/node'
+
+describe('Node entrypoint', () => {
+  it('loads the bundler-target Wasm package without native Wasm imports', () => {
+    expect(minify('let longName = 40 + 2; longName;').code).toBe('let a=42;a;')
+    expect(parseProgram('9007199254740993').body[0]).toMatchObject({
+      type: 'Integer',
+      raw: '9007199254740993',
+    })
+  })
+})

--- a/packages/monkey-minifier/test/node-smoke.cjs
+++ b/packages/monkey-minifier/test/node-smoke.cjs
@@ -1,0 +1,6 @@
+const assert = require('node:assert/strict')
+
+const { minify, parseProgram } = require('..')
+
+assert.equal(minify('let longName = 40 + 2; longName;').code, 'let a=42;a;')
+assert.equal(parseProgram('9007199254740993').body[0].raw, '9007199254740993')

--- a/packages/monkey-minifier/test/node-smoke.cjs
+++ b/packages/monkey-minifier/test/node-smoke.cjs
@@ -2,5 +2,5 @@ const assert = require('node:assert/strict')
 
 const { minify, parseProgram } = require('..')
 
-assert.equal(minify('let longName = 40 + 2; longName;').code, 'let a=42;a;')
+assert.equal(minify('let longName = 40 + 2; longName;').code, '42;')
 assert.equal(parseProgram('9007199254740993').body[0].raw, '9007199254740993')

--- a/packages/monkey-minifier/test/package.test.ts
+++ b/packages/monkey-minifier/test/package.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+type PackageJson = {
+  version: string
+  dependencies: Record<string, string>
+}
+
+function readPackageJson(url: URL) {
+  return JSON.parse(readFileSync(url, 'utf8')) as PackageJson
+}
+
+describe('package metadata', () => {
+  it('keeps the minifier on the same release line as its Wasm API', () => {
+    const rootPackage = readPackageJson(
+      new URL('../../../package.json', import.meta.url)
+    )
+    const minifierPackage = readPackageJson(
+      new URL('../package.json', import.meta.url)
+    )
+    const playgroundPackage = readPackageJson(
+      new URL('../../playground/package.json', import.meta.url)
+    )
+    const wasmRange = minifierPackage.dependencies['@gengjiawen/monkey-wasm']
+
+    expect(minifierPackage.version).toBe(rootPackage.version)
+    expect(wasmRange.replace(/^workspace:/, '')).toBe(
+      `^${minifierPackage.version}`
+    )
+    expect(playgroundPackage.dependencies['@gengjiawen/monkey-minifier']).toBe(
+      `workspace:^${minifierPackage.version}`
+    )
+  })
+})

--- a/packages/monkey-minifier/test/printer.test.ts
+++ b/packages/monkey-minifier/test/printer.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { minify } from '../src'
+
+describe('compact printer', () => {
+  const print = (source: string) =>
+    minify(source, { fold: false, mangle: false }).code
+
+  it.each([
+    ['1 + 2 * 3', '1+2*3;'],
+    ['(1 + 2) * 3', '(1+2)*3;'],
+    ['1 - (2 - 3)', '1-(2-3);'],
+    ['(1 - 2) - 3', '1-2-3;'],
+    ['-(a + b)', '-(a+b);'],
+    ['-a[0]', '-a[0];'],
+    ['a - -b', 'a--b;'],
+    ['if (true) { 1 } else { 2 }', 'if(true){1;}else{2;};'],
+    ['fn(x, y) { return x + y }', 'fn(x,y){return x+y;};'],
+    ['(fn(x) { x })(1)', '(fn(x){x;})(1);'],
+    ['{"a": [1, 2], true: {}}', '{"a":[1,2],true:{}};'],
+    ['new Thing(1).value[0]', 'new Thing(1).value[0];'],
+  ])('prints %s', (source, expected) => {
+    expect(print(source)).toBe(expected)
+  })
+
+  it('separates statements and does not append a semicolon to classes', () => {
+    expect(
+      print(
+        'class Box { constructor(value) { this.value = value } get() { this.value } } let box = new Box(1); box.get()'
+      )
+    ).toBe(
+      'class Box{constructor(value){this.value=value;}get(){this.value;}}let box=new Box(1);box.get();'
+    )
+  })
+
+  it('preserves lossless integer and string spelling', () => {
+    expect(print('9007199254740993; 9223372036854775807; "line\nbreak"')).toBe(
+      '9007199254740993;9223372036854775807;"line\nbreak";'
+    )
+  })
+})

--- a/packages/monkey-minifier/test/roundtrip.test.ts
+++ b/packages/monkey-minifier/test/roundtrip.test.ts
@@ -9,6 +9,7 @@ import {
   minify,
   printProgram,
 } from '../src'
+import { propagateConstants } from '../src/propagate'
 import { canonical, parseProgram } from './helpers'
 
 const corpus = [
@@ -38,6 +39,9 @@ describe('structural round trip', () => {
     (source) => {
       const transformed = parseProgram(source)
       foldConstants(transformed)
+      while (propagateConstants(transformed)) {
+        foldConstants(transformed)
+      }
       eliminateDeadLets(transformed)
       mangle(transformed)
       const reparsed = parseProgram(printProgram(transformed))

--- a/packages/monkey-minifier/test/roundtrip.test.ts
+++ b/packages/monkey-minifier/test/roundtrip.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  eliminateDeadLets,
+  foldConstants,
+  mangle,
+  minify,
+  printProgram,
+} from '../src'
+import { canonical, parseProgram } from './helpers'
+
+const corpus = [
+  readFileSync(new URL('./corpus/core.monkey', import.meta.url), 'utf8'),
+  readFileSync(new URL('./corpus/classes.monkey', import.meta.url), 'utf8'),
+  readFileSync(
+    new URL('../../../examples/hello.monkey', import.meta.url),
+    'utf8'
+  ),
+  'let value = 1 + 2 * 3; value;',
+  'let choose = fn(flag, left, right) { if (flag) { left } else { right } }; choose(true, 1, 2);',
+  'let data = [1, 9007199254740993, {"key": true}]; data[2]["key"];',
+  'class Box { constructor(value) { this.value = value; } get() { this.value } } let box = new Box(42); box.get();',
+  'let make = fn(x) { fn(y) { x + y } }; make(1)(2);',
+]
+
+describe('structural round trip', () => {
+  it.each(corpus)('preserves the lossless AST for %s', (source) => {
+    const code = minify(source, { fold: false, mangle: false }).code
+    expect(canonical(parseProgram(code))).toEqual(
+      canonical(parseProgram(source))
+    )
+  })
+
+  it.each(corpus)(
+    'prints every transformed AST without structural drift for %s',
+    (source) => {
+      const transformed = parseProgram(source)
+      foldConstants(transformed)
+      eliminateDeadLets(transformed)
+      mangle(transformed)
+      const reparsed = parseProgram(printProgram(transformed))
+      expect(canonical(reparsed)).toEqual(canonical(transformed))
+    }
+  )
+
+  it('is idempotent for every pass combination', () => {
+    const source = `
+      let unused = 10 + 20;
+      let longFunction = fn(longArgument) { longArgument + 1 };
+      longFunction(41);
+    `
+    for (const options of [
+      { fold: false, mangle: false },
+      { fold: false, mangle: true },
+      { fold: true, mangle: false },
+      { fold: true, mangle: true },
+    ]) {
+      const once = minify(source, options).code
+      expect(minify(once, options).code).toBe(once)
+    }
+  })
+
+  it('reports parser failures as SyntaxError', () => {
+    expect(() => minify('let =')).toThrow(SyntaxError)
+  })
+})

--- a/packages/monkey-minifier/tsconfig.json
+++ b/packages/monkey-minifier/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/monkey-minifier/vitest.config.ts
+++ b/packages/monkey-minifier/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+import wasm from 'vite-plugin-wasm'
+
+export default defineConfig({
+  plugins: [wasm()],
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -16,6 +16,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.1",
+    "@gengjiawen/monkey-minifier": "workspace:^1.1.0",
     "@gengjiawen/monkey-wasm": "workspace:^1.1.0",
     "@lezer/highlight": "^1.2.1",
     "@radix-ui/themes": "^3.3.0",

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -40,6 +40,15 @@ print(a)
 `.trimStart(),
   },
   {
+    // The Minify view folds this whole program down to `print(2);`.
+    label: 'Constant folding',
+    code: `
+let a = 1 + 1;
+let b = a + 1;
+print(a)
+`.trimStart(),
+  },
+  {
     label: 'Functions',
     code: `
 let add = fn(a, b) { a + b };

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -40,15 +40,6 @@ print(a)
 `.trimStart(),
   },
   {
-    // The Minify view folds this whole program down to `print(2);`.
-    label: 'Constant folding',
-    code: `
-let a = 1 + 1;
-let b = a + 1;
-print(a)
-`.trimStart(),
-  },
-  {
     label: 'Functions',
     code: `
 let add = fn(a, b) { a + b };
@@ -109,6 +100,15 @@ let makeCycle = fn() {
 };
 
 makeCycle();
+`.trimStart(),
+  },
+  {
+    // The Minify view folds this whole program down to `print(2);`.
+    label: 'Constant folding',
+    code: `
+let a = 1 + 1;
+let b = a + 1;
+print(a)
 `.trimStart(),
   },
 ]

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button, SegmentedControl, Select } from '@radix-ui/themes'
+import { Button, SegmentedControl, Select, Switch } from '@radix-ui/themes'
 import { compile_with_debug, parse } from '@gengjiawen/monkey-wasm'
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
@@ -17,6 +17,7 @@ import { Editor, type EditorHandle } from './Editor'
 import { GcReportView, type GcPanelState } from './GcReportView'
 import type { SourceSpan } from './gcReport'
 import { runGc } from './gcRunner'
+import { MinifyView, type MinifyState, utf8Bytes } from './MinifyView'
 import { utf16OffsetToUtf8Byte, utf8ByteSpanToUtf16 } from './sourceSpan'
 import {
   SnapshotView,
@@ -103,7 +104,7 @@ makeCycle();
   },
 ]
 
-type OutputView = 'ast' | 'bytecode' | 'gc' | 'snapshot' | 'arm64'
+type OutputView = 'ast' | 'bytecode' | 'gc' | 'snapshot' | 'arm64' | 'minify'
 
 const panelClass =
   'flex min-h-0 min-w-0 h-full flex-col overflow-hidden bg-(--color-background)'
@@ -153,6 +154,12 @@ function App() {
   const [arm64Build, setArm64Build] = useState<Arm64BuildState>({
     status: 'idle',
   })
+  const [minifyState, setMinifyState] = useState<MinifyState>({
+    status: 'idle',
+  })
+  const [mangleNames, setMangleNames] = useState(true)
+  const minifyRequestId = useRef(0)
+  const minifyActive = useRef(false)
   const editorRef = useRef<EditorHandle>(null)
   const arm64EditorRef = useRef<EditorHandle>(null)
   const latestCode = useRef(code)
@@ -245,6 +252,42 @@ function App() {
     [compileArm64]
   )
 
+  const minifyCode = useCallback(
+    async (source: string, shouldMangle: boolean, requestId: number) => {
+      try {
+        const { minify } = await import('../../monkey-minifier/src/index')
+        const result = minify(source, { mangle: shouldMangle })
+        if (
+          minifyRequestId.current !== requestId ||
+          latestCode.current !== source ||
+          !minifyActive.current
+        ) {
+          return
+        }
+        setMinifyState({
+          status: 'ok',
+          code: result.code,
+          originalBytes: utf8Bytes(source),
+          minifiedBytes: utf8Bytes(result.code),
+        })
+      } catch (error) {
+        if (
+          minifyRequestId.current === requestId &&
+          latestCode.current === source &&
+          minifyActive.current
+        ) {
+          setMinifyState({
+            status: 'invalid',
+            message: getErrorMessage(error),
+          })
+        }
+      }
+    },
+    []
+  )
+
+  const debouncedMinify = useMemo(() => debounce(minifyCode, 200), [minifyCode])
+
   const editorOnChange = useCallback(
     (value: string) => {
       // CodeMirror reports a document change even when the replacement text is
@@ -255,12 +298,27 @@ function App() {
         return
       }
       setCode(value)
+      minifyRequestId.current += 1
       gcRequestId.current += 1
       setGcState({ status: 'idle' })
       invalidateSnapshot()
     },
     [code, invalidateSnapshot]
   )
+
+  const handleOutputViewChange = useCallback((value: string) => {
+    const nextView = value as OutputView
+    if (nextView !== 'minify') {
+      minifyActive.current = false
+      minifyRequestId.current += 1
+    }
+    setOutputView(nextView)
+  }, [])
+
+  const handleMangleChange = useCallback((checked: boolean) => {
+    minifyRequestId.current += 1
+    setMangleNames(checked)
+  }, [])
 
   const handleStripDebugChange = useCallback(
     (nextStripDebug: boolean) => {
@@ -293,6 +351,7 @@ function App() {
         return
       }
       setCode(formatted)
+      minifyRequestId.current += 1
       setSelection(null)
       gcRequestId.current += 1
       setGcState({ status: 'idle' })
@@ -335,6 +394,20 @@ function App() {
   }, [code, debouncedArm64Compile, outputView])
 
   useEffect(() => {
+    minifyActive.current = outputView === 'minify'
+    minifyRequestId.current += 1
+    const requestId = minifyRequestId.current
+    if (outputView !== 'minify') {
+      debouncedMinify.cancel()
+      return
+    }
+
+    setMinifyState({ status: 'idle' })
+    debouncedMinify(code, mangleNames, requestId)
+    return () => debouncedMinify.cancel()
+  }, [code, debouncedMinify, mangleNames, outputView])
+
+  useEffect(() => {
     const index = Math.min(Math.max(snippetIndex, 0), snippets.length - 1)
     if (index !== snippetIndex) {
       setSnippetIndex(index)
@@ -343,12 +416,15 @@ function App() {
     gcRequestId.current += 1
     setGcState({ status: 'idle' })
     invalidateSnapshot()
+    minifyRequestId.current += 1
     setCode(snippets[index].code)
   }, [invalidateSnapshot, snippetIndex, setSnippetIndex])
 
   useEffect(
     () => () => {
       gcRequestId.current += 1
+      minifyActive.current = false
+      minifyRequestId.current += 1
     },
     []
   )
@@ -561,7 +637,7 @@ function App() {
             className="max-w-full min-w-0!"
             size="2"
             value={outputView}
-            onValueChange={(value) => setOutputView(value as OutputView)}
+            onValueChange={handleOutputViewChange}
           >
             <SegmentedControl.Item value="ast">AST</SegmentedControl.Item>
             <SegmentedControl.Item value="bytecode">
@@ -572,6 +648,7 @@ function App() {
               Snapshot
             </SegmentedControl.Item>
             <SegmentedControl.Item value="arm64">ARM64</SegmentedControl.Item>
+            <SegmentedControl.Item value="minify">Minify</SegmentedControl.Item>
           </SegmentedControl.Root>
           {outputView === 'gc' ? (
             <Button
@@ -591,6 +668,20 @@ function App() {
             >
               Run snapshot
             </Button>
+          ) : null}
+          {outputView === 'minify' ? (
+            <label
+              htmlFor="mangle-names"
+              className="flex items-center gap-2 text-xs text-(--gray-11)"
+            >
+              <Switch
+                id="mangle-names"
+                size="1"
+                checked={mangleNames}
+                onCheckedChange={handleMangleChange}
+              />
+              Mangle names
+            </label>
           ) : null}
         </div>
         <div className={editorFrameClass}>
@@ -631,6 +722,7 @@ function App() {
               onErrorSpanSelect={handleErrorSpanSelect}
             />
           ) : null}
+          {outputView === 'minify' ? <MinifyView state={minifyState} /> : null}
           {outputView === 'bytecode' ||
           (outputView === 'ast' && astData === null) ? (
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/packages/playground/src/Editor.tsx
+++ b/packages/playground/src/Editor.tsx
@@ -139,6 +139,7 @@ interface EditorProps {
   onSelectionChange?: (selection: { from: number; to: number }) => void
   vimMode?: boolean
   fill?: boolean
+  lineWrapping?: boolean
 }
 
 export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
@@ -149,6 +150,7 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     onSelectionChange,
     vimMode = true,
     fill = false,
+    lineWrapping = false,
   },
   ref
 ) {
@@ -185,11 +187,14 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     if (vimMode) {
       next.push(vim())
     }
+    if (lineWrapping) {
+      next.push(EditorView.lineWrapping)
+    }
     if (extraExtensions) {
       next.push(...extraExtensions)
     }
     return next
-  }, [extraExtensions, vimMode])
+  }, [extraExtensions, lineWrapping, vimMode])
 
   const handleCreateEditor = useCallback(
     (

--- a/packages/playground/src/MinifyView.tsx
+++ b/packages/playground/src/MinifyView.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Editor } from './Editor'
+
+export type MinifyState =
+  | { status: 'idle' }
+  | {
+      status: 'ok'
+      code: string
+      originalBytes: number
+      minifiedBytes: number
+    }
+  | { status: 'invalid'; message: string }
+
+interface MinifyViewProps {
+  state: MinifyState
+}
+
+const mutedClass = 'text-xs text-(--gray-10)'
+const alertClass =
+  'm-0 rounded-md border border-(--red-a6) bg-(--red-a3) px-3 py-2 text-sm text-(--red-11)'
+
+export function utf8Bytes(text: string): number {
+  return new TextEncoder().encode(text).byteLength
+}
+
+export function MinifyView({ state }: MinifyViewProps) {
+  if (state.status === 'idle') {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto bg-(--gray-1) p-4.5">
+        <output className={`${mutedClass} block`}>Minifying…</output>
+      </div>
+    )
+  }
+
+  if (state.status === 'invalid') {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto bg-(--gray-1) p-4.5">
+        <p role="alert" className={alertClass}>
+          {state.message}
+        </p>
+      </div>
+    )
+  }
+
+  const saved = state.originalBytes - state.minifiedBytes
+  const percentage =
+    state.originalBytes === 0 ? 0 : (saved / state.originalBytes) * 100
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-(--gray-a5) bg-(--color-background) px-3 py-2">
+        <output aria-label="Minified byte statistics" className={mutedClass}>
+          {state.originalBytes} → {state.minifiedBytes} UTF-8 bytes ·{' '}
+          {percentage >= 0 ? 'saved' : 'grew'} {Math.abs(percentage).toFixed(1)}
+          %
+        </output>
+      </div>
+      <Editor
+        code={state.code}
+        extra={{ readOnly: true, editable: false }}
+        vimMode={false}
+        fill
+      />
+    </div>
+  )
+}

--- a/packages/playground/src/MinifyView.tsx
+++ b/packages/playground/src/MinifyView.tsx
@@ -61,6 +61,7 @@ export function MinifyView({ state }: MinifyViewProps) {
         extra={{ readOnly: true, editable: false }}
         vimMode={false}
         fill
+        lineWrapping
       />
     </div>
   )

--- a/packages/playground/src/test/App.test.tsx
+++ b/packages/playground/src/test/App.test.tsx
@@ -32,6 +32,7 @@ const {
   highlightRangesMock,
   clearHighlightMock,
   formatMock,
+  minifyMock,
   sourceEditorHooks,
   outputEditorHooks,
 } = vi.hoisted(() => ({
@@ -52,6 +53,7 @@ const {
   highlightRangesMock: vi.fn(),
   clearHighlightMock: vi.fn(),
   formatMock: vi.fn(),
+  minifyMock: vi.fn(),
   // The mock editor below is a plain <textarea>, which cannot reproduce every
   // CodeMirror callback: change events whose text equals the current document,
   // or cursor movements. Tests drive those callbacks through these hooks.
@@ -91,6 +93,10 @@ vi.mock('prettier/standalone', () => ({
 
 vi.mock('../../../prettier-plugin-monkey/src/index', () => ({
   default: {},
+}))
+
+vi.mock('../../../monkey-minifier/src/index', () => ({
+  minify: minifyMock,
 }))
 
 interface MockEditorProps {
@@ -411,6 +417,8 @@ beforeEach(() => {
   buildArm64Mock.mockImplementation(() => arm64Envelope())
   formatMock.mockReset()
   formatMock.mockImplementation(async (source: string) => source)
+  minifyMock.mockReset()
+  minifyMock.mockImplementation(() => ({ code: '1;' }))
   highlightRangeMock.mockClear()
   highlightRangesMock.mockClear()
   clearHighlightMock.mockClear()
@@ -1249,5 +1257,61 @@ describe('ARM64 view', () => {
       { from: 6, to: 18 },
       { from: 25, to: 30 },
     ])
+  })
+})
+
+describe('Minify view', () => {
+  it('minifies only while active, reports UTF-8 bytes, and toggles mangling', async () => {
+    const user = userEvent.setup()
+    minifyMock.mockImplementation(() => ({ code: '中;' }))
+    renderApp()
+
+    expect(minifyMock).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('radio', { name: 'Minify' }))
+
+    await waitFor(() => expect(minifyMock).toHaveBeenCalledTimes(1))
+    expect(screen.getByLabelText('Minified byte statistics')).toHaveTextContent(
+      '→ 4 UTF-8 bytes'
+    )
+    expect(screen.getByLabelText('Output editor')).toHaveValue('中;')
+
+    await user.click(screen.getByRole('switch', { name: 'Mangle names' }))
+    await waitFor(() =>
+      expect(minifyMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({ mangle: false })
+      )
+    )
+
+    const calls = minifyMock.mock.calls.length
+    await user.click(screen.getByRole('radio', { name: 'AST' }))
+    await user.type(screen.getByLabelText('Source editor'), 'x')
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    expect(minifyMock).toHaveBeenCalledTimes(calls)
+  })
+
+  it('keeps only the latest debounced source and displays errors', async () => {
+    const user = userEvent.setup()
+    renderApp()
+    await user.click(screen.getByRole('radio', { name: 'Minify' }))
+    await waitFor(() => expect(minifyMock).toHaveBeenCalled())
+
+    minifyMock.mockClear()
+    const editor = screen.getByLabelText('Source editor')
+    await user.clear(editor)
+    await user.type(editor, '1 + 2')
+    await waitFor(() => expect(minifyMock).toHaveBeenCalledTimes(1))
+    expect(minifyMock).toHaveBeenLastCalledWith(
+      '1 + 2',
+      expect.objectContaining({ mangle: true })
+    )
+
+    minifyMock.mockImplementationOnce(() => {
+      throw new SyntaxError('bad Monkey source')
+    })
+    await user.type(editor, ';')
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'bad Monkey source'
+    )
   })
 })

--- a/packages/playground/src/test/MinifyView.test.tsx
+++ b/packages/playground/src/test/MinifyView.test.tsx
@@ -1,0 +1,38 @@
+import { Theme } from '@radix-ui/themes'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MinifyView, utf8Bytes } from '../MinifyView'
+
+afterEach(cleanup)
+
+describe('MinifyView', () => {
+  it('counts UTF-8 bytes rather than UTF-16 code units', () => {
+    expect(utf8Bytes('中;')).toBe(4)
+  })
+
+  it('renders byte savings and parser failures', () => {
+    const { rerender } = render(
+      <Theme>
+        <MinifyView
+          state={{
+            status: 'ok',
+            code: '中;',
+            originalBytes: 8,
+            minifiedBytes: 4,
+          }}
+        />
+      </Theme>
+    )
+    expect(screen.getByLabelText('Minified byte statistics')).toHaveTextContent(
+      '8 → 4 UTF-8 bytes · saved 50.0%'
+    )
+
+    rerender(
+      <Theme>
+        <MinifyView state={{ status: 'invalid', message: 'parse failed' }} />
+      </Theme>
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent('parse failed')
+  })
+})

--- a/packages/playground/src/test/MinifyView.test.tsx
+++ b/packages/playground/src/test/MinifyView.test.tsx
@@ -12,7 +12,7 @@ describe('MinifyView', () => {
   })
 
   it('renders byte savings and parser failures', () => {
-    const { rerender } = render(
+    const { container, rerender } = render(
       <Theme>
         <MinifyView
           state={{
@@ -27,6 +27,11 @@ describe('MinifyView', () => {
     expect(screen.getByLabelText('Minified byte statistics')).toHaveTextContent(
       '8 → 4 UTF-8 bytes · saved 50.0%'
     )
+    // Minified output is one long line; the pane wraps it instead of
+    // requiring horizontal scrolling.
+    expect(
+      container.querySelector('.cm-content.cm-lineWrapping')
+    ).not.toBeNull()
 
     rerender(
       <Theme>

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -45,12 +45,14 @@ async function createWasmBindings(): Promise<MonkeyWasm> {
 
   return {
     parse: bindings.parse,
+    parse_lossless: bindings.parse_lossless,
     compile: bindings.compile,
     compile_detail: bindings.compile_detail,
     compile_with_debug: bindings.compile_with_debug,
     run_gc_with_report: bindings.run_gc_with_report,
     compile_to_snapshot: bindings.compile_to_snapshot,
     run_snapshot: bindings.run_snapshot,
+    run_snapshot_with_output: bindings.run_snapshot_with_output,
     compile_to_arm64: bindings.compile_to_arm64,
   }
 }

--- a/parser/lib.rs
+++ b/parser/lib.rs
@@ -799,3 +799,36 @@ pub fn parse_ast_json_string(input: &str) -> Result<String, ParseErrors> {
 
     return Ok(ast);
 }
+
+/// Serialize the parser AST without routing i64 integer literals through a
+/// JavaScript `number`. The JSON shape otherwise stays identical to
+/// [`parse_ast_json_string`].
+pub fn parse_ast_lossless_json_string(input: &str) -> Result<String, ParseErrors> {
+    let node = parse(input)?;
+    let mut ast = serde_json::to_value(&node).expect("AST serialization should not fail");
+    stringify_integer_literals(&mut ast);
+    Ok(serde_json::to_string_pretty(&ast).expect("AST serialization should not fail"))
+}
+
+fn stringify_integer_literals(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                stringify_integer_literals(value);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            if object.get("type").and_then(serde_json::Value::as_str) == Some("Integer") {
+                if let Some(raw) = object.get_mut("raw") {
+                    if let Some(integer) = raw.as_i64() {
+                        *raw = serde_json::Value::String(integer.to_string());
+                    }
+                }
+            }
+            for value in object.values_mut() {
+                stringify_integer_literals(value);
+            }
+        }
+        _ => {}
+    }
+}

--- a/parser/parser_test.rs
+++ b/parser/parser_test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::ast::{Expression, MethodKind, Node, Statement};
-    use crate::parse;
+    use crate::{parse, parse_ast_lossless_json_string};
 
     fn verify_program(test_cases: &[(&str, &str)]) {
         for (input, expected) in test_cases {
@@ -251,5 +251,20 @@ connect();"#;
                 errors
             );
         }
+    }
+
+    #[test]
+    fn lossless_json_stringifies_every_integer_literal() {
+        let json = parse_ast_lossless_json_string(
+            r#"let large = 9007199254740993; [9223372036854775807, {1: 2}];"#,
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        let program = &value["Program"];
+        assert_eq!(program["body"][0]["expr"]["raw"], "9007199254740993");
+        assert_eq!(program["body"][1]["elements"][0]["raw"], "9223372036854775807");
+        assert_eq!(program["body"][1]["elements"][1]["elements"][0][0]["raw"], "1");
+        assert_eq!(program["body"][1]["elements"][1]["elements"][0][1]["raw"], "2");
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,31 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
 
+  packages/monkey-minifier:
+    dependencies:
+      '@gengjiawen/monkey-wasm':
+        specifier: ^1.1.0
+        version: link:../../wasm/pkg
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.24
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.0.4
+      vite:
+        specifier: ^8.1.4
+        version: 8.1.4(@types/node@20.19.24)(esbuild@0.28.0)(jiti@2.7.0)
+      vite-plugin-wasm:
+        specifier: ^3.6.0
+        version: 3.6.0(vite@8.1.4(@types/node@20.19.24)(esbuild@0.28.0)(jiti@2.7.0))
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.24)(jsdom@29.1.1)(vite@8.1.4(@types/node@20.19.24)(esbuild@0.28.0)(jiti@2.7.0))
+
   packages/playground:
     dependencies:
       '@codemirror/commands':
@@ -47,6 +72,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.43.1
         version: 6.43.1
+      '@gengjiawen/monkey-minifier':
+        specifier: workspace:^1.1.0
+        version: link:../monkey-minifier
       '@gengjiawen/monkey-wasm':
         specifier: workspace:^1.1.0
         version: link:../../wasm/pkg

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
   packages/monkey-minifier:
     dependencies:
       '@gengjiawen/monkey-wasm':
-        specifier: ^1.1.0
+        specifier: workspace:^1.1.0
         version: link:../../wasm/pkg
     devDependencies:
       '@types/node':

--- a/scripts/bump_cargo_packages.ts
+++ b/scripts/bump_cargo_packages.ts
@@ -82,17 +82,28 @@ const bump_cmd = `cargo workspaces version custom ${nextVersion} --no-git-commit
 console.log(bump_cmd)
 execSync(bump_cmd)
 
-// Also bump playground dependency on @gengjiawen/monkey-wasm
+// Also bump playground dependencies on the versioned Monkey packages.
 try {
   const playgroundPkgPath = repoPath('packages', 'playground', 'package.json')
   const playground = readPackageJson(playgroundPkgPath)
-  const changed = syncDependencyRange(
-    playground,
-    'playground',
-    '@gengjiawen/monkey-wasm',
-    `workspace:^${nextVersion}`
-  )
-  if (changed) {
+  let playgroundChanged = false
+
+  playgroundChanged =
+    syncDependencyRange(
+      playground,
+      'playground',
+      '@gengjiawen/monkey-wasm',
+      `workspace:^${nextVersion}`
+    ) || playgroundChanged
+  playgroundChanged =
+    syncDependencyRange(
+      playground,
+      'playground',
+      '@gengjiawen/monkey-minifier',
+      `workspace:^${nextVersion}`
+    ) || playgroundChanged
+
+  if (playgroundChanged) {
     writePackageJson(playgroundPkgPath, playground)
   }
 } catch (e) {
@@ -125,6 +136,37 @@ try {
   }
 } catch (e) {
   console.warn('Failed to update prettier-plugin-monkey dependency:', e)
+}
+
+// Also keep monkey-minifier package version and wasm dependency in sync.
+// The repository uses workspace: during development, while release PRs must
+// contain a registry-compatible range because npm publish preserves
+// workspace: specifiers verbatim.
+try {
+  const minifierPkgPath = repoPath(
+    'packages',
+    'monkey-minifier',
+    'package.json'
+  )
+  const minifier = readPackageJson(minifierPkgPath)
+  let minifierChanged = false
+
+  minifierChanged =
+    syncPackageVersion(minifier, 'monkey-minifier', nextVersion) ||
+    minifierChanged
+  minifierChanged =
+    syncDependencyRange(
+      minifier,
+      'monkey-minifier',
+      '@gengjiawen/monkey-wasm',
+      `^${nextVersion}`
+    ) || minifierChanged
+
+  if (minifierChanged) {
+    writePackageJson(minifierPkgPath, minifier)
+  }
+} catch (e) {
+  console.warn('Failed to update monkey-minifier dependency:', e)
 }
 
 // Also keep vscode-extension package version in sync

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -7,7 +7,7 @@ use compiler::snapshot_layout::describe_bytecode;
 use monkey_asm::emitter::AsmDialect;
 use monkey_asm::lower::lower_node;
 use parser::parse as parser_pase;
-use parser::parse_ast_json_string;
+use parser::{parse_ast_json_string, parse_ast_lossless_json_string};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::throw_str;
 
@@ -24,6 +24,17 @@ pub fn parse(input: &str) -> String {
     set_panic_hook();
     match parse_ast_json_string(input) {
         Ok(node) => node.to_string(),
+        Err(e) => throw_str(format!("parse error: {}", e[0]).as_str()),
+    }
+}
+
+/// Parse Monkey source to JSON while encoding every i64 literal as a decimal
+/// string so JavaScript consumers do not lose integer precision.
+#[wasm_bindgen]
+pub fn parse_lossless(input: &str) -> String {
+    set_panic_hook();
+    match parse_ast_lossless_json_string(input) {
+        Ok(node) => node,
         Err(e) => throw_str(format!("parse error: {}", e[0]).as_str()),
     }
 }
@@ -93,6 +104,7 @@ pub fn run_gc_with_report(input: &str) -> String {
         Err(error) => serde_json::json!({
             "status": "error",
             "stage": error.stage,
+            "kind": error.kind,
             "message": error.message,
             "span": error.span,
         }),
@@ -117,6 +129,7 @@ pub fn compile_to_arm64(input: &str) -> String {
         Err((stage, message, span)) => serde_json::json!({
             "status": "error",
             "stage": stage,
+            "kind": stage,
             "message": message,
             "span": span.map(|(start, end)| serde_json::json!({ "start": start, "end": end })),
         }),
@@ -192,6 +205,7 @@ pub fn compile_to_snapshot(input: &str, strip_debug: bool) -> String {
         Err((stage, message)) => serde_json::json!({
             "status": "error",
             "stage": stage,
+            "kind": stage,
             "message": message,
         }),
     };
@@ -253,6 +267,7 @@ pub fn run_snapshot(bytes: &[u8]) -> String {
             Err(error) => serde_json::json!({
                 "status": "error",
                 "stage": "runtime",
+                "kind": error.kind,
                 "message": error.message,
                 "span": error.span,
             }),
@@ -260,8 +275,48 @@ pub fn run_snapshot(bytes: &[u8]) -> String {
         Err(error) => serde_json::json!({
             "status": "error",
             "stage": "snapshot",
+            "kind": "invalidSnapshot",
             "message": format!("{:?}", error),
             "span": null,
+        }),
+    };
+    serde_json::to_string(&envelope).expect("snapshot run envelope serialization should not fail")
+}
+
+/// Execute an untrusted snapshot on a fresh GC VM and capture observable
+/// output. `stdout` is present on both success and failure so callers can
+/// compare programs that print before raising an error.
+#[wasm_bindgen]
+pub fn run_snapshot_with_output(bytes: &[u8]) -> String {
+    set_panic_hook();
+
+    let envelope = match read_bytecode(bytes) {
+        Ok(bytecode) => {
+            let (result, stdout) =
+                gc::run_bytecode_with_output(bytecode, PLAYGROUND_GC_INSTRUCTION_BUDGET);
+            match result {
+                Ok(result) => serde_json::json!({
+                    "status": "ok",
+                    "result": result,
+                    "stdout": stdout,
+                }),
+                Err(error) => serde_json::json!({
+                    "status": "error",
+                    "stage": "runtime",
+                    "kind": error.kind,
+                    "message": error.message,
+                    "span": error.span,
+                    "stdout": stdout,
+                }),
+            }
+        }
+        Err(error) => serde_json::json!({
+            "status": "error",
+            "stage": "snapshot",
+            "kind": "invalidSnapshot",
+            "message": format!("{:?}", error),
+            "span": null,
+            "stdout": "",
         }),
     };
     serde_json::to_string(&envelope).expect("snapshot run envelope serialization should not fail")

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -95,20 +95,21 @@ pub fn compile_with_debug(input: &str) -> String {
 pub fn run_gc_with_report(input: &str) -> String {
     set_panic_hook();
 
-    let envelope = match gc::run_source_with_report(input, PLAYGROUND_GC_INSTRUCTION_BUDGET) {
-        Ok(success) => serde_json::json!({
-            "status": "ok",
-            "result": success.result,
-            "report": success.report,
-        }),
-        Err(error) => serde_json::json!({
-            "status": "error",
-            "stage": error.stage,
-            "kind": error.kind,
-            "message": error.message,
-            "span": error.span,
-        }),
-    };
+    let envelope =
+        match gc::run_source_with_report_classified(input, PLAYGROUND_GC_INSTRUCTION_BUDGET) {
+            Ok(success) => serde_json::json!({
+                "status": "ok",
+                "result": success.result,
+                "report": success.report,
+            }),
+            Err(error) => serde_json::json!({
+                "status": "error",
+                "stage": error.stage,
+                "kind": error.kind,
+                "message": error.message,
+                "span": error.span,
+            }),
+        };
 
     serde_json::to_string(&envelope).expect("GC run envelope serialization should not fail")
 }
@@ -248,7 +249,8 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 /// Execute `.mbc` snapshot bytes on the cycle-collecting VM — the browser twin of
-/// `monkey-gc run foo.mbc`, sharing its execution path (`gc::run_bytecode`).
+/// `monkey-gc run foo.mbc`, running the same VM with raise-site error
+/// classification so the envelope can carry a stable `kind`.
 ///
 /// The buffer is untrusted input: it goes through the validating snapshot reader
 /// before the VM. Failures are data in the envelope — stage `snapshot` when the
@@ -259,19 +261,25 @@ pub fn run_snapshot(bytes: &[u8]) -> String {
     set_panic_hook();
 
     let envelope = match read_bytecode(bytes) {
-        Ok(bytecode) => match gc::run_bytecode(bytecode, PLAYGROUND_GC_INSTRUCTION_BUDGET) {
-            Ok(result) => serde_json::json!({
-                "status": "ok",
-                "result": result,
-            }),
-            Err(error) => serde_json::json!({
-                "status": "error",
-                "stage": "runtime",
-                "kind": error.kind,
-                "message": error.message,
-                "span": error.span,
-            }),
-        },
+        Ok(bytecode) => {
+            let mut vm = gc::GcVM::new(bytecode);
+            match vm
+                .run_with_budget_classified(PLAYGROUND_GC_INSTRUCTION_BUDGET)
+                .map(|()| vm.last_result_string())
+            {
+                Ok(result) => serde_json::json!({
+                    "status": "ok",
+                    "result": result,
+                }),
+                Err(error) => serde_json::json!({
+                    "status": "error",
+                    "stage": "runtime",
+                    "kind": error.kind,
+                    "message": error.message,
+                    "span": error.span,
+                }),
+            }
+        }
         Err(error) => serde_json::json!({
             "status": "error",
             "stage": "snapshot",

--- a/wasm/tests/web.rs
+++ b/wasm/tests/web.rs
@@ -3,7 +3,10 @@
 #![cfg(target_arch = "wasm32")]
 
 extern crate wasm_bindgen_test;
-use monkey_wasm::{compile_to_arm64, compile_to_snapshot, parse, run_gc_with_report, run_snapshot};
+use monkey_wasm::{
+    compile_to_arm64, compile_to_snapshot, parse, parse_lossless, run_gc_with_report, run_snapshot,
+    run_snapshot_with_output,
+};
 use serde_json::Value;
 use wasm_bindgen_test::*;
 
@@ -12,6 +15,14 @@ fn pass() {
     let input = "let a = 3";
     let r = parse(input);
     println!("{}", r);
+}
+
+#[wasm_bindgen_test]
+fn lossless_parse_preserves_i64_literals_as_strings() {
+    let ast: Value =
+        serde_json::from_str(&parse_lossless("[9007199254740993, 9223372036854775807]")).unwrap();
+    assert_eq!(ast["Program"]["body"][0]["elements"][0]["raw"], "9007199254740993");
+    assert_eq!(ast["Program"]["body"][0]["elements"][1]["raw"], "9223372036854775807");
 }
 
 fn run_gc(source: &str) -> Value {
@@ -180,6 +191,23 @@ fn snapshot_envelope_roundtrips_through_the_vm() {
     let run = run_bytes(&bytes);
     assert_eq!(run["status"], "ok");
     assert_eq!(run["result"], "3");
+}
+
+#[wasm_bindgen_test]
+fn snapshot_output_is_captured_before_success_or_failure() {
+    let success = build_snapshot(r#"puts("before"); 42"#, false);
+    let run: Value = serde_json::from_str(&run_snapshot_with_output(&snapshot_bytes(&success)))
+        .expect("valid output envelope");
+    assert_eq!(run["status"], "ok");
+    assert_eq!(run["result"], "42");
+    assert_eq!(run["stdout"], "before\n");
+
+    let failure = build_snapshot(r#"puts("before"); 1 / 0"#, false);
+    let run: Value = serde_json::from_str(&run_snapshot_with_output(&snapshot_bytes(&failure)))
+        .expect("valid output envelope");
+    assert_eq!(run["status"], "error");
+    assert_eq!(run["kind"], "arithmetic");
+    assert_eq!(run["stdout"], "before\n");
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary

- add a lossless parser AST API and output-aware GC snapshot runner for semantics-preserving differential checks
- add `@gengjiawen/monkey-minifier` with a compact printer, binding-identity-aware mangling, constant folding, constant propagation, and conservative dead-`let` elimination
- alternate folding and propagation to a fixed point so literal bindings inline through arithmetic — `let a = 1 + 1; let b = a + 1; print(a)` minifies to `print(2);`, matching terser on the equivalent JavaScript
- guard propagation against Monkey slot semantics: `let`s inside `if` arms are never inlined (their slot may stay unwritten), `new` callees stay identifier references, and a size guard skips literals whose inlined copies would outweigh the binding
- preserve compiler/VM edge cases around local slots, trailing `let` values, and parser-injected recursive function bindings
- ship separate browser ESM and Node Wasm entrypoints plus the `monkey-minify` CLI
- add a debounced Playground Minify view with mangling control, UTF-8 byte statistics, and line wrapping for the single-line output, plus a "Constant folding" example snippet

## Validation

- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `wasm-pack build --release --scope=gengjiawen`
- `wasm-pack test --node`
- `pnpm install --frozen-lockfile`
- `pnpm -C packages/monkey-minifier build`
- `pnpm -C packages/monkey-minifier test` (includes a differential corpus that runs each program before and after minification on the real VM)
- browser ESM, Node package entry, and CLI smoke tests
- `pnpm -C packages/playground test`
- `pnpm -C packages/playground build`
- `pnpm -C packages/playground lint` (passes; one pre-existing `<img>` warning)
- Prettier check for changed JS/TS/JSON/Markdown/YAML files
- `npm pack --dry-run --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)