### PR TITLE
fix(compiler): return classic VM runtime errors

### DIFF
--- a/compiler/main.rs
+++ b/compiler/main.rs
@@ -33,18 +33,23 @@ impl Repl {
 
         let mut compiler =
             Compiler::new_with_state(self.symbol_table.clone(), self.constants.clone());
-        let compiled = compiler.compile(&program).map(|bytecode| {
+        let compiled = compiler.compile(&program).and_then(|bytecode| {
             let mut vm = VM::new_with_global_store(bytecode, std::mem::take(&mut self.globals));
-            vm.run();
+            let run_result = vm.run_checked().map_err(|error| error.to_string());
             let output = vm
                 .last_popped_stack_elm()
                 .map_or_else(String::new, |o| o.to_string());
+            // The VM owns the persistent store while it runs. Take it back even
+            // when execution fails so the next REPL line starts from valid state.
             self.globals = vm.globals;
-            output
+            run_result?;
+            Ok(output)
         });
 
-        self.symbol_table = compiler.symbol_table;
-        self.constants = compiler.constants;
+        if compiled.is_ok() {
+            self.symbol_table = compiler.symbol_table;
+            self.constants = compiler.constants;
+        }
         return compiled;
     }
 }

--- a/compiler/repl_test.rs
+++ b/compiler/repl_test.rs
@@ -71,3 +71,33 @@ fn repl_survives_a_parse_error() {
         .expect("REPL should still evaluate after a parse error");
     assert_eq!(result, "2");
 }
+
+#[test]
+fn repl_reports_runtime_errors_and_keeps_running() {
+    let mut repl = Repl::new();
+    let error = repl
+        .eval_line("1 + \"a\";")
+        .expect_err("mixed operand types should fail");
+    assert_eq!(error, "unsupported binary operation for 1 and a");
+
+    let result = repl
+        .eval_line("1 + 1;")
+        .expect("REPL should still evaluate after a runtime error");
+    assert_eq!(result, "2");
+}
+
+#[test]
+fn repl_does_not_commit_bindings_from_a_failed_line() {
+    let mut repl = Repl::new();
+    repl.eval_line("let leaked = 1; 1 + \"a\";")
+        .expect_err("line should fail at runtime");
+
+    let error = repl
+        .eval_line("leaked;")
+        .expect_err("failed line must not commit its symbol table");
+    assert!(
+        error.to_lowercase().contains("undefined variable 'leaked'"),
+        "expected an undefined-variable error, got: {:?}",
+        error
+    );
+}

--- a/compiler/vm.rs
+++ b/compiler/vm.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt;
 use std::rc::Rc;
 
 use byteorder::{BigEndian, ByteOrder};
@@ -16,6 +17,41 @@ const STACK_SIZE: usize = 2048;
 pub const GLOBAL_SIZE: usize = 65536;
 const MAX_FRAMES: usize = 1024;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VmRuntimeErrorKind {
+    Arithmetic,
+    Call,
+    Index,
+    Property,
+    Stack,
+    Type,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmRuntimeError {
+    pub kind: VmRuntimeErrorKind,
+    pub message: String,
+}
+
+impl VmRuntimeError {
+    fn new(kind: VmRuntimeErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for VmRuntimeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for VmRuntimeError {}
+
+type VmResult<T> = Result<T, VmRuntimeError>;
+
 pub struct VM {
     constants: Vec<Rc<Object>>,
 
@@ -26,6 +62,7 @@ pub struct VM {
 
     frames: Vec<Frame>,
     frame_index: usize,
+    last_error: Option<VmRuntimeError>,
 }
 
 impl VM {
@@ -66,6 +103,7 @@ impl VM {
             globals: vec![null; GLOBAL_SIZE],
             frames,
             frame_index: 1,
+            last_error: None,
         };
     }
 
@@ -75,7 +113,26 @@ impl VM {
         return vm;
     }
 
+    /// Run bytecode while retaining the error for callers of the original API.
+    /// New code should prefer [`Self::run_checked`] so failures cannot be ignored.
     pub fn run(&mut self) {
+        let _ = self.run_checked();
+    }
+
+    pub fn run_checked(&mut self) -> VmResult<()> {
+        self.last_error = None;
+        let result = self.run_inner();
+        if let Err(error) = &result {
+            self.last_error = Some(error.clone());
+        }
+        result
+    }
+
+    pub fn last_error(&self) -> Option<&VmRuntimeError> {
+        self.last_error.as_ref()
+    }
+
+    fn run_inner(&mut self) -> VmResult<()> {
         let mut ip: usize;
         let mut ins: Vec<u8>;
         while self.current_frame().ip
@@ -92,31 +149,31 @@ impl VM {
                 Opcode::OpConst => {
                     let const_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
                     self.current_frame().ip += 2;
-                    self.push(Rc::clone(&self.constants[const_index]))
+                    self.push(Rc::clone(&self.constants[const_index]))?;
                 }
                 Opcode::OpAdd | Opcode::OpSub | Opcode::OpMul | Opcode::OpDiv => {
-                    self.execute_binary_operation(opcode);
+                    self.execute_binary_operation(opcode)?;
                 }
                 Opcode::OpPop => {
                     self.pop();
                 }
                 Opcode::OpTrue => {
-                    self.push(Rc::new(Object::Boolean(true)));
+                    self.push(Rc::new(Object::Boolean(true)))?;
                 }
                 Opcode::OpFalse => {
-                    self.push(Rc::new(Object::Boolean(false)));
+                    self.push(Rc::new(Object::Boolean(false)))?;
                 }
                 Opcode::OpEqual
                 | Opcode::OpNotEqual
                 | Opcode::OpGreaterThan
                 | Opcode::OpLessThan => {
-                    self.execute_comparison(opcode);
+                    self.execute_comparison(opcode)?;
                 }
                 Opcode::OpMinus => {
-                    self.execute_minus_operation(opcode);
+                    self.execute_minus_operation(opcode)?;
                 }
                 Opcode::OpBang => {
-                    self.execute_bang_operation();
+                    self.execute_bang_operation()?;
                 }
                 Opcode::OpJump => {
                     let pos = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
@@ -131,12 +188,12 @@ impl VM {
                     }
                 }
                 Opcode::OpNull => {
-                    self.push(Rc::new(Object::Null));
+                    self.push(Rc::new(Object::Null))?;
                 }
                 Opcode::OpGetGlobal => {
                     let global_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
                     self.current_frame().ip += 2;
-                    self.push(Rc::clone(&self.globals[global_index]));
+                    self.push(Rc::clone(&self.globals[global_index]))?;
                 }
                 Opcode::OpSetGlobal => {
                     let global_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
@@ -148,20 +205,20 @@ impl VM {
                     self.current_frame().ip += 2;
                     let elements = self.build_array(self.sp - count, self.sp);
                     self.sp -= count;
-                    self.push(Rc::new(Object::Array(elements)));
+                    self.push(Rc::new(Object::Array(elements)))?;
                 }
                 Opcode::OpHash => {
                     let count = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
                     self.current_frame().ip += 2;
                     #[allow(clippy::mutable_key_type)]
-                    let elements = self.build_hash(self.sp - count, self.sp);
+                    let elements = self.build_hash(self.sp - count, self.sp)?;
                     self.sp -= count;
-                    self.push(Rc::new(Object::Hash(elements)));
+                    self.push(Rc::new(Object::Hash(elements)))?;
                 }
                 Opcode::OpIndex => {
                     let index = self.pop();
                     let left = self.pop();
-                    self.execute_index_operation(left, index);
+                    self.execute_index_operation(left, index)?;
                 }
                 Opcode::OpReturnValue => {
                     let return_value = self.pop();
@@ -174,7 +231,7 @@ impl VM {
                     }
                     let frame = self.pop_frame();
                     self.sp = frame.base_pointer - 1;
-                    self.push(return_value);
+                    self.push(return_value)?;
                 }
                 Opcode::OpReturn => {
                     if self.frame_index == 1 {
@@ -184,12 +241,12 @@ impl VM {
                     }
                     let frame = self.pop_frame();
                     self.sp = frame.base_pointer - 1;
-                    self.push(Rc::new(object::Object::Null));
+                    self.push(Rc::new(object::Object::Null))?;
                 }
                 Opcode::OpCall => {
                     let num_args = ins[ip + 1] as usize;
                     self.current_frame().ip += 1;
-                    self.execute_call(num_args);
+                    self.execute_call(num_args)?;
                 }
                 Opcode::OpSetLocal => {
                     let local_index = ins[ip + 1] as usize;
@@ -201,29 +258,29 @@ impl VM {
                     let local_index = ins[ip + 1] as usize;
                     self.current_frame().ip += 1;
                     let base = self.current_frame().base_pointer;
-                    self.push(Rc::clone(&self.stack[base + local_index]));
+                    self.push(Rc::clone(&self.stack[base + local_index]))?;
                 }
                 Opcode::OpGetBuiltin => {
                     let built_index = ins[ip + 1] as usize;
                     self.current_frame().ip += 1;
                     let definition = BuiltIns.get(built_index).unwrap().function;
-                    self.push(Rc::new(Object::Builtin(definition)));
+                    self.push(Rc::new(Object::Builtin(definition)))?;
                 }
                 Opcode::OpClosure => {
                     let const_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
                     let num_free = ins[ip + 3] as usize;
                     self.current_frame().ip += 3;
-                    self.push_closure(const_index, num_free);
+                    self.push_closure(const_index, num_free)?;
                 }
                 Opcode::OpGetFree => {
                     let free_index = ins[ip + 1] as usize;
                     self.current_frame().ip += 1;
                     let current_closure = self.current_frame().cl.clone();
-                    self.push(current_closure.free[free_index].clone());
+                    self.push(current_closure.free[free_index].clone())?;
                 }
                 Opcode::OpCurrentClosure => {
                     let current_closure = self.current_frame().cl.clone();
-                    self.push(Rc::new(Object::ClosureObj(current_closure)));
+                    self.push(Rc::new(Object::ClosureObj(current_closure)))?;
                 }
                 Opcode::OpClass => {
                     let name_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
@@ -233,7 +290,7 @@ impl VM {
                         name,
                         constructor: None,
                         methods: HashMap::new(),
-                    })))));
+                    })))))?;
                 }
                 Opcode::OpMethod => {
                     let name_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
@@ -256,8 +313,8 @@ impl VM {
                     self.current_frame().ip += 2;
                     let name = self.constant_string(name_index);
                     let receiver = self.pop();
-                    let value = self.get_property(&receiver, &name);
-                    self.push(value);
+                    let value = self.get_property(&receiver, &name)?;
+                    self.push(value)?;
                 }
                 Opcode::OpSetProperty => {
                     let name_index = BigEndian::read_u16(&ins[ip + 1..ip + 3]) as usize;
@@ -265,91 +322,116 @@ impl VM {
                     let name = self.constant_string(name_index);
                     let value = self.pop();
                     let receiver = self.pop();
-                    self.set_property(&receiver, name, value);
+                    self.set_property(&receiver, name, value)?;
                 }
                 Opcode::OpNew => {
                     let num_args = ins[ip + 1] as usize;
                     self.current_frame().ip += 1;
-                    self.execute_new(num_args);
+                    self.execute_new(num_args)?;
                 }
             }
         }
