### PR TITLE
fix(compiler): balance valueless if arms

### DIFF
--- a/compiler/compiler.rs
+++ b/compiler/compiler.rs
@@ -468,23 +468,17 @@ impl Compiler {
             Expression::IF(if_node) => {
                 self.compile_expr(&if_node.condition)?;
                 let jump_not_truthy = self.emit_with_span(OpJumpNotTruthy, &[9527], &if_node.span);
-                self.compile_block_statement(&if_node.consequent)?;
-                if self.last_instruction_is(OpPop) {
-                    self.remove_last_pop();
-                }
+                self.compile_block_statement_as_value(&if_node.consequent)?;
 
                 let jump_pos = self.emit_with_span(OpJump, &[9527], &if_node.span);
 
                 let after_consequence_location = self.current_instruction().data.len();
                 self.change_operand(jump_not_truthy, after_consequence_location);
 
-                if if_node.alternate.is_none() {
-                    self.emit_with_span(OpNull, &[], &if_node.span);
+                if let Some(alternate) = &if_node.alternate {
+                    self.compile_block_statement_as_value(alternate)?;
                 } else {
-                    self.compile_block_statement(&if_node.clone().alternate.unwrap())?;
-                    if self.last_instruction_is(OpPop) {
-                        self.remove_last_pop();
-                    }
+                    self.emit_with_span(OpNull, &[], &if_node.span);
                 }
                 let after_alternative_location = self.current_instruction().data.len();
                 self.change_operand(jump_pos, after_alternative_location);
@@ -623,6 +617,22 @@ impl Compiler {
     ) -> Result<(), CompileError> {
         for stmt in &block_statement.body {
             self.compile_stmt(stmt)?;
+        }
+        Ok(())
+    }
+
+    fn compile_block_statement_as_value(
+        &mut self,
+        block_statement: &BlockStatement,
+    ) -> Result<(), CompileError> {
+        let block_start = self.current_instruction().data.len();
+        self.compile_block_statement(block_statement)?;
+        // A block in expression position must leave one value on every
+        // fallthrough path. Statement-only and empty blocks evaluate to null.
+        if self.current_instruction().data.len() > block_start && self.last_instruction_is(OpPop) {
+            self.remove_last_pop();
+        } else {
+            self.emit_with_span(OpNull, &[], &block_statement.span);
         }
         Ok(())
     }

--- a/compiler/compiler_test.rs
+++ b/compiler/compiler_test.rs
@@ -423,6 +423,26 @@ mod tests {
     }
 
     #[test]
+    fn condition_arms_without_values_emit_null() {
+        let tests = vec![CompilerTestCase {
+            input: "if (true) { let y = 1; } else {};",
+            expected_constants: vec![Object::Integer(1)],
+            expected_instructions: vec![
+                make_instructions(OpTrue, &[]),
+                make_instructions(OpJumpNotTruthy, &[14]),
+                make_instructions(OpConst, &[0]),
+                make_instructions(OpSetGlobal, &[0]),
+                make_instructions(OpNull, &[]),
+                make_instructions(OpJump, &[15]),
+                make_instructions(OpNull, &[]),
+                make_instructions(OpPop, &[]),
+            ],
+        }];
+
+        run_compiler_test(tests);
+    }
+
+    #[test]
     fn test_global_constants() {
         let tests = vec![
             CompilerTestCase {

--- a/compiler/vm_test.rs
+++ b/compiler/vm_test.rs
@@ -285,6 +285,34 @@ mod tests {
     }
 
     #[test]
+    fn test_conditionals_without_values() {
+        let tests = vec![
+            VmTestCase {
+                input: "if (true) { let y = 1; }",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "if (true) {} 2",
+                expected: Object::Integer(2),
+            },
+            VmTestCase {
+                input: "if (false) { 1 } else {}",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "let result = if (true) { let y = 1; } else { 2 }; result",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "let f = fn() { if (true) { let y = 2; }; y }; f()",
+                expected: Object::Integer(2),
+            },
+        ];
+
+        run_vm_tests(tests);
+    }
+
+    #[test]
     fn test_global_let_statements() {
         let tests = vec![
             VmTestCase {

--- a/gc/vm_test.rs
+++ b/gc/vm_test.rs
@@ -214,6 +214,32 @@ mod tests {
     }
 
     #[test]
+    fn test_conditionals_without_values() {
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "if (true) { let y = 1; }",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "if (true) {} 2",
+                expected: Object::Integer(2),
+            },
+            VmTestCase {
+                input: "if (false) { 1 } else {}",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "let result = if (true) { let y = 1; } else { 2 }; result",
+                expected: Object::Null,
+            },
+            VmTestCase {
+                input: "let f = fn() { if (true) { let y = 2; }; y }; f()",
+                expected: Object::Integer(2),
+            },
+        ]);
+    }
+
+    #[test]
     fn test_global_let_statements() {
         run_gc_vm_tests(vec![
             VmTestCase {

--- a/wasm/tests/web.rs
+++ b/wasm/tests/web.rs
@@ -121,6 +121,17 @@ makeCycle();
 }
 
 #[wasm_bindgen_test]
+fn gc_if_arms_without_values_stay_stack_balanced() {
+    let let_tail = run_gc("let value = if (true) { let y = 1; } else { 2 }; value");
+    assert_eq!(let_tail["status"], "ok");
+    assert_eq!(let_tail["result"], "null");
+
+    let empty_arm = run_gc("if (true) {} 2;");
+    assert_eq!(empty_arm["status"], "ok");
+    assert_eq!(empty_arm["result"], "2");
+}
+
+#[wasm_bindgen_test]
 fn gc_hash_edges_preserve_key_kinds_and_unicode_boundaries() {
     let unicode_key = format!("{}中", "a".repeat(63));
     let source = format!(


### PR DESCRIPTION
## Summary

- compile if arms in value position so empty and statement-only arms emit OpNull
- preserve expression-tailed arms while keeping both the standard VM and GC VM stacks balanced
- add bytecode, VM, GC VM, and wasm API regressions, including local-slot preservation inside call frames

## Rationale

A taken arm ending in let, or an empty arm, previously left no value for the enclosing expression's OpPop. At top level this raised stack underflow; inside a function it could consume a reserved local slot. These arms now evaluate to null, matching the tree-walking interpreter.

## Affected crates

- compiler
- gc
- wasm tests

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build
- cargo test
- cd wasm && wasm-pack build --release --scope=gengjiawen
- cd wasm && wasm-pack test --node

Fixes #302