### PR TITLE
fix(interpreter): stop evaluation when a builtin fails

### DIFF
--- a/interpreter/interpreter_test.rs
+++ b/interpreter/interpreter_test.rs
@@ -21,6 +21,19 @@ mod tests {
         }
     }
 
+    fn apply_error_test(test_cases: &[(&str, &str)]) {
+        let env: Env = Rc::new(RefCell::new(Default::default()));
+        for (input, expected) in test_cases {
+            match parse(input) {
+                Ok(node) => match eval(node, &env) {
+                    Ok(evaluated) => panic!("expected `{}` to fail, got {}", input, evaluated),
+                    Err(e) => assert_eq!(&e.to_string(), expected),
+                },
+                Err(e) => panic!("parse error: {}", e[0]),
+            }
+        }
+    }
+
     #[test]
     fn test_integer_expressions() {
         let test_case = [
@@ -209,13 +222,28 @@ mod tests {
             ("push([], 1)", "[1]"),
         ];
         apply_test(&test_case);
-        // let illegal_cases = [
-        //     "len(1)",
-        //     r#"len("one", "two")"#,
-        //     "first(1)",
-        //     "last(1)",
-        //     "push(1, 1)"
-        // ];
+    }
+
+    #[test]
+    fn test_builtin_errors_stop_evaluation() {
+        let test_case = [
+            ("len(1)", "builtin len not supported for for type 1"),
+            (r#"len("one", "two")"#, "builtin len expected 1 argument, got 2"),
+            ("first(1)", "builtin first not supported for for type 1"),
+            ("last(1)", "builtin last not supported for for type 1"),
+            ("rest(1)", "builtin rest not supported for for type 1"),
+            ("push(1, 1)", "builtin push not supported for for type 1"),
+            // a failed builtin must abort the program instead of flowing on as a value
+            ("if (len(1)) { 10 } else { 20 }", "builtin len not supported for for type 1"),
+            ("len(1) == len(1)", "builtin len not supported for for type 1"),
+            ("len(1); 42", "builtin len not supported for for type 1"),
+            ("let broken = len(1); broken", "builtin len not supported for for type 1"),
+            (
+                "let identity = fn(x) { x }; identity(len(1))",
+                "builtin len not supported for for type 1",
+            ),
+        ];
+        apply_error_test(&test_case);
     }
 
     #[test]

--- a/interpreter/lib.rs
+++ b/interpreter/lib.rs
@@ -294,7 +294,16 @@ fn apply_function(function: &Rc<Object>, args: &[Rc<Object>]) -> Result<Rc<Objec
             let evaluated = eval_block_statements(&body.body, &Rc::new(RefCell::new(env)))?;
             return unwrap_return(evaluated);
         }
-        Object::Builtin(b) => Ok(b(args.to_vec())),
+        Object::Builtin(b) => {
+            let result = b(args.to_vec());
+            // Builtins report failures as Object::Error values. Every other runtime
+            // failure here is an Err, so lift them instead of letting an error keep
+            // flowing as an ordinary value.
+            match &*result {
+                Object::Error(message) => Err(message.clone()),
+                _ => Ok(result),
+            }
+        }
         Object::BoundMethod(bound) => {
             apply_method(&bound.method, &bound.receiver, args, &bound.name)
         }


### PR DESCRIPTION
## Problem

Builtins report failures as `Object::Error` values, but `apply_function` handed that value straight back to the evaluator:

```rust
Object::Builtin(b) => Ok(b(args.to_vec())),
```

Every other runtime failure in the interpreter is an `Err`, so a failed builtin was the one error that kept flowing as an ordinary value — truthy as a condition, comparable with `==`, bindable with `let`, and the statements after it still ran. From the REPL on `main`:

```
>>> if (len(1)) { 10 } else { 20 }
10
>>> len(1) == len(1)
true
>>> len(1) + 1
eval infix error for op: start: 7, end: 8, kind: +, left: builtin len not supported for for type 1, right: 1
>>> let x = len(1); puts("still running"); x
still running
builtin len not supported for for type 1
```

## Fix

Lift `Object::Error` into `Err` at the builtin call boundary, so a failed builtin aborts evaluation like every other runtime error:

```
>>> if (len(1)) { 10 } else { 20 }
builtin len not supported for for type 1
>>> let x = len(1); puts("still running"); x
builtin len not supported for for type 1
```

## Tests

The illegal-argument cases that sat commented out in `test_array_builtin_functions` are now a real test, `test_builtin_errors_stop_evaluation`, plus cases pinning that an error does not flow on as a value (`if` condition, `==`, trailing statement, `let` binding, user-function argument).

They use a new `apply_error_test` helper: the existing `apply_test` formats `Ok` and `Err` identically, so it cannot tell an error *value* from an aborted evaluation and would have passed either way.

## Scope

- Affected crate: `interpreter` only. Nothing else depends on it — `wasm` builds on `parser`/`compiler`/`gc`/`asm`.
- The bytecode VMs (`compiler/vm.rs`, `gc/vm.rs`) intentionally keep error-as-value semantics; `docs/linter-plan.md` relies on that, and this PR does not touch them.
- `cargo fmt --all -- --check`, `cargo clippy -p monkey-interpreter --all-targets`, and `cargo test` (full workspace) all pass.

## Follow-ups (not in this PR)

- `first`/`last`/`rest`/`push` index `args[0]` with no arity check, so `first()` panics instead of erroring.
- The builtin messages read `not supported for for type` — a duplicated word, in both `object/builtins.rs` and `gc/value.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)