+        Ok(())
     }
 
-    fn execute_binary_operation(&mut self, opcode: Opcode) {
+    fn execute_binary_operation(&mut self, opcode: Opcode) -> VmResult<()> {
         let right = self.pop();
         let left = self.pop();
         match (left.as_ref(), right.as_ref()) {
             (Object::Integer(l), Object::Integer(r)) => {
                 let result = match opcode {
-                    Opcode::OpAdd => l + r,
-                    Opcode::OpSub => l - r,
-                    Opcode::OpMul => l * r,
-                    Opcode::OpDiv => l / r,
-                    _ => panic!("Unknown opcode for int"),
-                };
-                self.push(Rc::from(Object::Integer(result)));
+                    Opcode::OpAdd => l.checked_add(*r).ok_or_else(|| {
+                        VmRuntimeError::new(
+                            VmRuntimeErrorKind::Arithmetic,
+                            "integer overflow in addition",
+                        )
+                    }),
+                    Opcode::OpSub => l.checked_sub(*r).ok_or_else(|| {
+                        VmRuntimeError::new(
+                            VmRuntimeErrorKind::Arithmetic,
+                            "integer overflow in subtraction",
+                        )
+                    }),
+                    Opcode::OpMul => l.checked_mul(*r).ok_or_else(|| {
+                        VmRuntimeError::new(
+                            VmRuntimeErrorKind::Arithmetic,
+                            "integer overflow in multiplication",
+                        )
+                    }),
+                    Opcode::OpDiv if *r == 0 => {
+                        Err(VmRuntimeError::new(VmRuntimeErrorKind::Arithmetic, "division by zero"))
+                    }
+                    Opcode::OpDiv => l.checked_div(*r).ok_or_else(|| {
+                        VmRuntimeError::new(
+                            VmRuntimeErrorKind::Arithmetic,
+                            "integer overflow in division",
+                        )
+                    }),
+                    _ => unreachable!("compiler emitted non-binary opcode"),
+                }?;
+                self.push(Rc::from(Object::Integer(result)))
             }
-            (Object::String(l), Object::String(r)) => {
-                let result = match opcode {
-                    Opcode::OpAdd => l.to_string() + &r.to_string(),
-                    _ => panic!("Unknown opcode for string"),
-                };
-                self.push(Rc::from(Object::String(result)));
+            (Object::String(l), Object::String(r)) if opcode == Opcode::OpAdd => {
+                self.push(Rc::from(Object::String(l.to_string() + r)))
             }
-            _ => {
-                panic!("unsupported add for those types")
-            }
+            _ => Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Type,
+                format!("unsupported binary operation for {} and {}", left, right),
+            )),
         }
     }
 
