### PR TITLE
fix(object): validate builtin arity for first/last/rest/push

### DIFF
--- a/compiler/vm_function_test.rs
+++ b/compiler/vm_function_test.rs
@@ -213,4 +213,38 @@ mod tests {
         ];
         run_vm_tests(tests);
     }
+
+    #[test]
+    fn test_builtin_arity_errors() {
+        // Same wording as the gc VM (gc/vm_test.rs) and the interpreter: a
+        // wrong argument count is an error value, never a panic or a call that
+        // quietly ignores the extra arguments.
+        let tests = vec![
+            VmTestCase {
+                input: "first();",
+                expected: Object::Error("builtin first expected 1 argument, got 0".to_string()),
+            },
+            VmTestCase {
+                input: "first([1], [2]);",
+                expected: Object::Error("builtin first expected 1 argument, got 2".to_string()),
+            },
+            VmTestCase {
+                input: "last([1], [2]);",
+                expected: Object::Error("builtin last expected 1 argument, got 2".to_string()),
+            },
+            VmTestCase {
+                input: "rest([1], [2]);",
+                expected: Object::Error("builtin rest expected 1 argument, got 2".to_string()),
+            },
+            VmTestCase {
+                input: "push([1]);",
+                expected: Object::Error("builtin push expected 2 arguments, got 1".to_string()),
+            },
+            VmTestCase {
+                input: "push([1], 2, 3);",
+                expected: Object::Error("builtin push expected 2 arguments, got 3".to_string()),
+            },
+        ];
+        run_vm_tests(tests);
+    }
 }

--- a/docs/linter-plan.md
+++ b/docs/linter-plan.md
@@ -258,20 +258,22 @@ let h2 = {keyA: 1, keyB: 2};
 
 #### `builtin-arity`（error）
 
-v0 **只检查 `len` 必须恰好取 1 个参数**，且仅当这个名字未被用户绑定遮蔽时
-检查。`puts` 可变参不查；`print` 是 `puts` 的别名（`object/builtins.rs` 中复用
-同一个函数），同样不查。
+检查所有定参 builtin 的参数个数：`len`/`first`/`last`/`rest` 恰好 1 个，
+`push` 恰好 2 个，且仅当这个名字未被用户绑定遮蔽时检查。`puts` 可变参不查；
+`print` 是 `puts` 的别名（`object/builtins.rs` 中复用同一个函数），同样不查。
 
-不能把 `first`/`last`/`rest`/`push` 放进同一条确定性规则：GC VM 会严格检查它们
-的参数个数，而 interpreter 实现会忽略多余参数，缺少参数时甚至可能 panic。例如
-interpreter 中 `first([1], [2])` 得 `1`、`rest([1], [2])` 得 `[]`、
-`push([1], 2, 3)` 得 `[1, 3]`。这些调用应先归入 v1 的
-`backend-divergent-builtin-arity`，或先统一 runtime 行为后再扩展本规则。
+早期版本只查 `len`：当时 GC VM 会严格检查 `first`/`last`/`rest`/`push` 的参数
+个数，而 interpreter 会忽略多余参数（`first([1], [2])` 得 `1`、`push([1], 2, 3)`
+得 `[1, 3]`），缺少参数时甚至 panic。现在两边都走 `object/builtins.rs` 的
+`check_arity`，措辞也一致，因此这些 builtin 已并入本规则。
 
 ```
 // ✗ 两个后端都产生 "builtin len expected 1 argument, got 2" 错误对象/值；
 //    这不等同于 runner 报 runtime failure，也不保证立即中止执行。
 let n = len([1], [2]);
+
+// ✗ 同理：push 恰好取 2 个参数
+let xs = push([1], 2, 3);
 
 // ✓ 不报：len 已被用户遮蔽（改由 no-shadowed-builtin 报警）
 let len = fn(a, b) { 42; };
@@ -342,8 +344,6 @@ let d = 1 == true;
 - `no-self-compare`：把 `x == x` / `x != x` 作为高度可疑的自比较报告，但不宣称
   恒真/恒假。例如 `let x = []; x == x` 在 interpreter 中是 `true`，GC VM 则拒绝
   该比较。
-- `backend-divergent-builtin-arity`：在 runtime 行为统一前，报告
-  `first`/`last`/`rest`/`push` 的错误参数个数。
 - `no-empty-block`：`if (ready) {}` 空分支。
 
 ### 明确不做的规则
@@ -413,8 +413,7 @@ JSON 格式给编辑器集成与脚本消费。
 
 - **v0**：结构化 wasm analyzer API、包骨架、walker/scope、上表 9 条规则、CLI、
   测试与 CI，以及 playground 的 Lint 按钮接入。
-- **v1**：VS Code extension 接入；`backend-divergent-rebinding`
-  与 `backend-divergent-builtin-arity` 等进阶规则。
+- **v1**：VS Code extension 接入；`backend-divergent-rebinding` 等进阶规则。
 - **v2**：行内禁用指令（`// monkey-lint-disable-next-line <rule>`——
   `parse_lossless` 不含注释，需对原始 source 做行级扫描，不改 parser）；
   `--fix`（基于 span 的文本编辑，不走 printer，避免重排无关代码）。

