### PR TITLE
ci: publish monkey minifier with release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,13 +85,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}
-      - run: pnpm install --filter @gengjiawen/monkey-minifier... --frozen-lockfile && pnpm --filter @gengjiawen/monkey-minifier run build
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish --access public
-        working-directory: packages/monkey-minifier
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}
       - run: pnpm install --filter prettier-plugin-monkey... && pnpm --filter prettier-plugin-monkey run build
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish --access public
@@ -109,3 +102,10 @@ jobs:
           rm -f *.vsix
           pnpm run package
           pnpm exec ovsx publish --skip-duplicate --pat "$OVSX_PAT" *.vsix
+      - run: pnpm install --filter @gengjiawen/monkey-minifier... --frozen-lockfile && pnpm --filter @gengjiawen/monkey-minifier run build
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish --access public
+        working-directory: packages/monkey-minifier
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,6 +85,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}
+      - run: pnpm install --filter @gengjiawen/monkey-minifier... --frozen-lockfile && pnpm --filter @gengjiawen/monkey-minifier run build
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish --access public
+        working-directory: packages/monkey-minifier
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        if: ${{ steps.release.outputs.release_created }}
       - run: pnpm install --filter prettier-plugin-monkey... && pnpm --filter prettier-plugin-monkey run build
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ An interpreter and compiler for the Monkey programming language written in Rust
 ## What’s Monkey?
 
 ### Compiler playground
+
 https://monkey-lang-playground-jw.vercel.app/
 
 ### AST Online playground
-https://astexplorer.net/#/gist/e23a81ce309e8fcffe95ddd1b5661061/01d0b4b078304ddd9639eae9f4e6d342e2b9d075
 
+https://astexplorer.net/#/gist/e23a81ce309e8fcffe95ddd1b5661061/01d0b4b078304ddd9639eae9f4e6d342e2b9d075
 
 Monkey has a C-like syntax, supports **variable bindings**, **prefix** and **infix operators**, has **first-class** and **higher-order functions**, can handle **closures** with ease and has **integers**, **booleans**, **arrays** and **hashes** built-in.
 