-    fn execute_comparison(&mut self, opcode: Opcode) {
+    fn execute_comparison(&mut self, opcode: Opcode) -> VmResult<()> {
         let right = self.pop();
         let left = self.pop();
         if opcode == Opcode::OpEqual || opcode == Opcode::OpNotEqual {
             let equal = left.as_ref() == right.as_ref();
-            self.push(Rc::new(Object::Boolean(if opcode == Opcode::OpEqual {
+            return self.push(Rc::new(Object::Boolean(if opcode == Opcode::OpEqual {
                 equal
             } else {
                 !equal
             })));
-            return;
         }
         match (left.as_ref(), right.as_ref()) {
             (Object::Integer(l), Object::Integer(r)) => {
                 let result = match opcode {
                     Opcode::OpGreaterThan => l > r,
                     Opcode::OpLessThan => l < r,
-                    _ => panic!("Unknown opcode for comparing int"),
+                    _ => unreachable!("compiler emitted non-comparison opcode"),
                 };
-                self.push(Rc::from(Object::Boolean(result)));
+                self.push(Rc::from(Object::Boolean(result)))
             }
-            _ => {
-                panic!("unsupported comparison for those types")
-            }
+            _ => Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Type,
+                format!("unsupported comparison for {} and {}", left, right),
+            )),
         }
     }
 
-    fn execute_minus_operation(&mut self, opcode: Opcode) {
+    fn execute_minus_operation(&mut self, opcode: Opcode) -> VmResult<()> {
         let operand = self.pop();
         match operand.as_ref() {
-            Object::Integer(l) => {
-                self.push(Rc::from(Object::Integer(-*l)));
-            }
-            _ => {
-                panic!("unsupported types for negation {:?}", opcode)
-            }
+            Object::Integer(value) => value
+                .checked_neg()
+                .ok_or_else(|| {
+                    VmRuntimeError::new(
+                        VmRuntimeErrorKind::Arithmetic,
+                        "integer overflow in negation",
+                    )
+                })
+                .and_then(|value| self.push(Rc::from(Object::Integer(value)))),
+            _ => Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Type,
+                format!("unsupported type for negation {:?}: {}", opcode, operand),
+            )),
         }
     }
-    fn execute_bang_operation(&mut self) {
+
+    fn execute_bang_operation(&mut self) -> VmResult<()> {
         let operand = self.pop();
         match operand.as_ref() {
-            Object::Boolean(l) => {
-                self.push(Rc::from(Object::Boolean(!*l)));
-            }
-            _ => {
-                self.push(Rc::from(Object::Boolean(false)));
-            }
+            Object::Boolean(l) => self.push(Rc::from(Object::Boolean(!*l))),
+            _ => self.push(Rc::from(Object::Boolean(false))),
         }
     }
 
@@ -363,12 +445,13 @@ impl VM {
         return o;
     }
 
-    fn push(&mut self, o: Rc<Object>) {
+    fn push(&mut self, o: Rc<Object>) -> VmResult<()> {
         if self.sp >= STACK_SIZE {
-            panic!("Stack overflow");
-        };
+            return Err(VmRuntimeError::new(VmRuntimeErrorKind::Stack, "stack limit exceeded"));
+        }
         self.stack[self.sp] = o;
         self.sp += 1;
+        Ok(())
     }
     fn is_truthy(&self, condition: Rc<Object>) -> bool {
         match condition.as_ref() {
@@ -388,52 +471,56 @@ impl VM {
     // Object's Hash impl only covers Integer/Boolean/String, which have no
     // interior mutability, so the keys are effectively immutable.
     #[allow(clippy::mutable_key_type)]
-    fn build_hash(&self, start: usize, end: usize) -> HashMap<Rc<Object>, Rc<Object>> {
+    fn build_hash(&self, start: usize, end: usize) -> VmResult<HashMap<Rc<Object>, Rc<Object>>> {
         let mut elements = HashMap::new();
         for i in (start..end).step_by(2) {
             let key = Rc::clone(&self.stack[i]);
+            if !key.is_hashable() {
+                return Err(VmRuntimeError::new(
+                    VmRuntimeErrorKind::Index,
+                    format!("hash key must be hashable, got {}", key),
+                ));
+            }
             let value = Rc::clone(&self.stack[i + 1]);
             elements.insert(key, value);
         }
-        return elements;
+        Ok(elements)
     }
 
-    fn execute_index_operation(&mut self, left: Rc<Object>, index: Rc<Object>) {
+    fn execute_index_operation(&mut self, left: Rc<Object>, index: Rc<Object>) -> VmResult<()> {
         match (left.as_ref(), index.as_ref()) {
-            (Object::Array(l), Object::Integer(i)) => {
-                self.execute_array_index(l, *i);
-            }
-            (Object::Hash(l), _) => {
-                self.execute_hash_index(l, index);
-            }
-            _ => {
-                panic!("unsupported index operation for those types")
-            }
+            (Object::Array(l), Object::Integer(i)) => self.execute_array_index(l, *i),
+            (Object::Hash(l), _) => self.execute_hash_index(l, index),
+            _ => Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Index,
+                format!("unsupported index operation for {} with {}", left, index),
+            )),
         }
     }
 
-    fn execute_array_index(&mut self, array: &[Rc<Object>], index: i64) {
+    fn execute_array_index(&mut self, array: &[Rc<Object>], index: i64) -> VmResult<()> {
         if index < array.len() as i64 && index >= 0 {
-            self.push(Rc::clone(&array[index as usize]));
+            self.push(Rc::clone(&array[index as usize]))
         } else {
-            self.push(Rc::new(Object::Null));
+            self.push(Rc::new(Object::Null))
         }
     }
 
     #[allow(clippy::mutable_key_type)]
-    fn execute_hash_index(&mut self, hash: &HashMap<Rc<Object>, Rc<Object>>, index: Rc<Object>) {
+    fn execute_hash_index(
+        &mut self,
+        hash: &HashMap<Rc<Object>, Rc<Object>>,
+        index: Rc<Object>,
+    ) -> VmResult<()> {
         match &*index {
             Object::Integer(_) | Object::Boolean(_) | Object::String(_) => match hash.get(&index) {
-                Some(el) => {
-                    self.push(Rc::clone(el));
-                }
-                None => {
-                    self.push(Rc::new(Object::Null));
-                }
+                Some(el) => self.push(Rc::clone(el)),
+                None => self.push(Rc::new(Object::Null)),
             },
-            _ => {
-                panic!("unsupported hash index operation for those types {}", index)
-            }
+            _ => Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Index,
+                format!("unsupported hash index key {}", index),
+            )),
         }
     }
 
@@ -441,9 +528,13 @@ impl VM {
         &mut self.frames[self.frame_index - 1]
     }
 
-    fn push_frame(&mut self, frame: Frame) {
+    fn push_frame(&mut self, frame: Frame) -> VmResult<()> {
+        if self.frame_index >= MAX_FRAMES {
+            return Err(VmRuntimeError::new(VmRuntimeErrorKind::Stack, "frame limit exceeded"));
+        }
         self.frames[self.frame_index] = frame;
         self.frame_index += 1;
+        Ok(())
     }
 
     fn pop_frame(&mut self) -> Frame {
@@ -451,44 +542,52 @@ impl VM {
         return self.frames[self.frame_index].clone();
     }
 
-    fn execute_call(&mut self, num_args: usize) {
+    fn execute_call(&mut self, num_args: usize) -> VmResult<()> {
         let callee = Rc::clone(&self.stack[self.sp - 1 - num_args]);
         match &*callee {
-            Object::ClosureObj(cf) => {
-                self.call_closure(cf.clone(), num_args);
-            }
-            Object::Builtin(bt) => {
-                self.call_builtin(*bt, num_args);
-            }
-            Object::BoundMethod(bound) => {
-                self.call_bound_method(bound.clone(), num_args);
-            }
-            Object::Class(class) => {
-                panic!("class {} must be constructed with new", class.borrow().name)
-            }
-            _ => {
-                panic!("calling non-closure")
-            }
+            Object::ClosureObj(cf) => self.call_closure(cf.clone(), num_args),
+            Object::Builtin(bt) => self.call_builtin(*bt, num_args),
+            Object::BoundMethod(bound) => self.call_bound_method(bound.clone(), num_args),
+            Object::Class(class) => Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Call,
+                format!("class {} must be constructed with new", class.borrow().name),
+            )),
+            _ => Err(VmRuntimeError::new(VmRuntimeErrorKind::Call, "calling non-closure")),
         }
     }
-    fn call_closure(&mut self, cl: Closure, num_args: usize) {
+
+    fn call_closure(&mut self, cl: Closure, num_args: usize) -> VmResult<()> {
         if cl.func.num_parameters != num_args {
-            panic!("wrong number of arguments: want={}, got={}", cl.func.num_parameters, num_args);
+            return Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Call,
+                format!(
+                    "wrong number of arguments: want={}, got={}",
+                    cl.func.num_parameters, num_args
+                ),
+            ));
         }
 
         let frame = Frame::new(cl.clone(), self.sp - num_args);
-        self.sp = frame.base_pointer + cl.func.num_locals;
-        self.push_frame(frame);
+        let next_sp = frame
+            .base_pointer
+            .checked_add(cl.func.num_locals)
+            .filter(|next_sp| *next_sp <= STACK_SIZE)
+            .ok_or_else(|| {
+                VmRuntimeError::new(VmRuntimeErrorKind::Stack, "stack limit exceeded")
+            })?;
+        self.push_frame(frame)?;
+        self.sp = next_sp;
+        Ok(())
     }
 
-    fn call_builtin(&mut self, bt: BuiltinFunc, num_args: usize) {
+    fn call_builtin(&mut self, bt: BuiltinFunc, num_args: usize) -> VmResult<()> {
         let args = self.stack[self.sp - num_args..self.sp].to_vec();
         let result = bt(args);
         self.sp = self.sp - num_args - 1;
-        self.push(result);
+        self.push(result)
     }
 
-    fn push_closure(&mut self, const_index: usize, num_free: usize) {
+    fn push_closure(&mut self, const_index: usize, num_free: usize) -> VmResult<()> {
         match &*self.constants[const_index] {
             Object::CompiledFunction(f) => {
                 let mut free = Vec::with_capacity(num_free);
@@ -501,7 +600,7 @@ impl VM {
                     func: f.clone(),
                     free,
                 });
-                self.push(Rc::new(closure));
+                self.push(Rc::new(closure))
             }
             o => {
                 panic!("not a function {}", o);
@@ -516,12 +615,15 @@ impl VM {
         }
     }
 
-    fn get_property(&self, receiver: &Rc<Object>, name: &str) -> Rc<Object> {
+    fn get_property(&self, receiver: &Rc<Object>, name: &str) -> VmResult<Rc<Object>> {
         let Object::Instance(instance) = &**receiver else {
-            panic!("cannot read property '{}' of {}", name, receiver);
+            return Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Property,
+                format!("cannot read property '{}' of {}", name, receiver),
+            ));
         };
         if let Some(value) = instance.borrow().fields.get(name).cloned() {
-            return value;
+            return Ok(value);
         }
         let (class_name, method) = {
             let instance_object = instance.borrow();
@@ -529,27 +631,39 @@ impl VM {
             (class.name.clone(), class.methods.get(name).cloned())
         };
         match method {
-            Some(method) => Rc::new(Object::BoundMethod(Rc::new(BoundMethodObject {
+            Some(method) => Ok(Rc::new(Object::BoundMethod(Rc::new(BoundMethodObject {
                 receiver: Rc::clone(instance),
                 method,
                 name: name.to_string(),
-            }))),
-            None => panic!("property '{}' does not exist on {}", name, class_name),
+            })))),
+            None => Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Property,
+                format!("property '{}' does not exist on {}", name, class_name),
+            )),
         }
     }
 
-    fn set_property(&self, receiver: &Rc<Object>, name: String, value: Rc<Object>) {
+    fn set_property(&self, receiver: &Rc<Object>, name: String, value: Rc<Object>) -> VmResult<()> {
         let Object::Instance(instance) = &**receiver else {
-            panic!("cannot set property '{}' of {}", name, receiver);
+            return Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Property,
+                format!("cannot set property '{}' of {}", name, receiver),
+            ));
         };
         instance.borrow_mut().fields.insert(name, value);
+        Ok(())
     }
 
-    fn execute_new(&mut self, num_args: usize) {
+    fn execute_new(&mut self, num_args: usize) -> VmResult<()> {
         let base = self.sp - num_args - 1;
         let class = match &*self.stack[base] {
             Object::Class(class) => Rc::clone(class),
-            value => panic!("cannot construct {}", value),
+            value => {
+                return Err(VmRuntimeError::new(
+                    VmRuntimeErrorKind::Call,
+                    format!("cannot construct {}", value),
+                ))
+            }
         };
         let instance = Rc::new(RefCell::new(InstanceObject {
             class: Rc::clone(&class),
@@ -559,15 +673,18 @@ impl VM {
         let constructor = class.borrow().constructor.clone();
         let Some(constructor) = constructor else {
             if num_args != 0 {
-                panic!(
-                    "wrong number of arguments for {}.constructor: want=0, got={}",
-                    class.borrow().name,
-                    num_args
-                );
+                return Err(VmRuntimeError::new(
+                    VmRuntimeErrorKind::Call,
+                    format!(
+                        "wrong number of arguments for {}.constructor: want=0, got={}",
+                        class.borrow().name,
+                        num_args
+                    ),
+                ));
             }
             self.sp = base;
-            self.push(instance_value);
-            return;
+            self.push(instance_value)?;
+            return Ok(());
         };
 
         let closure = match &*constructor {
@@ -576,18 +693,21 @@ impl VM {
         };
         let expected = closure.func.num_parameters.saturating_sub(1);
         if expected != num_args {
-            panic!(
-                "wrong number of arguments for {}.constructor: want={}, got={}",
-                class.borrow().name,
-                expected,
-                num_args
-            );
+            return Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Call,
+                format!(
+                    "wrong number of arguments for {}.constructor: want={}, got={}",
+                    class.borrow().name,
+                    expected,
+                    num_args
+                ),
+            ));
         }
-        self.rewrite_receiver_call(constructor, instance_value, num_args);
-        self.call_closure(closure, num_args + 1);
+        self.rewrite_receiver_call(constructor, instance_value, num_args)?;
+        self.call_closure(closure, num_args + 1)
     }
 
-    fn call_bound_method(&mut self, bound: Rc<BoundMethodObject>, num_args: usize) {
+    fn call_bound_method(&mut self, bound: Rc<BoundMethodObject>, num_args: usize) -> VmResult<()> {
         let closure = match &*bound.method {
             Object::ClosureObj(closure) => closure.clone(),
             value => panic!("bound method is not a closure: {}", value),
@@ -595,14 +715,17 @@ impl VM {
         let expected = closure.func.num_parameters.saturating_sub(1);
         if expected != num_args {
             let class_name = bound.receiver.borrow().class.borrow().name.clone();
-            panic!(
-                "wrong number of arguments for {}.{}: want={}, got={}",
-                class_name, bound.name, expected, num_args
-            );
+            return Err(VmRuntimeError::new(
+                VmRuntimeErrorKind::Call,
+                format!(
+                    "wrong number of arguments for {}.{}: want={}, got={}",
+                    class_name, bound.name, expected, num_args
+                ),
+            ));
         }
         let receiver = Rc::new(Object::Instance(Rc::clone(&bound.receiver)));
-        self.rewrite_receiver_call(Rc::clone(&bound.method), receiver, num_args);
-        self.call_closure(closure, num_args + 1);
+        self.rewrite_receiver_call(Rc::clone(&bound.method), receiver, num_args)?;
+        self.call_closure(closure, num_args + 1)
     }
 
     fn rewrite_receiver_call(
@@ -610,7 +733,10 @@ impl VM {
         callable: Rc<Object>,
         receiver: Rc<Object>,
         num_args: usize,
-    ) {
+    ) -> VmResult<()> {
+        if self.sp >= STACK_SIZE {
+            return Err(VmRuntimeError::new(VmRuntimeErrorKind::Stack, "stack limit exceeded"));
+        }
         let base = self.sp - num_args - 1;
         for index in (base + 1..self.sp).rev() {
             self.stack[index + 1] = Rc::clone(&self.stack[index]);
@@ -618,5 +744,6 @@ impl VM {
         self.stack[base] = callable;
         self.stack[base + 1] = receiver;
         self.sp += 1;
+        Ok(())
     }
 }

--- a/compiler/vm_test.rs
+++ b/compiler/vm_test.rs
@@ -16,7 +16,8 @@ pub fn run_vm_tests(tests: Vec<VmTestCase>) {
         let bytecodes = compiler.compile(&program).unwrap();
         println!("ins {} for input {}", bytecodes.instructions.string(), t.input);
         let mut vm = VM::new(bytecodes);
-        vm.run();
+        vm.run_checked()
+            .unwrap_or_else(|error| panic!("VM error for {:?}: {}", t.input, error));
         let got = vm.last_popped_stack_elm().unwrap();
         let expected_argument = t.expected;
         test_constants(&[expected_argument], &vec![got]);
@@ -27,29 +28,19 @@ pub fn run_vm_tests(tests: Vec<VmTestCase>) {
 mod tests {
     use object::Object;
     use std::collections::HashMap;
-    use std::panic::{catch_unwind, AssertUnwindSafe};
     use std::rc::Rc;
 
     use crate::compiler::Compiler;
-    use crate::vm::VM;
+    use crate::vm::{VmRuntimeError, VmRuntimeErrorKind, VM};
     use crate::vm_test::{run_vm_tests, VmTestCase};
     use parser::parse;
 
-    fn vm_panic_message(input: &str) -> String {
+    fn vm_runtime_error(input: &str) -> VmRuntimeError {
         let program = parse(input).unwrap();
         let mut compiler = Compiler::new();
         let bytecode = compiler.compile(&program).unwrap();
         let mut vm = VM::new(bytecode);
-        let panic = catch_unwind(AssertUnwindSafe(|| vm.run())).expect_err("VM should panic");
-        panic
-            .downcast_ref::<String>()
-            .cloned()
-            .or_else(|| {
-                panic
-                    .downcast_ref::<&str>()
-                    .map(|message| (*message).to_string())
-            })
-            .unwrap_or_else(|| "non-string panic".to_string())
+        vm.run_checked().expect_err("VM should return an error")
     }
 
     #[test]
@@ -544,29 +535,98 @@ mod tests {
     }
 
     #[test]
+    fn runtime_errors_are_returned_instead_of_panicking() {
+        let cases = [
+            ("1 + \"a\";", VmRuntimeErrorKind::Type, "unsupported binary operation for 1 and a"),
+            (
+                "let add = fn(a, b) { a + b; }; add(1);",
+                VmRuntimeErrorKind::Call,
+                "wrong number of arguments: want=2, got=1",
+            ),
+            ("1();", VmRuntimeErrorKind::Call, "calling non-closure"),
+            (
+                "true > false;",
+                VmRuntimeErrorKind::Type,
+                "unsupported comparison for true and false",
+            ),
+            ("-\"a\";", VmRuntimeErrorKind::Type, "unsupported type for negation OpMinus: a"),
+            ("1[0];", VmRuntimeErrorKind::Index, "unsupported index operation for 1 with 0"),
+            ("{[]: 1};", VmRuntimeErrorKind::Index, "hash key must be hashable, got []"),
+            ("1 / 0;", VmRuntimeErrorKind::Arithmetic, "division by zero"),
+            (
+                "9223372036854775807 + 1;",
+                VmRuntimeErrorKind::Arithmetic,
+                "integer overflow in addition",
+            ),
+            (
+                "let recurse = fn() { recurse(); }; recurse();",
+                VmRuntimeErrorKind::Stack,
+                "frame limit exceeded",
+            ),
+        ];
+
+        for (input, kind, message) in cases {
+            let error = vm_runtime_error(input);
+            assert_eq!(error.kind, kind, "input: {input}");
+            assert_eq!(error.message, message, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn legacy_run_retains_runtime_error_without_panicking() {
+        let program = parse("1 + \"a\";").unwrap();
+        let mut compiler = Compiler::new();
+        let bytecode = compiler.compile(&program).unwrap();
+        let mut vm = VM::new(bytecode);
+
+        vm.run();
+
+        let error = vm.last_error().expect("legacy run should retain its error");
+        assert_eq!(error.kind, VmRuntimeErrorKind::Type);
+        assert_eq!(error.message, "unsupported binary operation for 1 and a");
+    }
+
+    #[test]
     fn class_runtime_errors_use_user_visible_arity() {
         let cases = [
             (
                 "class Empty {} new Empty(1);",
+                VmRuntimeErrorKind::Call,
                 "wrong number of arguments for Empty.constructor: want=0, got=1",
             ),
             (
                 "class Point { constructor(x) {} } new Point();",
+                VmRuntimeErrorKind::Call,
                 "wrong number of arguments for Point.constructor: want=1, got=0",
             ),
             (
                 "class Counter { increment(amount) { amount; } } new Counter().increment();",
+                VmRuntimeErrorKind::Call,
                 "wrong number of arguments for Counter.increment: want=1, got=0",
             ),
-            ("class Empty {} Empty();", "class Empty must be constructed with new"),
-            ("let factory = fn() {}; new factory();", "cannot construct [closure function]"),
-            ("class Empty {} new Empty().missing;", "property 'missing' does not exist on Empty"),
-            ("1.value;", "cannot read property 'value' of 1"),
-            ("1.value = 2;", "cannot set property 'value' of 1"),
+            (
+                "class Empty {} Empty();",
+                VmRuntimeErrorKind::Call,
+                "class Empty must be constructed with new",
+            ),
+            (
+                "let factory = fn() {}; new factory();",
+                VmRuntimeErrorKind::Call,
+                "cannot construct [closure function]",
+            ),
+            (
+                "class Empty {} new Empty().missing;",
+                VmRuntimeErrorKind::Property,
+                "property 'missing' does not exist on Empty",
+            ),
+            ("1.value;", VmRuntimeErrorKind::Property, "cannot read property 'value' of 1"),
+            ("1.value = 2;", VmRuntimeErrorKind::Property, "cannot set property 'value' of 1"),
         ];
 
-        for (input, expected) in cases {
-            assert_eq!(vm_panic_message(input), expected, "input: {input}");
+        for (input, kind, expected) in cases {
+            let error = vm_runtime_error(input);
+            assert_eq!(error.kind, kind, "input: {input}");
+            assert_eq!(error.message, expected, "input: {input}");
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace source-triggered panics in the classic compiler VM with classified `VmRuntimeError` values
- add `VM::run_checked()` and `VM::last_error()` while keeping the existing `VM::run()` entry point non-panicking and source-compatible
- make the compiler REPL report runtime errors, continue accepting input, and avoid committing symbol-table/constants changes from a failed line

## Covered failures

Regression coverage includes mixed-type arithmetic (`1 + "a"`), wrong closure arity (`add(1)`), calling a non-callable (`1()`), invalid comparison/negation/index/hash keys, arithmetic faults, recursion/frame limits, and class/property errors.

Malformed compiler bytecode remains an internal invariant failure; valid Monkey source now returns runtime errors instead of crashing the host process.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `wasm-pack build --release --scope=gengjiawen`
- `wasm-pack test --node`
- minifier build, browser smoke, Node smoke, and Vitest suites
- linter build, browser smoke, Node smoke, and Vitest suites
- Playground test, lint, and production build
- VS Code extension build
