### PR TITLE
fix(compiler): keep builtins resolvable in the REPL

### DIFF
--- a/compiler/main.rs
+++ b/compiler/main.rs
@@ -9,12 +9,49 @@ use std::rc::Rc;
 
 use parser::parse;
 
+struct Repl {
+    symbol_table: SymbolTable,
+    constants: Vec<Rc<Object>>,
+    globals: Vec<Rc<Object>>,
+}
+
+impl Repl {
+    fn new() -> Self {
+        // Seed the persistent state from Compiler::new() so builtins like `len`
+        // stay resolvable; new_with_state replaces the symbol table wholesale.
+        let bootstrap = Compiler::new();
+        let null = Rc::new(Object::Null);
+        Self {
+            symbol_table: bootstrap.symbol_table,
+            constants: bootstrap.constants,
+            globals: vec![null; compiler::vm::GLOBAL_SIZE],
+        }
+    }
+
+    fn eval_line(&mut self, input: &str) -> Result<String, String> {
+        let program = parse(input).map_err(|errors| errors[0].clone())?;
+
+        let mut compiler =
+            Compiler::new_with_state(self.symbol_table.clone(), self.constants.clone());
+        let compiled = compiler.compile(&program).map(|bytecode| {
+            let mut vm = VM::new_with_global_store(bytecode, std::mem::take(&mut self.globals));
+            vm.run();
+            let output = vm
+                .last_popped_stack_elm()
+                .map_or_else(String::new, |o| o.to_string());
+            self.globals = vm.globals;
+            output
+        });
+
+        self.symbol_table = compiler.symbol_table;
+        self.constants = compiler.constants;
+        return compiled;
+    }
+}
+
 fn main() {
     println!("Welcome to monkey compiler by gengjiawen");
-    let mut constants = vec![];
-    let mut symbol_table = SymbolTable::new();
-    let null = Rc::new(Object::Null);
-    let mut globals = vec![null; compiler::vm::GLOBAL_SIZE];
+    let mut repl = Repl::new();
     loop {
         print!("> ");
         io::stdout().flush().unwrap();
@@ -26,29 +63,12 @@ fn main() {
             std::process::exit(0);
         }
 
-        let program = match parse(&input) {
-            Ok(x) => x,
-            Err(e) => {
-                println!("{}", e[0]);
-                continue;
-            }
-        };
-
-        let mut compiler = Compiler::new_with_state(symbol_table, constants);
-
-        match compiler.compile(&program) {
-            Ok(bytecodes) => {
-                let mut vm = VM::new_with_global_store(bytecodes, globals);
-                vm.run();
-                println!("{}", vm.last_popped_stack_elm().unwrap());
-                globals = vm.globals;
-            }
-            Err(e) => {
-                println!("{}", e);
-            }
-        };
-
-        symbol_table = compiler.symbol_table;
-        constants = compiler.constants;
+        match repl.eval_line(&input) {
+            Ok(output) => println!("{}", output),
+            Err(e) => println!("{}", e),
+        }
     }
 }
+
+#[cfg(test)]
+mod repl_test;

