### PR TITLE
chore: remove pnpm ua script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "format": "npx prettier .github/**/*.yml *.yml README.md Maintainer.md --write",
-    "ua": "npx @gengjiawen/git-repo-cli clone fkling/astexplorer ./ast-website/",
     "playground": "pnpm --filter monkey-playground dev",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary

- remove the unused `ua` script from the root `package.json`

## Why

The script was a repository-specific shortcut for cloning AST Explorer and is no longer needed in the pnpm workspace scripts.

## Impact

`pnpm ua` is no longer available. Other root scripts are unchanged.

## Validation

- parsed `package.json` with Node.js
- ran `git diff --check`
