### PR TITLE
fix(parser): treat a stray semicolon as an empty statement

### DIFF
--- a/parser/lib.rs
+++ b/parser/lib.rs
@@ -73,6 +73,11 @@ impl<'a> Parser<'a> {
     pub fn parse_program(&mut self) -> Result<Program, ParseErrors> {
         let mut program = Program::new();
         while !self.current_token_is(&TokenKind::EOF) {
+            // a lone `;` is an empty statement, not the start of an expression
+            if self.current_token_is(&TokenKind::SEMICOLON) {
+                self.next_token();
+                continue;
+            }
             match self.parse_statement() {
                 Ok(stmt) => program.body.push(stmt),
                 Err(e) => self.errors.push(e),
@@ -432,6 +437,10 @@ impl<'a> Parser<'a> {
 
         while !self.current_token_is(&TokenKind::RBRACE) && !self.current_token_is(&TokenKind::EOF)
         {
+            if self.current_token_is(&TokenKind::SEMICOLON) {
+                self.next_token();
+                continue;
+            }
             let statement = match self.parse_statement() {
                 Ok(statement) => statement,
                 Err(error) => {

--- a/parser/parser_test.rs
+++ b/parser/parser_test.rs
@@ -230,6 +230,23 @@ connect();"#;
     }
 
     #[test]
+    fn skips_empty_statements() {
+        verify_program(&[
+            ("class A {};", "class A {}"),
+            (";;5", "5"),
+            ("5;;", "5"),
+            ("let x = 1;;", "let x = 1;"),
+            (";", ""),
+            (";;;", ""),
+            ("fn() { 1;; }", "fn () { 1 }"),
+            ("if (true) { ; } else { ;; }", "if true {  } else {  }"),
+        ]);
+
+        let Node::Program(program) = parse(";;5;;").unwrap() else { panic!("expected program") };
+        assert_eq!(program.body.len(), 1);
+    }
+
+    #[test]
     fn rejects_invalid_class_and_assignment_forms_without_panicking() {
         for (input, expected) in [
             ("class A { constructor() {} constructor() {} }", "more than one constructor"),


### PR DESCRIPTION
A redundant semicolon is currently a hard parse error. `class A {};` — a natural way to write a class declaration — fails to parse, and so do `;;5`, `5;;`, and `let x = 1;;`.

## Cause

Statement parsers consume their own trailing `;` (`parse_let_statement`, `parse_expression_statement`, ...). A second `;` is then left at a statement position, where `parse_statement` falls through to `parse_expression_statement` → `parse_prefix_expression`, which has no prefix rule for `SEMICOLON` (`parser/lib.rs:338`):

```
"class A {};"  => Err(["no prefix function for token: start: 10, end: 11, kind: ;"])
";;5"          => Err(["no prefix function for token: ...", "no prefix function for token: ..."])
"5;;"          => Err(["no prefix function for token: start: 2, end: 3, kind: ;"])
```

Since `parse_program` accumulates errors rather than recovering, a single stray semicolon fails the entire program.

## Fix

Skip lone semicolons at statement positions, in `parse_program` and `parse_block_statement`.

They produce no AST node, so this adds no `Statement` variant and downstream crates (`interpreter`, `compiler`/`vm`, `wasm`, the Prettier plugin) see exactly the AST they would have gotten for the same source without the extra semicolons. `;` on its own now parses as an empty program, which is the behaviour empty input already had.

A `;` in *expression* position is still an error — `1 + ;` and `fn() { 1 + ; }` continue to report `no prefix function`, covered by the existing `rejects_invalid_class_and_assignment_forms_without_panicking` test.

## Affected crates

`parser` only.

## Testing

- New `skips_empty_statements` covers `class A {};`, `;;5`, `5;;`, `let x = 1;;`, `;`, `;;;`, and stray semicolons inside `fn` and `if`/`else` blocks.
- `cargo test` passes workspace-wide with no snapshot updates.
- Verified end-to-end through the VM: `class A {}; let a = new A(); 5;;` → `5`, `;;41 + 1` → `42`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)