### PR TITLE
fix(parser): allow semicolons between class members

### DIFF
--- a/parser/lib.rs
+++ b/parser/lib.rs
@@ -706,6 +706,10 @@ impl<'a> Parser<'a> {
             if self.current_token_is(&TokenKind::EOF) {
                 return Err(format!("expected '}}' after class {}", class_name.name));
             }
+            // methods need no separator, but a `;` between them is harmless
+            if self.current_token_is(&TokenKind::SEMICOLON) {
+                continue;
+            }
 
             let method_name = match &self.current_token.kind {
                 TokenKind::IDENTIFIER {

--- a/parser/parser_test.rs
+++ b/parser/parser_test.rs
@@ -247,11 +247,33 @@ connect();"#;
     }
 
     #[test]
+    fn skips_semicolons_between_class_members() {
+        verify_program(&[
+            ("class A { foo() {}; bar() {} }", "class A {foo() {}bar() {}}"),
+            ("class A { foo() {}; }", "class A {foo() {}}"),
+            ("class A { constructor() {}; foo() {} }", "class A {constructor() {}foo() {}}"),
+            ("class A { ;; foo() {} }", "class A {foo() {}}"),
+            ("class A { ; }", "class A {}"),
+        ]);
+
+        let input = "class A { foo() {}; bar() {} }";
+        let Node::Program(program) = parse(input).unwrap() else { panic!("expected program") };
+        let Statement::Class(class) = &program.body[0] else {
+            panic!("expected class declaration")
+        };
+        assert_eq!(class.methods.len(), 2);
+        assert_eq!(class.methods[1].name.name, "bar");
+        assert_eq!(&input[class.span.start..class.span.end], input);
+    }
+
+    #[test]
     fn rejects_invalid_class_and_assignment_forms_without_panicking() {
         for (input, expected) in [
             ("class A { constructor() {} constructor() {} }", "more than one constructor"),
             ("class A { method() {} method() {} }", "duplicate method"),
             ("class A { let value = 1; }", "expected method definition"),
+            ("class A { method() {}; method() {} }", "duplicate method"),
+            ("class A { method() {};", "expected '}' after class"),
             ("fn() { class A {} }", "only allowed at top level"),
             ("new A", "requires an argument list"),
             ("value = 1", "only instance property assignment"),


### PR DESCRIPTION
Follow-up to #312, which covered stray semicolons at *statement* positions. This covers *class member* positions, which are a separate loop.

`class A { foo() {}; bar() {} }` fails to parse. Members need no separator, but writing one is natural coming from JS.

## Cause

The body loop in `parse_class_declaration` expects an identifier at the start of every iteration, so a `;` falls into the catch-all arm and reports `expected method definition in class body`.

The failure is also noisy: `parse_class_declaration` returns early from the middle of the body, so `parse_program` resumes *inside* the class and appends unrelated errors:

```
"class A { foo() {}; bar() {} }"
  => Err(["expected method definition in class body",
          "no prefix function for token: start: 29, end: 30, kind: }"])
"class A { ; }"
  => Err(["expected method definition in class body",
          "no prefix function for token: ...kind: }"])
```

## Fix

Skip lone semicolons in the class body loop. As in #312, they produce no AST node, so downstream crates (`interpreter`, `compiler`/`vm`, `wasm`, the Prettier plugin) see the same class they would for a body written without them.

The EOF check still runs *before* the new skip, so an unterminated body keeps reporting `expected } after class` rather than looping.

## Not weakened

Verified these still fail as before, and added the first two to `rejects_invalid_class_and_assignment_forms_without_panicking`:

| input | error |
| --- | --- |
| `class A { method() {}; method() {} }` | `duplicate method` |
| `class A { method() {};` | `expected '}' after class` |
| `class A { let value = 1; }` | `expected method definition` |
| `class A { constructor() {} constructor() {} }` | `more than one constructor` |

## Affected crates

`parser` only.

## Testing

- New `skips_semicolons_between_class_members` covers separators between methods, a trailing `;`, semicolons after a `constructor`, leading `;;`, and a body of only `;`. It also asserts the resulting `methods.len()` and that the class span still covers the whole declaration.
- `cargo test` passes workspace-wide with no snapshot updates.
- Verified end-to-end through the VM — `class P { constructor(v) { this.v = v; }; get() { return this.v; } } let p = new P(7); p.get()` → `7`.

## Relationship to #312

Independent — both branch off `main` and touch different functions, so they merge in either order. They are complementary: `class A {};` (semicolon *after* the class) needs #312, `class A { foo() {}; }` (semicolon *inside* the body) needs this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)