### PR TITLE
feat(lexer): decode escape sequences in string literals

### DIFF
--- a/compiler/vm_test.rs
+++ b/compiler/vm_test.rs
@@ -365,6 +365,30 @@ mod tests {
     }
 
     #[test]
+    fn test_string_escapes() {
+        let tests = vec![
+            VmTestCase {
+                input: r#""a\nb""#,
+                expected: Object::String("a\nb".to_string()),
+            },
+            VmTestCase {
+                input: r#""say \"hi\"""#,
+                expected: Object::String("say \"hi\"".to_string()),
+            },
+            VmTestCase {
+                input: r#""back\\slash""#,
+                expected: Object::String("back\\slash".to_string()),
+            },
+            VmTestCase {
+                input: r#"len("a\tb")"#,
+                expected: Object::Integer(3),
+            },
+        ];
+
+        run_vm_tests(tests);
+    }
+
+    #[test]
     fn test_arrays() {
         fn map_vec_to_object(vec: Vec<i64>) -> Object {
             let array = vec

--- a/interpreter/interpreter_test.rs
+++ b/interpreter/interpreter_test.rs
@@ -178,6 +178,20 @@ mod tests {
     }
 
     #[test]
+    fn test_string_escapes() {
+        let test_case = [
+            (r#""a\nb""#, "a\nb"),
+            (r#""a\tb""#, "a\tb"),
+            (r#""say \"hi\"""#, "say \"hi\""),
+            (r#""back\\slash""#, "back\\slash"),
+            // Escapes count as the single character they denote.
+            (r#"len("a\nb")"#, "3"),
+            (r#""a\n" + "b""#, "a\nb"),
+        ];
+        apply_test(&test_case);
+    }
+
+    #[test]
     fn test_builtin_functions() {
         let test_case = [
             (r#"len("")"#, "0"),

--- a/lexer/lexer_test.rs
+++ b/lexer/lexer_test.rs
@@ -60,6 +60,29 @@ mod tests {
         assert_eq!(token.span.end, r#""你好""#.len());
     }
 
+    fn first_token(input: &str) -> Token {
+        Lexer::new(input).next_token()
+    }
+
+    #[test]
+    fn decodes_string_escape_sequences() {
+        let token = first_token(r#""a\nb\tc\r\\d\"e""#);
+
+        assert_eq!(token.kind, TokenKind::STRING("a\nb\tc\r\\d\"e".to_string()));
+    }
+
+    #[test]
+    fn escaped_quote_does_not_terminate_string() {
+        let input = r#""say \"hi\"";"#;
+        let mut lexer = Lexer::new(input);
+
+        let string = lexer.next_token();
+        assert_eq!(string.kind, TokenKind::STRING(r#"say "hi""#.to_string()));
+        assert_eq!(string.span.start, 0);
+        assert_eq!(string.span.end, input.len() - 1);
+        assert_eq!(lexer.next_token().kind, TokenKind::SEMICOLON);
+    }
+
     #[test]
     fn unterminated_string_is_illegal() {
         let input = r#"let x = "unterminated"#;
@@ -71,6 +94,28 @@ mod tests {
         assert_eq!(string.span.start, 8);
         assert_eq!(string.span.end, input.len());
         assert_eq!(tokens.last().unwrap().kind, TokenKind::EOF);
+    }
+
+    #[test]
+    fn unterminated_string_with_escaped_closing_quote_is_illegal() {
+        // The trailing quote is escaped, so the literal never actually closes.
+        assert_eq!(first_token(r#""oops\""#).kind, TokenKind::ILLEGAL);
+        // A backslash immediately before EOF is not a complete escape either.
+        assert_eq!(first_token(r#""oops\"#).kind, TokenKind::ILLEGAL);
+    }
+
+    #[test]
+    fn unknown_escape_is_illegal_and_lexing_resumes() {
+        let input = r#""a\qb"; let x = 5"#;
+        let mut lexer = Lexer::new(input);
+
+        let string = lexer.next_token();
+        assert_eq!(string.kind, TokenKind::ILLEGAL);
+        assert_eq!(string.span.start, 0);
+        // The whole literal is one token, so the following tokens still line up.
+        assert_eq!(string.span.end, 6);
+        assert_eq!(lexer.next_token().kind, TokenKind::SEMICOLON);
+        assert_eq!(lexer.next_token().kind, TokenKind::LET);
     }
 
     #[test]

--- a/lexer/lib.rs
+++ b/lexer/lib.rs
@@ -100,8 +100,8 @@ impl<'a> Lexer<'a> {
                     },
                     kind: match string {
                         Some(value) => TokenKind::STRING(value),
-                        // Unterminated literal: report the whole literal as a
-                        // single ILLEGAL token instead of accepting it.
+                        // Unterminated literal or unknown escape: report the whole
+                        // literal as a single ILLEGAL token instead of accepting it.
                         None => TokenKind::ILLEGAL,
                     },
                 };
@@ -197,30 +197,51 @@ impl<'a> Lexer<'a> {
         return (pos, self.position, x);
     }
 
-    /// Reads a string literal starting at the opening `"`. Returns `None` when
-    /// the input ends before a closing quote, in which case the span still
-    /// covers everything scanned so the caller can emit one ILLEGAL token for
-    /// the whole literal.
+    /// Reads a string literal starting at the opening `"`, decoding escape
+    /// sequences into the value they denote. Returns `None` when the literal is
+    /// malformed, in which case the span still covers everything scanned so the
+    /// caller can emit one ILLEGAL token for the whole literal.
     fn read_string(&mut self) -> (usize, usize, Option<String>) {
         let pos = self.position;
+        let mut value = String::new();
+        let mut valid = true;
+
         loop {
             self.read_char();
-            if self.ch == '"' || self.ch == '\u{0}' {
-                break;
+            match self.ch {
+                '"' => {
+                    // consume the end "
+                    self.read_char();
+                    break;
+                }
+                // The input ended before a closing quote.
+                '\u{0}' => {
+                    valid = false;
+                    break;
+                }
+                '\\' => {
+                    self.read_char();
+                    match self.ch {
+                        'n' => value.push('\n'),
+                        't' => value.push('\t'),
+                        'r' => value.push('\r'),
+                        '"' => value.push('"'),
+                        '\\' => value.push('\\'),
+                        // A trailing backslash right before EOF.
+                        '\u{0}' => {
+                            valid = false;
+                            break;
+                        }
+                        // Unknown escape: keep scanning to the closing quote so a
+                        // single token covers the literal and lexing resumes cleanly.
+                        _ => valid = false,
+                    }
+                }
+                c => value.push(c),
             }
         }
 
-        let value = if self.ch == '"' {
-            let x = self.input[pos + 1..self.position].to_string();
-            // consume the end "
-            self.read_char();
-            Some(x)
-        } else {
-            // The input ended before a closing quote.
-            None
-        };
-
-        return (pos, self.position, value);
+        return (pos, self.position, if valid { Some(value) } else { None });
     }
 }
 

--- a/packages/monkey-minifier/src/printer.ts
+++ b/packages/monkey-minifier/src/printer.ts
@@ -123,7 +123,7 @@ function renderExpression(expression: Expression): PrintedExpression {
     case 'Boolean':
       return primary(String(expression.raw))
     case 'String':
-      return primary(`"${expression.raw}"`)
+      return primary(`"${escapeString(expression.raw)}"`)
     case 'Array':
       return primary(`[${expression.elements.map(printExpression).join(',')}]`)
     case 'Hash':
@@ -215,6 +215,20 @@ function renderFunction(expression: FunctionDeclaration): PrintedExpression {
 
 function primary(code: string): PrintedExpression {
   return { code, precedence: Precedence.Primary }
+}
+
+const stringEscapes: Record<string, string> = {
+  '\\': '\\\\',
+  '"': '\\"',
+  '\n': '\\n',
+  '\t': '\\t',
+  '\r': '\\r',
+}
+
+// The lexer decodes escape sequences, so `raw` holds the decoded value and has
+// to be re-encoded for the printed source to parse back to the same string.
+function escapeString(value: string): string {
+  return value.replace(/[\\"\n\t\r]/g, (char) => stringEscapes[char])
 }
 
 function operatorFor(kind: string): string {

--- a/packages/monkey-minifier/test/printer.test.ts
+++ b/packages/monkey-minifier/test/printer.test.ts
@@ -33,9 +33,21 @@ describe('compact printer', () => {
     )
   })
 
-  it('preserves lossless integer and string spelling', () => {
-    expect(print('9007199254740993; 9223372036854775807; "line\nbreak"')).toBe(
-      '9007199254740993;9223372036854775807;"line\nbreak";'
+  it('preserves lossless integer spelling', () => {
+    expect(print('9007199254740993; 9223372036854775807')).toBe(
+      '9007199254740993;9223372036854775807;'
     )
+  })
+
+  it('escapes string literals so the output stays on one line', () => {
+    // A raw newline in the source becomes a `\n` escape, which parses back to
+    // the same value without breaking the string across lines.
+    expect(print('"line\nbreak"')).toBe('"line\\nbreak";')
+    expect(print('"tab\tsep"')).toBe('"tab\\tsep";')
+  })
+
+  it('escapes quotes and backslashes so the output re-parses', () => {
+    expect(print('"say \\"hi\\""')).toBe('"say \\"hi\\"";')
+    expect(print('"back\\\\slash"')).toBe('"back\\\\slash";')
   })
 })

--- a/packages/prettier-plugin-monkey/src/printer.ts
+++ b/packages/prettier-plugin-monkey/src/printer.ts
@@ -448,6 +448,20 @@ function printInnerComments(node: ASTNode): Doc[] {
   return comments
 }
 
+const stringEscapes: Record<string, string> = {
+  '\\': '\\\\',
+  '"': '\\"',
+  '\n': '\\n',
+  '\t': '\\t',
+  '\r': '\\r',
+}
+
+// The lexer decodes escape sequences, so `raw` holds the decoded value and has
+// to be re-encoded for the printed source to parse back to the same string.
+function escapeString(value: string): string {
+  return value.replace(/[\\"\n\t\r]/g, (char) => stringEscapes[char])
+}
+
 function printLiteral(
   node: Literal,
   path: AstPath,
@@ -461,7 +475,7 @@ function printLiteral(
       return String((node as BooleanLiteral).raw)
     case 'String': {
       const str = (node as StringLiteral).raw
-      return `"${str}"`
+      return `"${escapeString(str)}"`
     }
     case 'Array':
       return printArrayLiteral(node as ArrayLiteral, path, print, options)

--- a/packages/prettier-plugin-monkey/tests/format.test.ts
+++ b/packages/prettier-plugin-monkey/tests/format.test.ts
@@ -24,6 +24,14 @@ describe('Prettier Plugin Monkey', () => {
     expect(await format(input)).toBe(expected)
   })
 
+  it('re-escapes string literals so formatting is idempotent', async () => {
+    // The lexer decodes escapes, so the printer has to encode them again.
+    const input = 'let  x= "a\\nb\\tc \\"q\\" \\\\";'
+    const expected = 'let x = "a\\nb\\tc \\"q\\" \\\\";\n'
+    expect(await format(input)).toBe(expected)
+    expect(await format(expected)).toBe(expected)
+  })
+
   it('formats binary expressions', async () => {
     const input = 'let x=1+2*3;'
     const expected = 'let x = 1 + (2 * 3);\n'

--- a/packages/vscode-extension/syntaxes/monkey.tmLanguage.json
+++ b/packages/vscode-extension/syntaxes/monkey.tmLanguage.json
@@ -30,7 +30,16 @@
           "name": "string.quoted.double.monkey",
           "begin": "\"",
           "end": "\"",
-          "patterns": []
+          "patterns": [
+            {
+              "name": "constant.character.escape.monkey",
+              "match": "\\\\[ntr\"\\\\]"
+            },
+            {
+              "name": "invalid.illegal.unknown-escape.monkey",
+              "match": "\\\\."
+            }
+          ]
         }
       ]
     },

--- a/parser/ast.rs
+++ b/parser/ast.rs
@@ -451,7 +451,7 @@ impl fmt::Display for Literal {
             Literal::String(StringType {
                 raw: s,
                 ..
-            }) => write!(f, "\"{}\"", s),
+            }) => write!(f, "\"{}\"", escape_string(s)),
             Literal::Array(Array {
                 elements: e,
                 ..
@@ -470,6 +470,25 @@ impl fmt::Display for Literal {
             }
         }
     }
+}
+
+/// Re-encodes a decoded string value as source text. The lexer turns escape
+/// sequences into the characters they denote, so printing a literal back has to
+/// undo that or the output would not re-parse.
+pub fn escape_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\n' => escaped.push_str("\\n"),
+            '\t' => escaped.push_str("\\t"),
+            '\r' => escaped.push_str("\\r"),
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            _ => escaped.push(c),
+        }
+    }
+
+    return escaped;
 }
 
 fn format_statements(statements: &[Statement]) -> String {

--- a/parser/parser_test.rs
+++ b/parser/parser_test.rs
@@ -147,6 +147,24 @@ mod tests {
     }
 
     #[test]
+    fn string_literal_escapes_round_trip() {
+        // The lexer decodes escapes, so printing a literal has to re-encode them
+        // for the output to parse back into the same value.
+        let test_case = [
+            (r#""a\nb";"#, r#""a\nb""#),
+            (r#""say \"hi\"";"#, r#""say \"hi\"""#),
+            (r#""back\\slash";"#, r#""back\\slash""#),
+            (r#""tab\tsep";"#, r#""tab\tsep""#),
+        ];
+        verify_program(&test_case);
+
+        for (input, _) in test_case {
+            let printed = parse(input).unwrap().to_string();
+            assert_eq!(parse(&printed).unwrap().to_string(), printed);
+        }
+    }
+
+    #[test]
     fn unterminated_string_is_a_parse_error() {
         assert!(parse(r#"let x = "unterminated"#).is_err());
     }


### PR DESCRIPTION
## Problem

`Lexer::read_string` copied the literal's bytes verbatim, so escape sequences were not handled at all:

```
$ printf '"a\\nb"\n"say \\"hi\\""\n' | cargo run -q --bin monkey-lexer
start: 0, end: 6,  kind: a\nb             # literal backslash + n, not a newline
start: 0, end: 7,  kind: say \            # terminated at the escaped quote...
start: 7, end: 9,  kind: hi               # ...and the rest became stray tokens
start: 9, end: 10, kind: ILLEGAL
```

## Fix

The scanner now decodes `\n`, `\t`, `\r`, `\"` and `\\`. An unknown escape (or a trailing backslash at EOF) makes the literal invalid: scanning continues to the closing quote so one bad escape doesn't cascade into a run of garbage tokens, and the whole literal becomes a single `ILLEGAL` token via the mechanism #315 introduced for unterminated strings.

```
start: 0, end: 6,  kind: a
b                                          # real newline
start: 0, end: 12, kind: say "hi"          # one token
```

Unknown escapes are rejected rather than passed through, which keeps room to add `\u{...}` later without changing the meaning of existing programs. No example or test in the repo used a backslash in a string, so nothing existing changes meaning.

## Printers have to re-encode

The token now carries the decoded *value* instead of the source text, so anything printing a literal back to source must escape it again. `Display for Literal`, the Prettier plugin printer and the minifier printer all wrapped `raw` in quotes verbatim, which would now emit an unterminated or misparsing literal. All three escape on the way out.

One minifier expectation changed: a raw newline inside a source string is now printed as `\n` rather than a literal newline. The output parses back to the same value and keeps minified output on one line, which is what a minifier should emit. The `preserves lossless integer and string spelling` test was split — the integer half is unchanged, and the string half now asserts the escaped form.

The interpreter, compiler and asm backend already read `raw` as the semantic value, so they pick up correct escape handling with no changes. The VS Code TextMate grammar now highlights escapes so the editor agrees with the lexer.

## Affected crates/packages

`lexer`, `parser`, `packages/prettier-plugin-monkey`, `packages/monkey-minifier`, `packages/vscode-extension`

## Tests

New coverage for decoding, escaped quotes not terminating the literal, a trailing backslash / escaped final quote leaving the literal unterminated, unknown-escape recovery, `Display` round-tripping, and end-to-end escape behaviour in both the interpreter and the VM.

`cargo test` (all 23 targets), `cargo clippy --all-targets`, `cargo fmt --all`, `pnpm -C packages/monkey-minifier test` (84) and `pnpm -C packages/prettier-plugin-monkey test` (24) all pass on this branch, with the wasm package rebuilt first so the JS suites exercise the new lexer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
