### PR TITLE
docs: add npm badges and a linter entry for the newly published packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Monkey has a C-like syntax, supports **variable bindings**, **prefix** and **inf
 - **Wasm**: A WebAssembly target, thus run monkey on browser is directly supported.
 - **Prettier Plugin**: Format Monkey source code with [Prettier](https://prettier.io/) via `prettier-plugin-monkey`.
 - **Minifier** ([`@gengjiawen/monkey-minifier`](packages/monkey-minifier/README.md)): A semantics-preserving source-to-source minifier powered by the Rust/Wasm parser, with compact printing, identifier mangling, constant folding and propagation, dead `let` elimination, and Node/browser/CLI APIs.
+- **Linter** ([`@gengjiawen/monkey-lint`](packages/monkey-linter/README.md)): A static linter powered by the Rust/Wasm parser, whose AST rules are anchored to both backends — a construct is only flagged when the tree-walking interpreter and the GC bytecode VM agree it is wrong or useless — with per-rule severity overrides and Node/browser/CLI APIs.
 - **VS Code Extension**: First-class editor support with syntax highlighting, snippets, WASM-powered diagnostics, AST preview, and bytecode compilation commands.
 - bytecode viewer from source
 - **GC** ([`monkey-gc`](gc/README.md)): alternate bytecode VM with QuickJS-style refcounting and three-phase cycle collection (`gc_decref` → `gc_scan` → `gc_free_cycles`) on a `GcHeap`, so cyclic object graphs can be reclaimed without changing `object` or the default `Rc` VM.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 ![Rust](https://github.com/gengjiawen/monkey-rust/actions/workflows/rust.yml/badge.svg?branch=main&event=push)
 [![monkey-interpreter](https://img.shields.io/crates/v/monkey-interpreter)](https://crates.io/crates/monkey-interpreter)
-[![npm version](https://img.shields.io/npm/v/@gengjiawen/monkey-wasm)](https://www.npmjs.com/package/@gengjiawen/monkey-wasm)
+[![npm version](https://img.shields.io/npm/v/@gengjiawen/monkey-wasm?label=@gengjiawen/monkey-wasm)](https://www.npmjs.com/package/@gengjiawen/monkey-wasm)
 [![npm version](https://img.shields.io/npm/v/prettier-plugin-monkey?label=prettier-plugin-monkey)](https://www.npmjs.com/package/prettier-plugin-monkey)
+[![npm version](https://img.shields.io/npm/v/@gengjiawen/monkey-minifier?label=@gengjiawen/monkey-minifier)](https://www.npmjs.com/package/@gengjiawen/monkey-minifier)
+[![npm version](https://img.shields.io/npm/v/@gengjiawen/monkey-lint?label=@gengjiawen/monkey-lint)](https://www.npmjs.com/package/@gengjiawen/monkey-lint)
 
 An interpreter and compiler for the Monkey programming language written in Rust
 


### PR DESCRIPTION
## Summary

`@gengjiawen/monkey-minifier` and `@gengjiawen/monkey-lint` are now published on npm at 1.2.0. This adds their version badges to the README badge row, and gives the linter a feature-list entry — it had none at all, unlike every other published package.

## Context

The 1.2.0 release run ([#30712221755](https://github.com/gengjiawen/monkey-rust/actions/runs/30712221755)) failed to publish both packages with `ENEEDAUTH`. The release workflow has no `actions/setup-node` and no `.npmrc`, so the `NODE_AUTH_TOKEN` env var on the publish steps is never read by npm — the publishes that do succeed authenticate via OIDC trusted publishing (visible as auto-signed provenance without a `--provenance` flag). Since these two packages had never been published, no trusted publisher could be configured for them, leaving npm with no credentials at all.

Both were published manually to bootstrap them. Trusted publishers still need to be configured on npmjs.com for each so CI can publish them from 1.3.0 onward.

## Changes

- Add npm version badges for `@gengjiawen/monkey-minifier` and `@gengjiawen/monkey-lint`
- Label the `@gengjiawen/monkey-wasm` badge with its package name, matching `prettier-plugin-monkey`. With four npm badges in the row, the unlabeled one renders as just `npm v1.2.0` with no indication of which package it tracks. Drop this hunk if you'd rather keep the diff to the two new badges.
- Add a **Linter** entry to the feature list, mirroring the **Minifier** bullet's shape and leading with the dual-backend anchoring that distinguishes it. No rule count is given on purpose — it would go stale the moment a rule is added, and the package README already carries the full table.

Package READMEs are left alone — badges only live in the root README in this repo, including for `prettier-plugin-monkey`.

## Test plan

All four badge endpoints were verified to resolve to a real version rather than `invalid`:

```
@gengjiawen/monkey-wasm          <title>npm: v1.2.0</title>
prettier-plugin-monkey           <title>npm: v1.2.0</title>
@gengjiawen/monkey-minifier      <title>npm: v1.2.0</title>
@gengjiawen/monkey-lint          <title>npm: v1.2.0</title>
```

The `packages/monkey-linter/README.md` link target was verified to exist (the directory is `monkey-linter` while the package is `monkey-lint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)