### PR TITLE
fix(lexer): emit ILLEGAL for unterminated string literals

### DIFF
--- a/lexer/lexer_test.rs
+++ b/lexer/lexer_test.rs
@@ -61,6 +61,19 @@ mod tests {
     }
 
     #[test]
+    fn unterminated_string_is_illegal() {
+        let input = r#"let x = "unterminated"#;
+        let mut lexer = Lexer::new(input);
+        let tokens = test_token_set(&mut lexer);
+        let string = &tokens[3];
+
+        assert_eq!(string.kind, TokenKind::ILLEGAL);
+        assert_eq!(string.span.start, 8);
+        assert_eq!(string.span.end, input.len());
+        assert_eq!(tokens.last().unwrap().kind, TokenKind::EOF);
+    }
+
+    #[test]
     fn test_lexer_array() {
         test_lexer_common("array", "[3]");
     }

--- a/lexer/lib.rs
+++ b/lexer/lib.rs
@@ -98,7 +98,12 @@ impl<'a> Lexer<'a> {
                         start,
                         end,
                     },
-                    kind: TokenKind::STRING(string),
+                    kind: match string {
+                        Some(value) => TokenKind::STRING(value),
+                        // Unterminated literal: report the whole literal as a
+                        // single ILLEGAL token instead of accepting it.
+                        None => TokenKind::ILLEGAL,
+                    },
                 };
             }
             _ => {
@@ -192,8 +197,12 @@ impl<'a> Lexer<'a> {
         return (pos, self.position, x);
     }
 
-    fn read_string(&mut self) -> (usize, usize, String) {
-        let pos = self.position + 1;
+    /// Reads a string literal starting at the opening `"`. Returns `None` when
+    /// the input ends before a closing quote, in which case the span still
+    /// covers everything scanned so the caller can emit one ILLEGAL token for
+    /// the whole literal.
+    fn read_string(&mut self) -> (usize, usize, Option<String>) {
+        let pos = self.position;
         loop {
             self.read_char();
             if self.ch == '"' || self.ch == '\u{0}' {
@@ -201,13 +210,17 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        let x = self.input[pos..self.position].to_string();
-
-        // consume the end "
-        if self.ch == '"' {
+        let value = if self.ch == '"' {
+            let x = self.input[pos + 1..self.position].to_string();
+            // consume the end "
             self.read_char();
-        }
-        return (pos - 1, self.position, x);
+            Some(x)
+        } else {
+            // The input ended before a closing quote.
+            None
+        };
+
+        return (pos, self.position, value);
     }
 }
 

--- a/parser/parser_test.rs
+++ b/parser/parser_test.rs
@@ -147,6 +147,11 @@ mod tests {
     }
 
     #[test]
+    fn unterminated_string_is_a_parse_error() {
+        assert!(parse(r#"let x = "unterminated"#).is_err());
+    }
+
+    #[test]
     fn test_array_literal_expression() {
         let test_case = [("[]", "[]"), ("[1, 2 * 2, 3 + 3]", "[1, (2 * 2), (3 + 3)]")];
         verify_program(&test_case);


### PR DESCRIPTION
## Problem

`Lexer::read_string` (`lexer/lib.rs`) stopped at either a closing quote or EOF and treated the two cases identically, so an unterminated string literal was silently accepted as a well-formed STRING token:

```
$ printf 'let x = "unterminated\n' | cargo run -q --bin monkey-lexer
start: 8, end: 22, kind: unterminated     # no error, swallowed to EOF
```

## Fix

`read_string` now reports whether the literal was actually closed. On EOF the lexer emits a single `ILLEGAL` token spanning from the opening quote to the end of input, which the parser already turns into a parse error (`no prefix function for token: ILLEGAL`):

```
start: 8, end: 22, kind: ILLEGAL
```

Escape sequences are intentionally out of scope — #314 is stacked on this branch and adds them.

## Affected crates

`lexer` (plus a parser regression test)

## Tests

- lexer: an unterminated literal yields one `ILLEGAL` token with the right span, followed by EOF
- parser: `let x = "unterminated` is a parse error

`cargo test` (all targets), `cargo clippy --all-targets` and `cargo fmt --all` are clean. The JS packages are unaffected: the value of every valid token is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)