--- a/gc/vm_test.rs
+++ b/gc/vm_test.rs
@@ -533,6 +533,38 @@ mod tests {
     }
 
     #[test]
+    fn test_builtin_arity_errors() {
+        // The gc VM has always rejected these; pinning them here keeps the
+        // three backends from drifting apart again (see object/builtins.rs).
+        run_gc_vm_tests(vec![
+            VmTestCase {
+                input: "first();",
+                expected: Object::Error("builtin first expected 1 argument, got 0".to_string()),
+            },
+            VmTestCase {
+                input: "first([1], [2]);",
+                expected: Object::Error("builtin first expected 1 argument, got 2".to_string()),
+            },
+            VmTestCase {
+                input: "last([1], [2]);",
+                expected: Object::Error("builtin last expected 1 argument, got 2".to_string()),
+            },
+            VmTestCase {
+                input: "rest([1], [2]);",
+                expected: Object::Error("builtin rest expected 1 argument, got 2".to_string()),
+            },
+            VmTestCase {
+                input: "push([1]);",
+                expected: Object::Error("builtin push expected 2 arguments, got 1".to_string()),
+            },
+            VmTestCase {
+                input: "push([1], 2, 3);",
+                expected: Object::Error("builtin push expected 2 arguments, got 3".to_string()),
+            },
+        ]);
+    }
+
+    #[test]
     fn builtin_call_releases_callee_args_and_stack_temporaries() {
         let program = parse("len([1, 2, 3]);").unwrap();
         let mut compiler = Compiler::new();

--- a/interpreter/interpreter_test.rs
+++ b/interpreter/interpreter_test.rs
@@ -219,6 +219,29 @@ mod tests {
     }
 
     #[test]
+    fn test_array_builtin_arity_errors() {
+        // A wrong argument count must produce an error, not a panic and not a
+        // silently truncated call. `push` used to read args.first()/args.last(),
+        // so `push([1])` appended the array to itself and `push([1], 2, 3)`
+        // dropped the middle argument; `first`/`last`/`rest` indexed args[0]
+        // unchecked and panicked when called with none. The gc VM already
+        // rejected all of these, with the wording pinned here.
+        let test_case = [
+            ("first()", "builtin first expected 1 argument, got 0"),
+            ("first([1], [2])", "builtin first expected 1 argument, got 2"),
+            ("last()", "builtin last expected 1 argument, got 0"),
+            ("last([1], [2])", "builtin last expected 1 argument, got 2"),
+            ("rest()", "builtin rest expected 1 argument, got 0"),
+            ("rest([1], [2])", "builtin rest expected 1 argument, got 2"),
+            ("push()", "builtin push expected 2 arguments, got 0"),
+            ("push([1])", "builtin push expected 2 arguments, got 1"),
+            ("push([1], 2, 3)", "builtin push expected 2 arguments, got 3"),
+            ("len()", "builtin len expected 1 argument, got 0"),
+        ];
+        apply_test(&test_case);
+    }
+
+    #[test]
     fn test_hash_index_expressions() {
         let test_case = [
             (r#"{"foo": 5}["foo"]"#, "5"),

--- a/object/builtins.rs
+++ b/object/builtins.rs
@@ -64,12 +64,27 @@ lazy_static! {
 //     .into_iter()
 //     .collect();
 
+/// Reject a call whose argument count does not match the builtin's arity,
+/// mirroring the checks the gc runtime performs in `gc/value.rs`. Returns the
+/// `Object::Error` the builtin should hand back, or `None` when the call is
+/// well-formed. Every fixed-arity builtin must call this before touching
+/// `args[..]`, otherwise a short call indexes out of bounds and panics.
+fn check_arity(name: &str, args: &[Rc<Object>], expected: usize) -> Option<Rc<Object>> {
+    if args.len() == expected {
+        return None;
+    }
+    Some(Rc::from(Object::Error(format!(
+        "builtin {} expected {} argument{}, got {}",
+        name,
+        expected,
+        if expected == 1 { "" } else { "s" },
+        args.len()
+    ))))
+}
+
 pub fn len(args: Vec<Rc<Object>>) -> Rc<Object> {
-    if args.len() != 1 {
-        return Rc::from(Object::Error(format!(
-            "builtin len expected 1 argument, got {}",
-            args.len()
-        )));
+    if let Some(error) = check_arity("len", &args, 1) {
+        return error;
     }
     Rc::from(match &*args[0] {
         Object::String(s) => Object::Integer(s.len() as i64),
@@ -84,6 +99,9 @@ pub fn puts(args: Vec<Rc<Object>>) -> Rc<Object> {
 }
 
 pub fn first(args: Vec<Rc<Object>>) -> Rc<Object> {
+    if let Some(error) = check_arity("first", &args, 1) {
+        return error;
+    }
     match &*args[0] {
         Object::Array(s) => match s.first() {
             Some(obj) => Rc::clone(obj),
@@ -94,6 +112,9 @@ pub fn first(args: Vec<Rc<Object>>) -> Rc<Object> {
 }
 
 pub fn last(args: Vec<Rc<Object>>) -> Rc<Object> {
+    if let Some(error) = check_arity("last", &args, 1) {
+        return error;
+    }
     match &*args[0] {
         Object::Array(s) => match s.last() {
             Some(obj) => Rc::clone(obj),
@@ -104,6 +125,9 @@ pub fn last(args: Vec<Rc<Object>>) -> Rc<Object> {
 }
 
 pub fn rest(args: Vec<Rc<Object>>) -> Rc<Object> {
+    if let Some(error) = check_arity("rest", &args, 1) {
+        return error;
+    }
     match &*args[0] {
         Object::Array(s) => {
             let len = s.len();
@@ -118,12 +142,13 @@ pub fn rest(args: Vec<Rc<Object>>) -> Rc<Object> {
 }
 
 pub fn push(args: Vec<Rc<Object>>) -> Rc<Object> {
-    let array = args.first().unwrap();
-    let obj = Rc::clone(args.last().unwrap());
-    match &**array {
+    if let Some(error) = check_arity("push", &args, 2) {
+        return error;
+    }
+    match &*args[0] {
         Object::Array(s) => {
             let mut new_array = s.clone();
-            new_array.push(obj);
+            new_array.push(Rc::clone(&args[1]));
             return Rc::new(Object::Array(new_array));
         }
         o => Rc::new(Object::Error(format!("builtin push not supported for for type {}", o))),

--- a/packages/monkey-linter/src/rules/builtin-arity.ts
+++ b/packages/monkey-linter/src/rules/builtin-arity.ts
@@ -4,20 +4,24 @@ import { walk } from '../walk'
 
 /**
  * Builtins whose arity *both* backends reject identically, regardless of the
- * argument types. Only `len` qualifies for v0:
+ * argument types. Every fixed-arity builtin qualifies: each one routes through
+ * `check_arity` in `object/builtins.rs` (interpreter and bytecode VM) and
+ * through the matching guards in `call_builtin_with_output` (`gc/value.rs`),
+ * so a wrong count is an error value on both sides.
  *
- *   - `len` errors cleanly on any count other than 1 in the interpreter
- *     (`args.len() != 1`) and in the GC VM (`call_builtin_with_output`).
- *   - `first` / `last` / `rest` / `push` diverge: the interpreter indexes
- *     `args[0]` (and `args.last()`) directly, so too *many* arguments are
- *     silently ignored and too *few* panic rather than returning an error,
- *     while the VM returns a clean arity error. Flagging them would be unsound
- *     against the interpreter, so they are intentionally excluded until the
- *     backends converge.
- *   - `puts` / `print` are variadic.
+ * `first` / `last` / `rest` / `push` used to be excluded because the
+ * interpreter indexed `args[0]` directly — extra arguments were silently
+ * ignored and a short call panicked instead of erroring. That divergence was
+ * fixed, so they are checked here too.
+ *
+ * `puts` / `print` stay out: they are variadic.
  */
 const FIXED_ARITY: Record<string, number> = {
   len: 1,
+  first: 1,
+  last: 1,
+  rest: 1,
+  push: 2,
 }
 
 export const builtinArity: Rule = {

--- a/packages/monkey-linter/test/oracle.test.ts
+++ b/packages/monkey-linter/test/oracle.test.ts
@@ -54,8 +54,30 @@ describe('builtin-arity tracks the GC VM', () => {
     }
   )
 
+  it.each([
+    ['first();', 'expected 1 argument'],
+    ['first([1], [2]);', 'expected 1 argument'],
+    ['last([1], [2]);', 'expected 1 argument'],
+    ['rest([1], [2]);', 'expected 1 argument'],
+    ['push([1]);', 'expected 2 arguments'],
+    ['push([1], 2, 3);', 'expected 2 arguments'],
+  ])('flags %s, which the VM evaluates to an arity error', (source, wording) => {
+    expect(rulesOf(source)).toContain('builtin-arity')
+    const report = runGc(source)
+    expect(`${report.result ?? report.message ?? ''}`).toContain(wording)
+  })
+
   it('stays quiet for len("hi"), which the VM accepts', () => {
     expect(rulesOf('len("hi");')).not.toContain('builtin-arity')
     expect(runGc('len("hi");').result).toBe('2')
+  })
+
+  it.each([
+    ['first([1, 2]);', '1'],
+    ['last([1, 2]);', '2'],
+    ['push([1], 2);', '[1, 2]'],
+  ])('stays quiet for %s, which the VM accepts', (source, expected) => {
+    expect(rulesOf(source)).not.toContain('builtin-arity')
+    expect(runGc(source).result).toBe(expected)
   })
 })

--- a/packages/monkey-linter/test/rules.test.ts
+++ b/packages/monkey-linter/test/rules.test.ts
@@ -183,12 +183,27 @@ describe('builtin-arity', () => {
   )
 
   it.each([
+    'first();',
+    'first([1], [2]);',
+    'last([1], [2]);',
+    'rest([1], [2]);',
+    'push([1]);',
+    'push([1], 2, 3);',
+  ])('flags a wrong-arity array builtin call: %s', (source) => {
+    expect(rulesOf(source)).toEqual(['builtin-arity'])
+  })
+
+  it.each([
     'len("hi");',
     'len([1, 2]);',
-    // first/last/rest/push are not checked: the interpreter's loose arity
-    // handling diverges from the VM's.
-    'first([1], [2]);',
-    'push([1]);',
+    'first([1]);',
+    'last([1]);',
+    'rest([1]);',
+    'push([1], 2);',
+    // puts and its print alias are variadic, so no count is wrong.
+    'puts();',
+    'puts(1, 2, 3);',
+    'print(1, 2, 3);',
   ])('stays quiet otherwise: %s', (source) => {
     expect(rulesOf(source)).not.toContain('builtin-arity')
   })


### PR DESCRIPTION
## Problem

`object/builtins.rs` — the builtin table shared by the tree-walking interpreter and the bytecode VM — never checked argument counts for `first`, `last`, `rest` and `push`. Only `len` did.

`push` read `args.first()` and `args.last()`, which silently produced wrong results:

| call | before | after |
| --- | --- | --- |
| `push([1])` | `[1, [1]]` — appends the array to itself | `builtin push expected 2 arguments, got 1` |
| `push([1], 2, 3)` | `[1, 3]` — drops the middle argument | `builtin push expected 2 arguments, got 3` |
| `first([1], [2])` | `1` — ignores the extra argument | `builtin first expected 1 argument, got 2` |

`first`, `last` and `rest` indexed `args[0]` unchecked, so a zero-argument call panicked rather than returning an error:

```
$ printf 'first()\n' | cargo run -q -p monkey-interpreter
thread 'main' panicked at object/builtins.rs:87:17:
index out of bounds: the len is 0 but the index is 0
```

The gc VM (`gc/value.rs`) and the asm runtime (`asm/runtime_core.rs`) already validated all of this correctly — `object/builtins.rs` was the lone holdout, which made the same program behave differently depending on the backend.

## Changes

**`fix(object)`** — route every fixed-arity builtin through a shared `check_arity` helper that reuses the wording the gc runtime already emits (`builtin push expected 2 arguments, got 1`). `puts`/`print` stay variadic. Tests pin the interpreter, the bytecode VM and the gc VM to identical messages so the backends cannot drift apart again.

**`feat(linter)`** — `packages/monkey-linter`'s `builtin-arity` rule deliberately checked only `len`; its comment and `docs/linter-plan.md` both recorded the backend divergence as the reason, with a v1 `backend-divergent-builtin-arity` placeholder to cover the gap. That blocker is gone, so the array builtins fold into the same deterministic rule and the placeholder is dropped. New oracle tests execute each case through the gc VM so the rule stays tied to real runtime behaviour.

## Affected crates / packages

`object`, `interpreter` (tests), `compiler` (tests), `gc` (tests), `packages/monkey-linter`, `docs/linter-plan.md`.

## Verification

- `cargo test --workspace` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `pnpm -C packages/monkey-linter test` — 157 passed

## Compatibility

Calls that were already well-formed are unchanged. Programs relying on the old lenient behaviour (`push(arr)`, or extra arguments being ignored) now get an error object instead of a silently wrong value — which is what the gc VM has always done for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)