@@ -28,6 +29,7 @@ Monkey has a C-like syntax, supports **variable bindings**, **prefix** and **inf
 - test for every module
 - **Wasm**: A WebAssembly target, thus run monkey on browser is directly supported.
 - **Prettier Plugin**: Format Monkey source code with [Prettier](https://prettier.io/) via `prettier-plugin-monkey`.
+- **Minifier** ([`@gengjiawen/monkey-minifier`](packages/monkey-minifier/README.md)): A semantics-preserving source-to-source minifier powered by the Rust/Wasm parser, with compact printing, identifier mangling, constant folding and propagation, dead `let` elimination, and Node/browser/CLI APIs.
 - **VS Code Extension**: First-class editor support with syntax highlighting, snippets, WASM-powered diagnostics, AST preview, and bytecode compilation commands.
 - bytecode viewer from source
 - **GC** ([`monkey-gc`](gc/README.md)): alternate bytecode VM with QuickJS-style refcounting and three-phase cycle collection (`gc_decref` → `gc_scan` → `gc_free_cycles`) on a `GcHeap`, so cyclic object graphs can be reclaimed without changing `object` or the default `Rc` VM.
@@ -35,6 +37,7 @@ Monkey has a C-like syntax, supports **variable bindings**, **prefix** and **inf
 - **ASM** ([`monkey-asm`](asm/README.md)): AOT arm64 (AArch64) assembly backend — single-pass lowering from the AST to AArch64 assembly text, assembled and linked against a cross-built Rust runtime into a native executable, in Linux/ELF and macOS/Mach-O flavors (the Linux flavor runs on any host via `qemu-aarch64`); the playground's **ARM64** tab shows the same assembly godbolt-style ([design doc](docs/arm64-asm-backend-design.md)).
 
 ## Resources
+
 Official site is: https://monkeylang.org/. It's has various implementation languages :).
 
 There is a book about learning how to make an interpreter: [Writing An Interpreter In Go](https://interpreterbook.com/#the-monkey-programming-language). This is where the Monkey programming language come from.

--- a/docs/minifier-plan.md
+++ b/docs/minifier-plan.md
@@ -489,9 +489,9 @@ Compression ratio 不是 correctness assertion，也不会写进 test output。P
 - 按 `AGENTS.md`，feature PR 不做 version bump。
   `scripts/bump_cargo_packages.ts` 会在 release PR 中同步 minifier version、Wasm
   dependency range 和 playground minifier range。
-- release-please workflow 会在 Wasm package 发布后 build 并 publish
-  `@gengjiawen/monkey-minifier`；playground demo 直接 import workspace source，不依赖
-  package 发布。
+- release-please workflow 会把 `@gengjiawen/monkey-minifier` 作为最后一个 release
+  artifact build 并 publish；playground demo 直接 import workspace source，不依赖 package
+  发布。
 - `AGENTS.md` 已加入 minifier package，package 自带 README 和 CLI usage。
 
 ## Implementation status

--- a/docs/minifier-plan.md
+++ b/docs/minifier-plan.md
@@ -2,7 +2,7 @@
 
 本仓库为 Monkey 方言实现了一个 TypeScript source-to-source minifier，作为
 workspace package 提供，并准备发布为 npm package；playground 已提供在线 demo。
-本文记录当前实现、correctness boundaries 和仍未完成的 release follow-up；Phase
+本文记录当前实现、correctness boundaries 和剩余的 optional follow-up；Phase
 编号只表示功能演进顺序，不再表示多个待提交的 PR。
 
 处理管线：
@@ -489,8 +489,9 @@ Compression ratio 不是 correctness assertion，也不会写进 test output。P
 - 按 `AGENTS.md`，feature PR 不做 version bump。
   `scripts/bump_cargo_packages.ts` 会在 release PR 中同步 minifier version、Wasm
   dependency range 和 playground minifier range。
-- npm release 仍需给 release-please workflow 增加 minifier build/publish step；
-  playground demo 直接 import workspace source，不依赖 package 发布。
+- release-please workflow 会在 Wasm package 发布后 build 并 publish
+  `@gengjiawen/monkey-minifier`；playground demo 直接 import workspace source，不依赖
+  package 发布。
 - `AGENTS.md` 已加入 minifier package，package 自带 README 和 CLI usage。
 
 ## Implementation status
@@ -504,4 +505,4 @@ Compression ratio 不是 correctness assertion，也不会写进 test output。P
 | Constant folding、constant propagation、DCE                         | Implemented        |
 | CLI、Node/browser entries、package smoke tests、README              | Implemented        |
 | `runs identically ✓` playground badge                               | Optional follow-up |
-| release-please build/publish step for `@gengjiawen/monkey-minifier` | Follow-up          |
+| release-please build/publish step for `@gengjiawen/monkey-minifier` | Implemented        |


### PR DESCRIPTION
## Summary

- build and publish `@gengjiawen/monkey-minifier` as the final release artifact, after Rust crates, Wasm, the Prettier plugin, and the Open VSX extension
- publish the minifier to npm with the existing release credentials
- document the release integration and ordering in the minifier plan
- introduce the minifier and link its package documentation from the root README

The existing prepare-release workflow already synchronizes the minifier version and converts its Wasm dependency to a registry-compatible range before release.

## Verification

- `pnpm --filter @gengjiawen/monkey-minifier build`
- `pnpm --filter @gengjiawen/monkey-minifier test` (82 tests)
- `pnpm --filter @gengjiawen/monkey-minifier test:node`
- `pnpm --filter @gengjiawen/monkey-minifier test:browser`
- `npm pack --dry-run --json`
- `npx prettier --check .github/workflows/release-please.yml docs/minifier-plan.md README.md`
- `git diff --check`