--- a/compiler/repl_test.rs
+++ b/compiler/repl_test.rs
@@ -1,0 +1,73 @@
+use super::Repl;
+
+#[test]
+fn repl_resolves_builtins() {
+    // Regression: the REPL used to seed its persistent state with a bare
+    // SymbolTable::new(), so every builtin failed with "Undefined variable".
+    let mut repl = Repl::new();
+    let result = repl
+        .eval_line("len([1, 2, 3]);")
+        .expect("builtin call should succeed");
+    assert_eq!(result, "3");
+}
+
+#[test]
+fn repl_keeps_builtins_resolvable_across_lines() {
+    // The symbol table round-trips through new_with_state on every line, so a
+    // builtin that resolves on line 1 must still resolve after other lines run.
+    let mut repl = Repl::new();
+    repl.eval_line("let xs = [1, 2];")
+        .expect("let binding should succeed");
+    let result = repl
+        .eval_line("len(xs);")
+        .expect("builtin must survive a committed line");
+    assert_eq!(result, "2");
+}
+
+#[test]
+fn repl_keeps_state_across_successful_lines() {
+    let mut repl = Repl::new();
+    repl.eval_line("let answer = 21 * 2;")
+        .expect("let binding should succeed");
+    let result = repl
+        .eval_line("answer;")
+        .expect("persisted global should resolve");
+    assert_eq!(result, "42");
+}
+
+#[test]
+fn repl_allows_shadowing_a_builtin() {
+    // Guards the fix's shape: re-registering builtins on every line would be a
+    // tempting alternative, but it would clobber a user binding that shadows one.
+    let mut repl = Repl::new();
+    repl.eval_line("let len = 5;")
+        .expect("shadowing a builtin should succeed");
+    let result = repl
+        .eval_line("len;")
+        .expect("user binding must win over the builtin");
+    assert_eq!(result, "5");
+}
+
+#[test]
+fn repl_reports_undefined_variables() {
+    let mut repl = Repl::new();
+    let error = repl
+        .eval_line("nope;")
+        .expect_err("unknown name should fail");
+    assert!(
+        error.to_lowercase().contains("undefined variable 'nope'"),
+        "expected an undefined-variable error, got: {:?}",
+        error
+    );
+}
+
+#[test]
+fn repl_survives_a_parse_error() {
+    let mut repl = Repl::new();
+    repl.eval_line("let =")
+        .expect_err("malformed let should fail");
+    let result = repl
+        .eval_line("1 + 1;")
+        .expect("REPL should still evaluate after a parse error");
+    assert_eq!(result, "2");
+}


### PR DESCRIPTION
## Problem

Every builtin was unusable in the compiler REPL:

```
$ monkey-compiler
> len([1,2])
Undefined variable 'len'
> puts(1)
Undefined variable 'puts'
> 1+2
3          ← non-builtin code was fine
```

## Root cause

`compiler/main.rs` seeded its persistent state with a bare `SymbolTable::new()`, which registers no builtins. `Compiler::new_with_state` delegates to `Compiler::new()` — which *does* register them — and then replaces the symbol table wholesale, so the builtins were discarded on every line.

The validator never caught it because `Compiler::compile` builds its `predefined_names` from `visible_names()` **plus** `BuiltIns`, so `len` passed validation and only fell over later in `compile_expr`'s `resolve`. The two "predefined names" sources disagreed. The error casing gives it away: `foo` yields the validator's lowercase `undefined variable 'foo'`, while `len` yielded the compiler's uppercase `Undefined variable 'len'`.

Only this REPL was affected. The interpreter evaluates via an env, `asm/lower.rs` registers builtins right after building its table, and the gc REPL already fixed this exact trap:

```rust
// gc/main.rs
// Seed the persistent state from Compiler::new() so builtins like `len`
// stay resolvable; new_with_state replaces the symbol table wholesale.
```

## Fix

Seed the persistent state from `Compiler::new()`, matching that documented gc bootstrap.

## Why it went unnoticed

No test exercised the REPL path — the compiler tests all construct `Compiler::new()` directly, which registers builtins, so the user-facing path was never covered. This extracts the REPL into a testable `Repl` with `eval_line` (mirroring `gc/main.rs`, which pairs with `gc/repl_test.rs`) and adds `compiler/repl_test.rs`.

Both builtin tests fail against the previous code with the exact reported error:

```
---- repl_test::repl_resolves_builtins stdout ----
panicked at compiler/repl_test.rs:10:10:
builtin call should succeed: "Undefined variable 'len'"
```

`repl_allows_shadowing_a_builtin` pins a constraint worth keeping: `let len = 5;` must still shadow the builtin. That rules out re-registering builtins on every line as an alternative fix, since it would clobber the user's binding.

## Verification

- `cargo test --workspace` green; `cargo fmt --all --check` and `cargo clippy --workspace --all-targets` clean.
- Manually confirmed in the built binary: `len`/`puts`/`first`/`last`/`rest`/`push` all work, globals still persist across lines, and builtin shadowing still behaves.

Behavior is otherwise unchanged: the prompt, the `bye` exit on empty input, parse-error recovery, and the existing commit-state-after-compile semantics are all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)