### PR TITLE
fix(playground): let output tabs scroll instead of collapsing on mobile

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -669,23 +669,26 @@ function App() {
 
       <div className={panelClass}>
         <div className={outputToolbarClass}>
-          <SegmentedControl.Root
-            className="max-w-full min-w-0!"
-            size="2"
-            value={outputView}
-            onValueChange={handleOutputViewChange}
-          >
-            <SegmentedControl.Item value="ast">AST</SegmentedControl.Item>
-            <SegmentedControl.Item value="bytecode">
-              Bytecode
-            </SegmentedControl.Item>
-            <SegmentedControl.Item value="gc">GC</SegmentedControl.Item>
-            <SegmentedControl.Item value="snapshot">
-              Snapshot
-            </SegmentedControl.Item>
-            <SegmentedControl.Item value="arm64">ARM64</SegmentedControl.Item>
-            <SegmentedControl.Item value="minify">Minify</SegmentedControl.Item>
-          </SegmentedControl.Root>
+          <div className="min-w-0 max-w-full overflow-x-auto">
+            <SegmentedControl.Root
+              size="2"
+              value={outputView}
+              onValueChange={handleOutputViewChange}
+            >
+              <SegmentedControl.Item value="ast">AST</SegmentedControl.Item>
+              <SegmentedControl.Item value="bytecode">
+                Bytecode
+              </SegmentedControl.Item>
+              <SegmentedControl.Item value="gc">GC</SegmentedControl.Item>
+              <SegmentedControl.Item value="snapshot">
+                Snapshot
+              </SegmentedControl.Item>
+              <SegmentedControl.Item value="arm64">ARM64</SegmentedControl.Item>
+              <SegmentedControl.Item value="minify">
+                Minify
+              </SegmentedControl.Item>
+            </SegmentedControl.Root>
+          </div>
           {outputView === 'gc' ? (
             <Button
               size="2"


### PR DESCRIPTION
## Problem

On narrow screens the output-view tab strip (AST / Bytecode / GC / Snapshot / ARM64 / Minify) broke down: the `SegmentedControl.Root` carried `max-w-full min-w-0!`, which forced the control below its natural width (~445px content in a ~366px slot). Since the parent had `overflow: visible`, the tab labels overlapped each other, the active-tab indicator covered the neighboring "GC" tab, and the trailing tabs (ARM64 partially, Minify entirely) were pushed out of view with no way to reach them.

## Fix

Wrap the segmented control in a `min-w-0 max-w-full overflow-x-auto` container and drop the compression classes from the control itself. The tabs now keep their natural width and the strip scrolls horizontally on small screens; desktop layout is unchanged (no overflow, so no scrollbar).

## Affected packages

- `packages/playground` only (`src/App.tsx`)

## Testing

- `pnpm -C packages/playground test` — 159 tests pass
- `pnpm -C packages/playground lint` — clean (one pre-existing unrelated warning in `Header.tsx`)
- Verified in headless Chrome at a 390px viewport against `next dev`:
  - Before: tab labels overlapped, the Snapshot indicator covered "GC", and "Minify" was invisible
  - After: tabs render at natural width with no overlap, and swiping the strip reveals ARM64 and Minify; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)